### PR TITLE
MELD-89: Statistik-Navigation und responsives Layout

### DIFF
--- a/evaluate.php
+++ b/evaluate.php
@@ -31,74 +31,90 @@ $payload = array(
     'inactive' => $inactive,
     'logLabels' => array('FATAL', 'ERROR', 'WARNING', 'DBDELETE', 'DBINSERT', 'DBUPDATE', 'EMAIL', 'INFO'),
 );
+
+$titleBar = $GLOBALS['optionsDB']['colorTitleBar'];
+$btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
 ?>
-<div id="header" class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
+<div id="header" class="w3-container <?php echo $titleBar; ?>">
   <h2>Datenauswertung</h2>
 </div>
 
 <div class="w3-container w3-margin-top w3-margin-bottom">
-  <form method="get" action="evaluate.php" class="w3-bar w3-mobile" style="display:flex;flex-wrap:wrap;gap:0.75rem;align-items:center;">
+  <form method="get" action="evaluate.php" class="eval-filter" id="eval-filter">
     <label for="eval-days"><b>Zeitraum</b></label>
-    <input id="eval-days" name="days" type="number" min="1" max="3650" step="1" value="<?php echo (int)$days; ?>" class="w3-input w3-border w3-mobile" style="max-width:6rem;" required>
+    <input id="eval-days" name="days" type="number" min="1" max="3650" step="1" value="<?php echo (int)$days; ?>" class="w3-input w3-border" required>
     <span>Tage</span>
-    <button type="submit" class="w3-button w3-border <?php echo $GLOBALS['optionsDB']['colorBtnSubmit']; ?>">Anzeigen</button>
-    <label class="w3-mobile">
+    <button type="submit" class="w3-button w3-border <?php echo $btnSubmit; ?>">Anzeigen</button>
+    <label>
       <input type="checkbox" name="besetzung" value="1"<?php echo $besetzungOnly ? ' checked' : ''; ?> onchange="this.form.submit()">
       nur Besetzung
     </label>
   </form>
 </div>
 
-<div class="w3-container w3-margin-bottom">
-  <h3>Teilnahme über Zeit</h3>
-  <p class="w3-text-gray">Veröffentlichte Termine ohne Schichten<?php echo $besetzungOnly ? ' (nur Besetzung)' : ''; ?> der letzten <?php echo (int)$days; ?> Tage.</p>
-  <div class="w3-responsive" style="position:relative;height:320px;">
-    <canvas id="chartAttendance" aria-label="Teilnahme-Diagramm"></canvas>
-  </div>
-</div>
+<nav class="eval-toc w3-container w3-margin-bottom" aria-label="Seitenabschnitte">
+  <a class="w3-button w3-border w3-round" href="#eval-attendance">Teilnahme</a>
+  <a class="w3-button w3-border w3-round" href="#eval-log">System-Log</a>
+  <a class="w3-button w3-border w3-round" href="#eval-ranking">Ranking</a>
+  <a class="w3-button w3-border w3-round" href="#eval-inactive">Inaktive</a>
+</nav>
 
-<div class="w3-container w3-margin-bottom">
-  <h3>System-Log</h3>
-  <div class="w3-responsive" style="position:relative;height:320px;">
-    <canvas id="chartLog" aria-label="Log-Diagramm"></canvas>
-  </div>
-</div>
+<div class="eval-layout w3-container">
+  <div class="eval-charts">
+    <section class="eval-panel" id="eval-attendance">
+      <h3>Teilnahme über Zeit</h3>
+      <p class="w3-text-gray">Veröffentlichte Termine ohne Schichten<?php echo $besetzungOnly ? ' (nur Besetzung)' : ''; ?> der letzten <?php echo (int)$days; ?> Tage.</p>
+      <div class="eval-chart-wrap">
+        <canvas id="chartAttendance" aria-label="Teilnahme-Diagramm"></canvas>
+      </div>
+    </section>
 
-<div class="w3-container w3-margin-bottom">
-  <h3>Ranking nach Teilnahme</h3>
-  <p class="w3-text-gray">Quote = Ja-Meldungen / Termine im Zeitraum. Spaltenüberschriften zum Sortieren anklicken.</p>
-  <div class="w3-responsive">
-    <table id="evalRanking" class="w3-table w3-striped w3-bordered w3-hoverable">
-      <thead>
-        <tr class="<?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-          <th class="eval-sort" data-sort="name" data-type="string" style="cursor:pointer;">Name</th>
-          <th class="eval-sort" data-sort="yes" data-type="number" style="cursor:pointer;">Ja</th>
-          <th class="eval-sort" data-sort="no" data-type="number" style="cursor:pointer;">Nein</th>
-          <th class="eval-sort" data-sort="maybe" data-type="number" style="cursor:pointer;">Vielleicht</th>
-          <th class="eval-sort" data-sort="termine" data-type="number" style="cursor:pointer;">Termine</th>
-          <th class="eval-sort" data-sort="quote" data-type="number" style="cursor:pointer;">Quote</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <section class="eval-panel" id="eval-log">
+      <h3>System-Log</h3>
+      <div class="eval-chart-wrap">
+        <canvas id="chartLog" aria-label="Log-Diagramm"></canvas>
+      </div>
+    </section>
   </div>
-</div>
 
-<div class="w3-container w3-margin-bottom">
-  <h3>Inaktive Nutzer</h3>
-  <p class="w3-text-gray">Musiker ohne Aktivität (Login und Teilnahme) in den letzten <?php echo (int)$inactiveDays; ?> Tagen. Schwellwert: Konfiguration <code>inactiveUsersDays</code>.</p>
-  <div class="w3-responsive">
-    <table id="evalInactive" class="w3-table w3-striped w3-bordered w3-hoverable">
-      <thead>
-        <tr class="<?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-          <th class="eval-sort" data-sort="name" data-type="string" style="cursor:pointer;">Name</th>
-          <th class="eval-sort" data-sort="lastLogin" data-type="string" style="cursor:pointer;">Letzter Login</th>
-          <th class="eval-sort" data-sort="lastAttend" data-type="string" style="cursor:pointer;">Letzte Teilnahme</th>
-          <th class="eval-sort" data-sort="quote" data-type="number" style="cursor:pointer;">Meldequote</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+  <div class="eval-tables">
+    <section class="eval-panel" id="eval-ranking">
+      <h3>Ranking nach Teilnahme</h3>
+      <p class="w3-text-gray">Quote = Ja-Meldungen / Termine im Zeitraum. Spaltenüberschriften zum Sortieren anklicken.</p>
+      <div class="eval-table-scroll w3-responsive">
+        <table id="evalRanking" class="w3-table w3-striped w3-bordered w3-hoverable">
+          <thead>
+            <tr class="<?php echo $titleBar; ?>">
+              <th class="eval-sort" data-sort="name" data-type="string">Name</th>
+              <th class="eval-sort" data-sort="yes" data-type="number">Ja</th>
+              <th class="eval-sort" data-sort="no" data-type="number">Nein</th>
+              <th class="eval-sort" data-sort="maybe" data-type="number">Vielleicht</th>
+              <th class="eval-sort" data-sort="termine" data-type="number">Termine</th>
+              <th class="eval-sort" data-sort="quote" data-type="number">Quote</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="eval-panel" id="eval-inactive">
+      <h3>Inaktive Nutzer</h3>
+      <p class="w3-text-gray">Musiker ohne Aktivität (Login und Teilnahme) in den letzten <?php echo (int)$inactiveDays; ?> Tagen. Schwellwert: Konfiguration <code>inactiveUsersDays</code>.</p>
+      <div class="eval-table-scroll w3-responsive">
+        <table id="evalInactive" class="w3-table w3-striped w3-bordered w3-hoverable">
+          <thead>
+            <tr class="<?php echo $titleBar; ?>">
+              <th class="eval-sort" data-sort="name" data-type="string">Name</th>
+              <th class="eval-sort" data-sort="lastLogin" data-type="string">Letzter Login</th>
+              <th class="eval-sort" data-sort="lastAttend" data-type="string">Letzte Teilnahme</th>
+              <th class="eval-sort" data-sort="quote" data-type="number">Meldequote</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
   </div>
 </div>
 

--- a/evaluate.php
+++ b/evaluate.php
@@ -81,7 +81,7 @@ $btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
     <section class="eval-panel" id="eval-ranking">
       <h3>Ranking nach Teilnahme</h3>
       <p class="w3-text-gray">Quote = Ja-Meldungen / Termine im Zeitraum. Spaltenüberschriften zum Sortieren anklicken.</p>
-      <div class="eval-table-scroll w3-responsive">
+      <div class="eval-table-scroll">
         <table id="evalRanking" class="w3-table w3-striped w3-bordered w3-hoverable">
           <thead>
             <tr class="<?php echo $titleBar; ?>">
@@ -101,7 +101,7 @@ $btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
     <section class="eval-panel" id="eval-inactive">
       <h3>Inaktive Nutzer</h3>
       <p class="w3-text-gray">Musiker ohne Aktivität (Login und Teilnahme) in den letzten <?php echo (int)$inactiveDays; ?> Tagen. Schwellwert: Konfiguration <code>inactiveUsersDays</code>.</p>
-      <div class="eval-table-scroll w3-responsive">
+      <div class="eval-table-scroll">
         <table id="evalInactive" class="w3-table w3-striped w3-bordered w3-hoverable">
           <thead>
             <tr class="<?php echo $titleBar; ?>">

--- a/evaluate.php
+++ b/evaluate.php
@@ -82,15 +82,15 @@ $btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
       <h3>Ranking nach Teilnahme</h3>
       <p class="w3-text-gray">Quote = Ja-Meldungen / Termine im Zeitraum. Spaltenüberschriften zum Sortieren anklicken.</p>
       <div class="eval-table-scroll">
-        <table id="evalRanking" class="w3-table w3-striped w3-bordered w3-hoverable">
+        <table id="evalRanking" class="w3-table w3-striped w3-bordered w3-hoverable eval-data-table">
           <thead>
-            <tr class="<?php echo $titleBar; ?>">
-              <th class="eval-sort" data-sort="name" data-type="string">Name</th>
-              <th class="eval-sort" data-sort="yes" data-type="number">Ja</th>
-              <th class="eval-sort" data-sort="no" data-type="number">Nein</th>
-              <th class="eval-sort" data-sort="maybe" data-type="number">Vielleicht</th>
-              <th class="eval-sort" data-sort="termine" data-type="number">Termine</th>
-              <th class="eval-sort" data-sort="quote" data-type="number">Quote</th>
+            <tr>
+              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="name" data-type="string">Name</th>
+              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="yes" data-type="number">Ja</th>
+              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="no" data-type="number">Nein</th>
+              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="maybe" data-type="number">Vielleicht</th>
+              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="termine" data-type="number">Termine</th>
+              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="quote" data-type="number">Quote</th>
             </tr>
           </thead>
           <tbody></tbody>
@@ -102,13 +102,13 @@ $btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
       <h3>Inaktive Nutzer</h3>
       <p class="w3-text-gray">Musiker ohne Aktivität (Login und Teilnahme) in den letzten <?php echo (int)$inactiveDays; ?> Tagen. Schwellwert: Konfiguration <code>inactiveUsersDays</code>.</p>
       <div class="eval-table-scroll">
-        <table id="evalInactive" class="w3-table w3-striped w3-bordered w3-hoverable">
+        <table id="evalInactive" class="w3-table w3-striped w3-bordered w3-hoverable eval-data-table">
           <thead>
-            <tr class="<?php echo $titleBar; ?>">
-              <th class="eval-sort" data-sort="name" data-type="string">Name</th>
-              <th class="eval-sort" data-sort="lastLogin" data-type="string">Letzter Login</th>
-              <th class="eval-sort" data-sort="lastAttend" data-type="string">Letzte Teilnahme</th>
-              <th class="eval-sort" data-sort="quote" data-type="number">Meldequote</th>
+            <tr>
+              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="name" data-type="string">Name</th>
+              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="lastLogin" data-type="string">Letzter Login</th>
+              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="lastAttend" data-type="string">Letzte Teilnahme</th>
+              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="quote" data-type="number">Meldequote</th>
             </tr>
           </thead>
           <tbody></tbody>

--- a/js/evaluate.js
+++ b/js/evaluate.js
@@ -201,36 +201,34 @@
     paint();
   }
 
-  function rankingRow(row) {
-    var tr = document.createElement('tr');
-    [
-      row.name,
-      row.yes,
-      row.no,
-      row.maybe,
-      row.termine,
-      formatQuote(row.quote)
-    ].forEach(function (val) {
+  function cellsWithLabels(tr, pairs) {
+    pairs.forEach(function (pair) {
       var td = document.createElement('td');
-      td.textContent = val == null ? '' : String(val);
+      td.setAttribute('data-label', pair[0]);
+      td.textContent = pair[1] == null ? '' : String(pair[1]);
       tr.appendChild(td);
     });
     return tr;
   }
 
+  function rankingRow(row) {
+    return cellsWithLabels(document.createElement('tr'), [
+      ['Name', row.name],
+      ['Ja', row.yes],
+      ['Nein', row.no],
+      ['Vielleicht', row.maybe],
+      ['Termine', row.termine],
+      ['Quote', formatQuote(row.quote)]
+    ]);
+  }
+
   function inactiveRow(row) {
-    var tr = document.createElement('tr');
-    [
-      row.name,
-      formatDate(row.lastLogin),
-      formatDate(row.lastAttend),
-      formatQuote(row.quote)
-    ].forEach(function (val) {
-      var td = document.createElement('td');
-      td.textContent = val == null ? '' : String(val);
-      tr.appendChild(td);
-    });
-    return tr;
+    return cellsWithLabels(document.createElement('tr'), [
+      ['Name', row.name],
+      ['Letzter Login', formatDate(row.lastLogin)],
+      ['Letzte Teilnahme', formatDate(row.lastAttend)],
+      ['Meldequote', formatQuote(row.quote)]
+    ]);
   }
 
   drawAttendance();

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1415,6 +1415,13 @@ body.insurance-print {
   overflow: auto;
 }
 
+.eval-table-scroll thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.12);
+}
+
 .eval-sort {
   cursor: pointer;
   user-select: none;

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1366,3 +1366,82 @@ body.insurance-print {
     page-break-inside: avoid;
   }
 }
+
+/* MELD-89: evaluate.php layout */
+.eval-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.eval-filter #eval-days {
+  max-width: 6rem;
+}
+
+.eval-toc {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  background: inherit;
+}
+
+.eval-toc a {
+  text-decoration: none;
+}
+
+.eval-panel {
+  margin-bottom: 1.25rem;
+  scroll-margin-top: 3.5rem;
+}
+
+.eval-panel h3 {
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  padding-bottom: 0.25rem;
+}
+
+.eval-chart-wrap {
+  position: relative;
+  height: 320px;
+}
+
+.eval-table-scroll {
+  max-height: 28rem;
+  overflow: auto;
+}
+
+.eval-sort {
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.eval-charts,
+.eval-tables {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 993px) {
+  .eval-charts,
+  .eval-tables {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+
+  .eval-chart-wrap {
+    height: 360px;
+  }
+}
+
+@media (min-width: 1400px) {
+  .eval-chart-wrap {
+    height: 400px;
+  }
+}

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1425,17 +1425,19 @@ body.insurance-print {
   border-radius: 0.25rem;
 }
 
-.eval-table-scroll table {
+.eval-table-scroll table.eval-data-table {
   width: 100%;
   min-width: 28rem;
   margin: 0;
+  border-collapse: separate;
+  border-spacing: 0;
 }
 
 .eval-table-scroll thead th {
   position: sticky;
   top: 0;
   z-index: 2;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.18);
 }
 
 .eval-sort {
@@ -1464,7 +1466,7 @@ body.insurance-print {
     border-radius: 0;
   }
 
-  .eval-table-scroll table {
+  .eval-table-scroll table.eval-data-table {
     min-width: 0;
     width: 100%;
     border-collapse: separate;
@@ -1533,6 +1535,29 @@ body.insurance-print {
     padding-bottom: 0.45rem;
     margin-bottom: 0.25rem;
     border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  }
+}
+
+@media (min-width: 701px) {
+  .eval-table-scroll thead {
+    display: table-header-group;
+  }
+
+  .eval-table-scroll tbody {
+    display: table-row-group;
+  }
+
+  .eval-table-scroll tr {
+    display: table-row;
+  }
+
+  .eval-table-scroll th,
+  .eval-table-scroll td {
+    display: table-cell;
+  }
+
+  .eval-table-scroll tbody td::before {
+    content: none;
   }
 }
 

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1368,6 +1368,11 @@ body.insurance-print {
 }
 
 /* MELD-89: evaluate.php layout */
+.eval-layout {
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
 .eval-filter {
   display: flex;
   flex-wrap: wrap;
@@ -1398,6 +1403,7 @@ body.insurance-print {
 .eval-panel {
   margin-bottom: 1.25rem;
   scroll-margin-top: 3.5rem;
+  min-width: 0;
 }
 
 .eval-panel h3 {
@@ -1407,12 +1413,22 @@ body.insurance-print {
 
 .eval-chart-wrap {
   position: relative;
-  height: 320px;
+  height: 280px;
+  max-width: 100%;
 }
 
 .eval-table-scroll {
   max-height: 28rem;
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 0.25rem;
+}
+
+.eval-table-scroll table {
+  width: 100%;
+  min-width: 28rem;
+  margin: 0;
 }
 
 .eval-table-scroll thead th {
@@ -1433,6 +1449,91 @@ body.insurance-print {
   display: grid;
   grid-template-columns: 1fr;
   gap: 1rem;
+  min-width: 0;
+}
+
+@media (max-width: 700px) {
+  .eval-chart-wrap {
+    height: 240px;
+  }
+
+  .eval-table-scroll {
+    max-height: none;
+    overflow: visible;
+    border: none;
+    border-radius: 0;
+  }
+
+  .eval-table-scroll table {
+    min-width: 0;
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+  }
+
+  .eval-table-scroll thead {
+    display: block;
+    margin-bottom: 0.75rem;
+  }
+
+  .eval-table-scroll thead tr {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .eval-table-scroll thead th {
+    position: static;
+    display: inline-block;
+    float: none;
+    width: auto;
+    padding: 0.4rem 0.65rem;
+    border: none;
+    border-radius: 0.25rem;
+    box-shadow: none;
+    font-size: 0.85rem;
+    font-weight: 600;
+  }
+
+  .eval-table-scroll tbody {
+    display: block;
+  }
+
+  .eval-table-scroll tbody tr {
+    display: block;
+    margin-bottom: 0.75rem;
+    padding: 0.65rem 0.75rem;
+    border: 1px solid rgba(0, 0, 0, 0.14);
+    border-radius: 0.35rem;
+    background: #fff;
+  }
+
+  .eval-table-scroll tbody td {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.75rem;
+    padding: 0.3rem 0;
+    border: none;
+    text-align: right;
+    white-space: normal;
+    word-break: break-word;
+  }
+
+  .eval-table-scroll tbody td::before {
+    content: attr(data-label);
+    font-weight: 600;
+    text-align: left;
+    flex: 0 0 42%;
+    color: rgba(0, 0, 0, 0.65);
+  }
+
+  .eval-table-scroll tbody td:first-child {
+    font-weight: 600;
+    padding-bottom: 0.45rem;
+    margin-bottom: 0.25rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  }
 }
 
 @media (min-width: 993px) {

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -213,7 +213,7 @@ $sections[] = array(
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung)</li>
-<li><b>Statistik</b> – Auswertungen: Zeitraum in Tagen frei wählen, Teilnahme- und Log-Diagramme, Ranking nach Teilnahme (sortierbar), Liste inaktiver Musiker (Login/Teilnahme)</li>
+<li><b>Statistik</b> – Auswertungen mit Abschnittsnavigation; auf breiten Bildschirmen Diagramme und Tabellen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking und Inaktive (sortierbar)</li>
 ' : '').'
 </ul>
 '


### PR DESCRIPTION
## Summary
- Abschnittsnavigation (sticky) auf der Statistik-Seite
- Zweispaltiges Layout für Diagramme/Tabellen auf breiten Screens
- Sticky Tabellenköpfe; Karten-Layout auf schmalen Screens
- Fix: Header überlappt nicht mehr die erste Zeile

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-89

## Test plan
- [ ] Statistik Desktop: zwei Spalten, sticky Header beim Scrollen
- [ ] Schmaler Viewport: Karten + Sortier-Chips
- [ ] Keine Überlappung Kopf/erste Zeile


Made with [Cursor](https://cursor.com)