### PR TITLE
MELD-94: GitHub README und Lizenz

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+Copyright (c) 2026 Manuel Schedler
+All rights reserved.
+
+This software and associated documentation files (the "Software") are the
+proprietary property of Manuel Schedler.
+
+Permission to use, copy, modify, merge, publish, distribute, sublicense, or
+sell copies of the Software is granted only with the prior written permission
+of the copyright holder.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Meldeliste
+
+Zentrale Plattform für Termine, Rückmeldungen und Verwaltung im Musikverein Bonn-Duisdorf – u. a. Meldelisten, Register, Inventar, Nachrichten und Auswertung.
+
+## Voraussetzungen
+
+- PHP (mit MySQLi)
+- MySQL oder MariaDB
+- Webserver (Apache/nginx o. Ä.) mit Document Root auf dem Projektverzeichnis
+
+## Installation
+
+1. Repository klonen und `common/config_sample.php` nach `common/config.php` kopieren.
+2. In `common/config.php` MySQL-Zugangsdaten, SMTP und weitere Platzhalter eintragen.
+3. Im Browser `install.php` öffnen (ohne Login, solange noch keine Admin-Benutzer existieren) und Schema anlegen bzw. prüfen.
+
+Details zum Schema und zur Erstinstallation liefert die Install-Seite selbst.
+
+## Branches
+
+| Branch | Verwendung |
+|--------|------------|
+| `master` | Produktion |
+| `dev` | Staging / Vorschau |
+| `MELD-<n>-…` | Feature-Branches |
+
+## Tests
+
+Automatisierte Integrationstests liegen im privaten Sibling-Repository [meldeliste-tests](https://github.com/Musikverein-Bonn-Duisdorf/meldeliste-tests) (Checkout neben `meldeliste/`). Setup und Ausführung sind dort dokumentiert.
+
+## Changelog
+
+Siehe [CHANGELOG.md](CHANGELOG.md).
+
+## License
+
+Proprietär – siehe [LICENSE](LICENSE).
+
+Copyright (c) 2026 Manuel Schedler. All rights reserved.
+
+Enthaltene Drittkomponenten (z. B. TinyMCE, Font Awesome, PHPMailer) unterliegen jeweils eigenen Lizenzen.


### PR DESCRIPTION
## Summary
- Proprietäre `LICENSE` (Copyright Manuel Schedler) und Projekt-`README.md` ergänzt
- GitHub-Repo-Description gesetzt

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-94

## Test plan
- [ ] README und LICENSE auf dem Branch im Repo-Root sichtbar
- [ ] Inhalt/Copyright prüfen


Made with [Cursor](https://cursor.com)