### PR TITLE
MELD-89: Evaluierung dynamischer

### DIFF
--- a/common/include.php
+++ b/common/include.php
@@ -43,4 +43,5 @@ include "libs/aushilfe.php";
 include "libs/aushilfeShift.php";
 include "libs/AppmntFreeTextResponse.php";
 include "libs/listChunk.php";
+include "libs/evaluateStats.php";
 ?>

--- a/config/ConfigDefaults.php
+++ b/config/ConfigDefaults.php
@@ -288,6 +288,12 @@ function getConfigDefaults() {
             'Description' => 'Anzahl der Tage in der Statistikberechnung',
         ),
         array(
+            'Parameter' => 'inactiveUsersDays',
+            'Value' => '90',
+            'Type' => 'uint',
+            'Description' => 'Nutzer gelten in der Statistik als inaktiv, wenn letzter Login und letzte Teilnahme älter sind (Tage)',
+        ),
+        array(
             'Parameter' => 'calendarPastDays',
             'Value' => '0',
             'Type' => 'uint',

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -3,5 +3,5 @@
  * Expected DB schema version number (MELD-51).
  * Bump when DBconfig.json, DatabaseManager migrations, or ConfigDefaults.php change.
  */
-return 7;
+return 8;
 ?>

--- a/evaluate.php
+++ b/evaluate.php
@@ -39,11 +39,9 @@ $payload = array(
 <div class="w3-container w3-margin-top w3-margin-bottom">
   <form method="get" action="evaluate.php" class="w3-bar w3-mobile" style="display:flex;flex-wrap:wrap;gap:0.75rem;align-items:center;">
     <label for="eval-days"><b>Zeitraum</b></label>
-    <select id="eval-days" name="days" class="w3-select w3-border w3-mobile" style="max-width:10rem;" onchange="this.form.submit()">
-      <?php foreach(evaluateAllowedDayOptions() as $opt): ?>
-      <option value="<?php echo (int)$opt; ?>"<?php echo $days === $opt ? ' selected' : ''; ?>><?php echo (int)$opt; ?> Tage</option>
-      <?php endforeach; ?>
-    </select>
+    <input id="eval-days" name="days" type="number" min="1" max="3650" step="1" value="<?php echo (int)$days; ?>" class="w3-input w3-border w3-mobile" style="max-width:6rem;" required>
+    <span>Tage</span>
+    <button type="submit" class="w3-button w3-border <?php echo $GLOBALS['optionsDB']['colorBtnSubmit']; ?>">Anzeigen</button>
     <label class="w3-mobile">
       <input type="checkbox" name="besetzung" value="1"<?php echo $besetzungOnly ? ' checked' : ''; ?> onchange="this.form.submit()">
       nur Besetzung

--- a/evaluate.php
+++ b/evaluate.php
@@ -1,137 +1,112 @@
 <?php
 session_start();
-$_SESSION['page']='evaluate';
-$_SESSION['adminpage']=true;
+$_SESSION['page'] = 'evaluate';
+$_SESSION['adminpage'] = true;
 include "common/header.php";
 if(!requirePermission("perm_showLog")) {
     denyAccess();
 }
+
+require_once __DIR__.'/libs/evaluateStats.php';
+
+$days = evaluateNormalizeDays(isset($_GET['days']) ? (int)$_GET['days'] : 90);
+$besetzungOnly = !empty($_GET['besetzung']);
+$inactiveDays = isset($GLOBALS['optionsDB']['inactiveUsersDays'])
+    ? max(1, (int)$GLOBALS['optionsDB']['inactiveUsersDays'])
+    : 90;
+
+$attendance = evaluateAttendanceSeries($days, $besetzungOnly);
+$logSeries = evaluateLogSeries($days);
+$ranking = evaluateAttendanceRanking($days, $besetzungOnly);
+$inactive = evaluateInactiveUsers($inactiveDays);
+
+$assetV = isset($GLOBALS['version']['Hash']) ? $GLOBALS['version']['Hash'] : '0';
+$jsMtime = @filemtime(__DIR__.'/js/evaluate.js');
+$evaluateJs = htmlspecialchars('js/evaluate.js?'.$assetV.'-'.$jsMtime, ENT_QUOTES, 'UTF-8');
+
+$payload = array(
+    'attendance' => $attendance,
+    'log' => $logSeries,
+    'ranking' => $ranking,
+    'inactive' => $inactive,
+    'logLabels' => array('FATAL', 'ERROR', 'WARNING', 'DBDELETE', 'DBINSERT', 'DBUPDATE', 'EMAIL', 'INFO'),
+);
 ?>
 <div id="header" class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-<h2>Datenauswertung</h2>
+  <h2>Datenauswertung</h2>
 </div>
-<?php
-$now = date("Y-m-d");
-$sql = sprintf('SELECT DATE(`Timestamp`) AS `LogDate`, COUNT(CASE WHEN `Type` = 0 THEN 1 END) AS `NumLogs0`, COUNT(CASE WHEN `Type` = 1 THEN 1 END) AS `NumLogs1`, COUNT(CASE WHEN `Type` = 2 THEN 1 END) AS `NumLogs2`, COUNT(CASE WHEN `Type` = 3 THEN 1 END) AS `NumLogs3`, COUNT(CASE WHEN `Type` = 4 THEN 1 END) AS `NumLogs4`, COUNT(CASE WHEN `Type` = 5 THEN 1 END) AS `NumLogs5`, COUNT(CASE WHEN `Type` = 6 THEN 1 END) AS `NumLogs6`, COUNT(CASE WHEN `Type` = 7 THEN 1 END) AS `NumLogs7` FROM  `%sLog` GROUP BY DATE(`Timestamp`) ORDER BY `LogDate` DESC LIMIT %d;',
-$GLOBALS['dbprefix'],
-$GLOBALS['optionsDB']['numberOfDaysInHistory']
-);
-$dbr = mysqli_query($conn, $sql);
-sqlerror();
-$plotline = "[";
-while($row = mysqli_fetch_array($dbr)) {
-    $plotline = $plotline."[".string2gDate($row['LogDate']).",".$row['NumLogs0'].",".$row['NumLogs1'].",".$row['NumLogs2'].",".$row['NumLogs3'].",".$row['NumLogs4'].",".$row['NumLogs5'].",".$row['NumLogs6'].",".$row['NumLogs7']."],\n";
-}
-$plotline = $plotline."]";
 
-?>
-    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-    <script>
-    google.charts.load('current', {packages: ['corechart', 'line'], 'language': 'de'});
-google.charts.setOnLoadCallback(drawBasic);
+<div class="w3-container w3-margin-top w3-margin-bottom">
+  <form method="get" action="evaluate.php" class="w3-bar w3-mobile" style="display:flex;flex-wrap:wrap;gap:0.75rem;align-items:center;">
+    <label for="eval-days"><b>Zeitraum</b></label>
+    <select id="eval-days" name="days" class="w3-select w3-border w3-mobile" style="max-width:10rem;" onchange="this.form.submit()">
+      <?php foreach(evaluateAllowedDayOptions() as $opt): ?>
+      <option value="<?php echo (int)$opt; ?>"<?php echo $days === $opt ? ' selected' : ''; ?>><?php echo (int)$opt; ?> Tage</option>
+      <?php endforeach; ?>
+    </select>
+    <label class="w3-mobile">
+      <input type="checkbox" name="besetzung" value="1"<?php echo $besetzungOnly ? ' checked' : ''; ?> onchange="this.form.submit()">
+      nur Besetzung
+    </label>
+  </form>
+</div>
 
-function drawBasic() {
-    var data = new google.visualization.DataTable();
-    data.addColumn('date', 'Datum');
-    data.addColumn('number', 'FATAL');
-    data.addColumn('number', 'ERROR');
-    data.addColumn('number', 'WARNING');
-    data.addColumn('number', 'DBDELETE');
-    data.addColumn('number', 'DBINSERT');
-    data.addColumn('number', 'DBUPDATE');
-    data.addColumn('number', 'EMAIL');
-    data.addColumn('number', 'INFO');
-    
-    data.addRows(<?php echo $plotline; ?>);
+<div class="w3-container w3-margin-bottom">
+  <h3>Teilnahme über Zeit</h3>
+  <p class="w3-text-gray">Veröffentlichte Termine ohne Schichten<?php echo $besetzungOnly ? ' (nur Besetzung)' : ''; ?> der letzten <?php echo (int)$days; ?> Tage.</p>
+  <div class="w3-responsive" style="position:relative;height:320px;">
+    <canvas id="chartAttendance" aria-label="Teilnahme-Diagramm"></canvas>
+  </div>
+</div>
 
-    var options = {
-        hAxis: {
-            title: 'Datum'
-        },
-        vAxis: {
-            title: 'Anzahl'
-        },
-        height: 450,
-        timeline: {
-          groupByRowLabel: true
-        },
-        bar: {
-          groupWidth: '100%',
-        },
-        isStacked: true,
-    };
+<div class="w3-container w3-margin-bottom">
+  <h3>System-Log</h3>
+  <div class="w3-responsive" style="position:relative;height:320px;">
+    <canvas id="chartLog" aria-label="Log-Diagramm"></canvas>
+  </div>
+</div>
 
-    var chart = new google.visualization.ColumnChart(document.getElementById('chart_div'));
+<div class="w3-container w3-margin-bottom">
+  <h3>Ranking nach Teilnahme</h3>
+  <p class="w3-text-gray">Quote = Ja-Meldungen / Termine im Zeitraum. Spaltenüberschriften zum Sortieren anklicken.</p>
+  <div class="w3-responsive">
+    <table id="evalRanking" class="w3-table w3-striped w3-bordered w3-hoverable">
+      <thead>
+        <tr class="<?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
+          <th class="eval-sort" data-sort="name" data-type="string" style="cursor:pointer;">Name</th>
+          <th class="eval-sort" data-sort="yes" data-type="number" style="cursor:pointer;">Ja</th>
+          <th class="eval-sort" data-sort="no" data-type="number" style="cursor:pointer;">Nein</th>
+          <th class="eval-sort" data-sort="maybe" data-type="number" style="cursor:pointer;">Vielleicht</th>
+          <th class="eval-sort" data-sort="termine" data-type="number" style="cursor:pointer;">Termine</th>
+          <th class="eval-sort" data-sort="quote" data-type="number" style="cursor:pointer;">Quote</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
 
-    chart.draw(data, options);
-}
+<div class="w3-container w3-margin-bottom">
+  <h3>Inaktive Nutzer</h3>
+  <p class="w3-text-gray">Musiker ohne Aktivität (Login und Teilnahme) in den letzten <?php echo (int)$inactiveDays; ?> Tagen. Schwellwert: Konfiguration <code>inactiveUsersDays</code>.</p>
+  <div class="w3-responsive">
+    <table id="evalInactive" class="w3-table w3-striped w3-bordered w3-hoverable">
+      <thead>
+        <tr class="<?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
+          <th class="eval-sort" data-sort="name" data-type="string" style="cursor:pointer;">Name</th>
+          <th class="eval-sort" data-sort="lastLogin" data-type="string" style="cursor:pointer;">Letzter Login</th>
+          <th class="eval-sort" data-sort="lastAttend" data-type="string" style="cursor:pointer;">Letzte Teilnahme</th>
+          <th class="eval-sort" data-sort="quote" data-type="number" style="cursor:pointer;">Meldequote</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
 
-     </script>
-                                     
-  <div id="chart_div"></div>
-
-
-<?php
-    $sql = sprintf("SELECT * FROM `%sTermine` WHERE `Shifts` = 0 AND `published` = 1 AND `Datum` BETWEEN NOW() - INTERVAL %d DAY AND NOW() ORDER BY `Datum`;",
-    $GLOBALS['dbprefix'],
-    $GLOBALS['optionsDB']['numberOfDaysInHistory']
-    );
-$dbr = mysqli_query($GLOBALS['conn'], $sql);
-sqlerror();
-$str = "";
-while($row = mysqli_fetch_array($dbr)) {
-    $t = new Termin;
-    $t->load_by_id($row['Index']);
-    /* $str=$str."[".string2gDate($t->Datum).", ".($t->getMeldungRatio()*100)."],\n"; */
-    $yes = $t->getMeldungenVal(1);
-    $no = $t->getMeldungenVal(2);
-    $maybe = $t->getMeldungenVal(3);
-    $all = $yes + $no + $maybe;
-    $str=$str."[".string2gDate($t->Datum).", ".$yes.", ".$no.", ".$maybe."],\n";
-}
-    ?>
-
-    <script>
-
-google.charts.load('current', {packages: ['corechart'], 'language': 'de'});
-google.charts.setOnLoadCallback(drawBasic);
-
-function drawBasic() {
-    var data = new google.visualization.DataTable();
-    data.addColumn('date', 'Datum');
-    data.addColumn('number', 'ja');
-    data.addColumn('number', 'nein');
-    data.addColumn('number', 'vielleicht');
-    
-    data.addRows(<?php echo "[".$str."]"; ?>);
-
-    var options = {
-        hAxis: {
-            title: 'Datum'
-        },
-        vAxis: {
-          title: 'Meldungen',
-          minValue: 0,
-          /* maxValue: 100, */
-        },
-        height: 450,
-        /* timeline: { */
-        /*   groupByRowLabel: true */
-        /* }, */
-        bar: {
-          groupWidth: '50%',
-        },
-        legend: 'true',
-        isStacked: true
-    };
-
-    var chart = new google.visualization.ColumnChart(document.getElementById('chart_rate'));
-
-    chart.draw(data, options);
-}
-
-     </script>
-<div id="chart_rate"></div>
+<script type="application/json" id="evaluate-data"><?php echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS); ?></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.8/dist/chart.umd.min.js"></script>
+<script src="<?php echo $evaluateJs; ?>"></script>
 
 <?php
 include "common/footer.php";

--- a/js/evaluate.js
+++ b/js/evaluate.js
@@ -1,0 +1,240 @@
+(function () {
+  'use strict';
+
+  var dataEl = document.getElementById('evaluate-data');
+  if (!dataEl) {
+    return;
+  }
+
+  var data;
+  try {
+    data = JSON.parse(dataEl.textContent);
+  } catch (e) {
+    return;
+  }
+
+  var attendance = data.attendance || { labels: [], yes: [], no: [], maybe: [], rate: [] };
+  var log = data.log || { labels: [], series: {} };
+  var logLabels = data.logLabels || [];
+
+  function drawAttendance() {
+    var canvas = document.getElementById('chartAttendance');
+    if (!canvas || typeof Chart === 'undefined') {
+      return;
+    }
+    new Chart(canvas, {
+      data: {
+        labels: attendance.labels,
+        datasets: [
+          {
+            type: 'bar',
+            label: 'Ja',
+            data: attendance.yes,
+            backgroundColor: 'rgba(76, 175, 80, 0.75)',
+            stack: 'meld'
+          },
+          {
+            type: 'bar',
+            label: 'Nein',
+            data: attendance.no,
+            backgroundColor: 'rgba(244, 67, 54, 0.75)',
+            stack: 'meld'
+          },
+          {
+            type: 'bar',
+            label: 'Vielleicht',
+            data: attendance.maybe,
+            backgroundColor: 'rgba(33, 150, 243, 0.75)',
+            stack: 'meld'
+          },
+          {
+            type: 'line',
+            label: 'Ja-Quote %',
+            data: attendance.rate,
+            yAxisID: 'yRate',
+            borderColor: 'rgba(255, 152, 0, 1)',
+            backgroundColor: 'rgba(255, 152, 0, 0.2)',
+            tension: 0.2,
+            pointRadius: 3
+          }
+        ]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: 'index', intersect: false },
+        scales: {
+          x: { stacked: true },
+          y: { stacked: true, beginAtZero: true, title: { display: true, text: 'Meldungen' } },
+          yRate: {
+            position: 'right',
+            beginAtZero: true,
+            max: 100,
+            grid: { drawOnChartArea: false },
+            title: { display: true, text: 'Ja-Quote %' }
+          }
+        }
+      }
+    });
+  }
+
+  function drawLog() {
+    var canvas = document.getElementById('chartLog');
+    if (!canvas || typeof Chart === 'undefined') {
+      return;
+    }
+    var colors = [
+      '#b71c1c', '#e53935', '#fb8c00', '#6d4c41',
+      '#43a047', '#1e88e5', '#8e24aa', '#546e7a'
+    ];
+    var datasets = [];
+    for (var i = 0; i <= 7; i++) {
+      datasets.push({
+        label: logLabels[i] || ('Type ' + i),
+        data: (log.series && log.series[i]) ? log.series[i] : [],
+        backgroundColor: colors[i],
+        stack: 'log'
+      });
+    }
+    new Chart(canvas, {
+      type: 'bar',
+      data: {
+        labels: log.labels || [],
+        datasets: datasets
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          x: { stacked: true },
+          y: { stacked: true, beginAtZero: true, title: { display: true, text: 'Anzahl' } }
+        }
+      }
+    });
+  }
+
+  function formatQuote(q) {
+    var n = Number(q);
+    if (!isFinite(n)) {
+      return '—';
+    }
+    return (n * 100).toFixed(1) + ' %';
+  }
+
+  function formatDate(v) {
+    return v ? String(v) : '—';
+  }
+
+  function sortRows(rows, key, type, dir) {
+    var mul = dir === 'asc' ? 1 : -1;
+    return rows.slice().sort(function (a, b) {
+      var av = a[key];
+      var bv = b[key];
+      if (type === 'number') {
+        av = Number(av) || 0;
+        bv = Number(bv) || 0;
+        if (av === bv) {
+          return String(a.name || '').localeCompare(String(b.name || ''));
+        }
+        return (av < bv ? -1 : 1) * mul;
+      }
+      av = av == null || av === '' ? '' : String(av);
+      bv = bv == null || bv === '' ? '' : String(bv);
+      return av.localeCompare(bv, 'de') * mul;
+    });
+  }
+
+  function bindSortableTable(tableId, rows, renderRow, defaultKey, defaultDir) {
+    var table = document.getElementById(tableId);
+    if (!table) {
+      return;
+    }
+    var tbody = table.querySelector('tbody');
+    var state = { key: defaultKey, dir: defaultDir, type: 'number' };
+
+    function paint() {
+      var sorted = sortRows(rows, state.key, state.type, state.dir);
+      tbody.innerHTML = '';
+      if (!sorted.length) {
+        var empty = document.createElement('tr');
+        var td = document.createElement('td');
+        td.colSpan = table.querySelectorAll('thead th').length;
+        td.textContent = 'Keine Einträge';
+        td.className = 'w3-text-gray';
+        empty.appendChild(td);
+        tbody.appendChild(empty);
+        return;
+      }
+      sorted.forEach(function (row) {
+        tbody.appendChild(renderRow(row));
+      });
+      Array.prototype.forEach.call(table.querySelectorAll('th.eval-sort'), function (th) {
+        var label = th.getAttribute('data-label') || th.textContent.replace(/\s*[▲▼]\s*$/, '');
+        th.setAttribute('data-label', label);
+        if (th.getAttribute('data-sort') === state.key) {
+          th.textContent = label + (state.dir === 'asc' ? ' ▲' : ' ▼');
+        } else {
+          th.textContent = label;
+        }
+      });
+    }
+
+    Array.prototype.forEach.call(table.querySelectorAll('th.eval-sort'), function (th) {
+      th.addEventListener('click', function () {
+        var key = th.getAttribute('data-sort');
+        var type = th.getAttribute('data-type') || 'string';
+        if (state.key === key) {
+          state.dir = state.dir === 'asc' ? 'desc' : 'asc';
+        } else {
+          state.key = key;
+          state.type = type;
+          state.dir = type === 'number' ? 'desc' : 'asc';
+        }
+        paint();
+      });
+    });
+
+    var defaultTh = table.querySelector('th.eval-sort[data-sort="' + defaultKey + '"]');
+    if (defaultTh) {
+      state.type = defaultTh.getAttribute('data-type') || 'number';
+    }
+    paint();
+  }
+
+  function rankingRow(row) {
+    var tr = document.createElement('tr');
+    [
+      row.name,
+      row.yes,
+      row.no,
+      row.maybe,
+      row.termine,
+      formatQuote(row.quote)
+    ].forEach(function (val) {
+      var td = document.createElement('td');
+      td.textContent = val == null ? '' : String(val);
+      tr.appendChild(td);
+    });
+    return tr;
+  }
+
+  function inactiveRow(row) {
+    var tr = document.createElement('tr');
+    [
+      row.name,
+      formatDate(row.lastLogin),
+      formatDate(row.lastAttend),
+      formatQuote(row.quote)
+    ].forEach(function (val) {
+      var td = document.createElement('td');
+      td.textContent = val == null ? '' : String(val);
+      tr.appendChild(td);
+    });
+    return tr;
+  }
+
+  drawAttendance();
+  drawLog();
+  bindSortableTable('evalRanking', data.ranking || [], rankingRow, 'quote', 'desc');
+  bindSortableTable('evalInactive', data.inactive || [], inactiveRow, 'lastLogin', 'asc');
+})();

--- a/libs/evaluateStats.php
+++ b/libs/evaluateStats.php
@@ -4,21 +4,18 @@
  */
 
 /**
- * @return int[]
- */
-function evaluateAllowedDayOptions() {
-    return array(30, 90, 180, 365);
-}
-
-/**
+ * Clamp evaluation window to a positive day count (default 90).
+ *
  * @param int $days
  * @return int
  */
 function evaluateNormalizeDays($days) {
     $days = (int)$days;
-    $allowed = evaluateAllowedDayOptions();
-    if(!in_array($days, $allowed, true)) {
+    if($days < 1) {
         return 90;
+    }
+    if($days > 3650) {
+        return 3650;
     }
     return $days;
 }

--- a/libs/evaluateStats.php
+++ b/libs/evaluateStats.php
@@ -1,0 +1,328 @@
+<?php
+/**
+ * Aggregations for evaluate.php statistics (MELD-89).
+ */
+
+/**
+ * @return int[]
+ */
+function evaluateAllowedDayOptions() {
+    return array(30, 90, 180, 365);
+}
+
+/**
+ * @param int $days
+ * @return int
+ */
+function evaluateNormalizeDays($days) {
+    $days = (int)$days;
+    $allowed = evaluateAllowedDayOptions();
+    if(!in_array($days, $allowed, true)) {
+        return 90;
+    }
+    return $days;
+}
+
+/**
+ * SQL fragment for published non-shift termines in the window.
+ *
+ * @param int $days
+ * @param bool $besetzungOnly
+ * @param string $alias Table alias including trailing dot, e.g. "`t`." or ""
+ * @return string
+ */
+function evaluateTerminWindowSql($days, $besetzungOnly, $alias = '') {
+    $days = (int)$days;
+    $a = $alias;
+    $extra = $besetzungOnly ? ' AND '.$a.'`Auftritt` = 1' : '';
+    return sprintf(
+        '%s`Shifts` = 0 AND %s`published` = 1'
+        .' AND %s`Datum` BETWEEN (CURRENT_DATE() - INTERVAL %d DAY) AND CURRENT_DATE()%s',
+        $a,
+        $a,
+        $a,
+        $days,
+        $extra
+    );
+}
+
+/**
+ * Attendance counts per termin date in the window.
+ *
+ * @param int $days
+ * @param bool $besetzungOnly
+ * @return array{labels:string[],yes:int[],no:int[],maybe:int[],rate:float[]}
+ */
+function evaluateAttendanceSeries($days, $besetzungOnly = false) {
+    $days = evaluateNormalizeDays($days);
+    $prefix = $GLOBALS['dbprefix'];
+    $window = evaluateTerminWindowSql($days, $besetzungOnly, '`t`.');
+
+    $sql = sprintf(
+        'SELECT `t`.`Datum` AS `Datum`,'
+        .' COALESCE(SUM(CASE WHEN `m`.`Wert` = 1 THEN 1 ELSE 0 END), 0) AS `Yes`,'
+        .' COALESCE(SUM(CASE WHEN `m`.`Wert` = 2 THEN 1 ELSE 0 END), 0) AS `No`,'
+        .' COALESCE(SUM(CASE WHEN `m`.`Wert` = 3 THEN 1 ELSE 0 END), 0) AS `Maybe`'
+        .' FROM `%sTermine` `t`'
+        .' LEFT JOIN `%sMeldungen` `m` ON `m`.`Termin` = `t`.`Index`'
+        .' WHERE %s'
+        .' GROUP BY `t`.`Index`, `t`.`Datum`'
+        .' ORDER BY `t`.`Datum` ASC, `t`.`Index` ASC;',
+        $prefix,
+        $prefix,
+        $window
+    );
+
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+
+    $labels = array();
+    $yes = array();
+    $no = array();
+    $maybe = array();
+    $rate = array();
+
+    if($dbr) {
+        while($row = mysqli_fetch_assoc($dbr)) {
+            $y = (int)$row['Yes'];
+            $n = (int)$row['No'];
+            $m = (int)$row['Maybe'];
+            $total = $y + $n + $m;
+            $labels[] = $row['Datum'];
+            $yes[] = $y;
+            $no[] = $n;
+            $maybe[] = $m;
+            $rate[] = $total > 0 ? round(($y / $total) * 100, 1) : 0.0;
+        }
+    }
+
+    return array(
+        'labels' => $labels,
+        'yes' => $yes,
+        'no' => $no,
+        'maybe' => $maybe,
+        'rate' => $rate,
+    );
+}
+
+/**
+ * System log counts per day in the window.
+ *
+ * @param int $days
+ * @return array{labels:string[],series:array<int,int[]>}
+ */
+function evaluateLogSeries($days) {
+    $days = evaluateNormalizeDays($days);
+    $prefix = $GLOBALS['dbprefix'];
+
+    $sql = sprintf(
+        'SELECT DATE(`Timestamp`) AS `LogDate`,'
+        .' COUNT(CASE WHEN `Type` = 0 THEN 1 END) AS `NumLogs0`,'
+        .' COUNT(CASE WHEN `Type` = 1 THEN 1 END) AS `NumLogs1`,'
+        .' COUNT(CASE WHEN `Type` = 2 THEN 1 END) AS `NumLogs2`,'
+        .' COUNT(CASE WHEN `Type` = 3 THEN 1 END) AS `NumLogs3`,'
+        .' COUNT(CASE WHEN `Type` = 4 THEN 1 END) AS `NumLogs4`,'
+        .' COUNT(CASE WHEN `Type` = 5 THEN 1 END) AS `NumLogs5`,'
+        .' COUNT(CASE WHEN `Type` = 6 THEN 1 END) AS `NumLogs6`,'
+        .' COUNT(CASE WHEN `Type` = 7 THEN 1 END) AS `NumLogs7`'
+        .' FROM `%sLog`'
+        .' WHERE `Timestamp` >= (NOW() - INTERVAL %d DAY)'
+        .' GROUP BY DATE(`Timestamp`)'
+        .' ORDER BY `LogDate` ASC;',
+        $prefix,
+        $days
+    );
+
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+
+    $labels = array();
+    $series = array();
+    for($i = 0; $i <= 7; $i++) {
+        $series[$i] = array();
+    }
+
+    if($dbr) {
+        while($row = mysqli_fetch_assoc($dbr)) {
+            $labels[] = $row['LogDate'];
+            for($i = 0; $i <= 7; $i++) {
+                $series[$i][] = (int)$row['NumLogs'.$i];
+            }
+        }
+    }
+
+    return array(
+        'labels' => $labels,
+        'series' => $series,
+    );
+}
+
+/**
+ * Count of matching termines in the window (denominator for ranking quote).
+ *
+ * @param int $days
+ * @param bool $besetzungOnly
+ * @return int
+ */
+function evaluateTerminCount($days, $besetzungOnly = false) {
+    $days = evaluateNormalizeDays($days);
+    $prefix = $GLOBALS['dbprefix'];
+    $window = evaluateTerminWindowSql($days, $besetzungOnly);
+
+    $sql = sprintf(
+        'SELECT COUNT(*) AS `CNT` FROM `%sTermine` WHERE %s;',
+        $prefix,
+        $window
+    );
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    $row = $dbr ? mysqli_fetch_assoc($dbr) : null;
+    return $row ? (int)$row['CNT'] : 0;
+}
+
+/**
+ * Per-user attendance ranking in the window.
+ *
+ * @param int $days
+ * @param bool $besetzungOnly
+ * @return array<int,array{id:int,name:string,yes:int,no:int,maybe:int,termine:int,quote:float}>
+ */
+function evaluateAttendanceRanking($days, $besetzungOnly = false) {
+    $days = evaluateNormalizeDays($days);
+    $prefix = $GLOBALS['dbprefix'];
+    $termineCount = evaluateTerminCount($days, $besetzungOnly);
+    $window = evaluateTerminWindowSql($days, $besetzungOnly);
+
+    $sql = sprintf(
+        'SELECT `u`.`Index` AS `UserId`, `u`.`Vorname`, `u`.`Nachname`,'
+        .' COALESCE(SUM(CASE WHEN `m`.`Wert` = 1 THEN 1 ELSE 0 END), 0) AS `Yes`,'
+        .' COALESCE(SUM(CASE WHEN `m`.`Wert` = 2 THEN 1 ELSE 0 END), 0) AS `No`,'
+        .' COALESCE(SUM(CASE WHEN `m`.`Wert` = 3 THEN 1 ELSE 0 END), 0) AS `Maybe`'
+        .' FROM `%sUser` `u`'
+        .' LEFT JOIN `%sMeldungen` `m` ON `m`.`User` = `u`.`Index`'
+        .' AND `m`.`Termin` IN (SELECT `Index` FROM `%sTermine` WHERE %s)'
+        .' WHERE `u`.`Deleted` != 1 AND `u`.`Instrument` > 0'
+        .' GROUP BY `u`.`Index`, `u`.`Vorname`, `u`.`Nachname`'
+        .' ORDER BY `u`.`Nachname` ASC, `u`.`Vorname` ASC;',
+        $prefix,
+        $prefix,
+        $prefix,
+        $window
+    );
+
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+
+    $rows = array();
+    if($dbr) {
+        while($row = mysqli_fetch_assoc($dbr)) {
+            $yes = (int)$row['Yes'];
+            $quote = $termineCount > 0 ? round($yes / $termineCount, 4) : 0.0;
+            $rows[] = array(
+                'id' => (int)$row['UserId'],
+                'name' => trim($row['Nachname'].', '.$row['Vorname']),
+                'yes' => $yes,
+                'no' => (int)$row['No'],
+                'maybe' => (int)$row['Maybe'],
+                'termine' => $termineCount,
+                'quote' => $quote,
+            );
+        }
+    }
+
+    usort($rows, function($a, $b) {
+        if($a['quote'] == $b['quote']) {
+            if($a['yes'] == $b['yes']) {
+                return strcmp($a['name'], $b['name']);
+            }
+            return $b['yes'] - $a['yes'];
+        }
+        return ($a['quote'] < $b['quote']) ? 1 : -1;
+    });
+
+    return $rows;
+}
+
+/**
+ * Users considered inactive by last login / last attendance (Wert=1).
+ *
+ * @param int $thresholdDays
+ * @return array<int,array{id:int,name:string,lastLogin:?string,lastAttend:?string,quote:float}>
+ */
+function evaluateInactiveUsers($thresholdDays) {
+    $thresholdDays = max(1, (int)$thresholdDays);
+    $prefix = $GLOBALS['dbprefix'];
+
+    $sql = sprintf(
+        'SELECT `u`.`Index` AS `UserId`, `u`.`Vorname`, `u`.`Nachname`, `u`.`LastLogin`, `u`.`Joined`,'
+        .' ('
+        .'   SELECT MAX(`t`.`Datum`) FROM `%sMeldungen` `m`'
+        .'   INNER JOIN `%sTermine` `t` ON `t`.`Index` = `m`.`Termin`'
+        .'   WHERE `m`.`User` = `u`.`Index` AND `m`.`Wert` = 1 AND `t`.`Datum` <= CURRENT_DATE()'
+        .' ) AS `LastAttend`'
+        .' FROM `%sUser` `u`'
+        .' WHERE `u`.`Deleted` != 1 AND `u`.`Instrument` > 0;',
+        $prefix,
+        $prefix,
+        $prefix
+    );
+
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+
+    $cutoff = new DateTimeImmutable('today');
+    $cutoff = $cutoff->modify('-'.$thresholdDays.' days');
+    $cutoffDate = $cutoff->format('Y-m-d');
+
+    $rows = array();
+    if($dbr) {
+        while($row = mysqli_fetch_assoc($dbr)) {
+            $lastLogin = $row['LastLogin'] ? substr($row['LastLogin'], 0, 10) : null;
+            $lastAttend = $row['LastAttend'] ? substr($row['LastAttend'], 0, 10) : null;
+
+            $lastActivity = null;
+            if($lastLogin && $lastAttend) {
+                $lastActivity = ($lastLogin > $lastAttend) ? $lastLogin : $lastAttend;
+            }
+            elseif($lastLogin) {
+                $lastActivity = $lastLogin;
+            }
+            elseif($lastAttend) {
+                $lastActivity = $lastAttend;
+            }
+
+            if($lastActivity !== null && $lastActivity >= $cutoffDate) {
+                continue;
+            }
+
+            $user = new User();
+            $user->load_by_id((int)$row['UserId']);
+            $quote = 0.0;
+            if($user->Index) {
+                $quote = (float)$user->getMeldeQuote();
+            }
+
+            $rows[] = array(
+                'id' => (int)$row['UserId'],
+                'name' => trim($row['Nachname'].', '.$row['Vorname']),
+                'lastLogin' => $lastLogin,
+                'lastAttend' => $lastAttend,
+                'quote' => $quote,
+            );
+        }
+    }
+
+    usort($rows, function($a, $b) {
+        $aKey = $a['lastLogin'] ?: '0000-00-00';
+        $bKey = $b['lastLogin'] ?: '0000-00-00';
+        if($aKey === $bKey) {
+            $aA = $a['lastAttend'] ?: '0000-00-00';
+            $bA = $b['lastAttend'] ?: '0000-00-00';
+            return strcmp($aA, $bA);
+        }
+        return strcmp($aKey, $bKey);
+    });
+
+    return $rows;
+}
+?>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -213,7 +213,7 @@ $sections[] = array(
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung)</li>
-<li><b>Statistik</b> – Auswertungen: Zeitraum wählen, Teilnahme- und Log-Diagramme, Ranking nach Teilnahme (sortierbar), Liste inaktiver Musiker (Login/Teilnahme)</li>
+<li><b>Statistik</b> – Auswertungen: Zeitraum in Tagen frei wählen, Teilnahme- und Log-Diagramme, Ranking nach Teilnahme (sortierbar), Liste inaktiver Musiker (Login/Teilnahme)</li>
 ' : '').'
 </ul>
 '

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -213,7 +213,7 @@ $sections[] = array(
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung)</li>
-<li><b>Statistik</b> – Auswertungen</li>
+<li><b>Statistik</b> – Auswertungen: Zeitraum wählen, Teilnahme- und Log-Diagramme, Ranking nach Teilnahme (sortierbar), Liste inaktiver Musiker (Login/Teilnahme)</li>
 ' : '').'
 </ul>
 '


### PR DESCRIPTION
## Summary
- Statistik-Seite mit Chart.js (Teilnahme + System-Log), freiem Zeitraum in Tagen und Besetzung-Filter
- Sortierbares Teilnahme-Ranking und Inaktiven-Liste (`inactiveUsersDays`)
- Schema-Version 8 / Config-Default; Hilfe aktualisiert

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-89

## Test plan
- [ ] Statistik öffnen (Recht `perm_showLog`), Zeitraum frei setzen, Anzeigen
- [ ] Teilnahme-/Log-Charts responsiv prüfen
- [ ] Ranking und Inaktive sortieren
- [ ] Toggle „nur Besetzung“
- [ ] Nach Deploy: DB-Repair/Updater für `inactiveUsersDays`


Made with [Cursor](https://cursor.com)