### PR TITLE
MELD-90: Backup export/restore via cron and admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ Details zum Schema und zur Erstinstallation liefert die Install-Seite selbst.
 | `dev` | Staging / Vorschau |
 | `MELD-<n>-…` | Feature-Branches |
 
+## Backup
+
+Datenbank-Backup als ZIP (`manifest.json` mit Software-/Schema-Version + `database.sql`).
+
+- Admin-UI: **System → Backup** (Recht Konfiguration)
+- Remote-Abruf (Cron auf einem anderen Server):
+
+```bash
+curl -fsS "https://HOST/cron.php?id=CRONID&cmd=backup" -o "backup-$(date +%F).zip"
+```
+
+CLI-Restore (destruktiv, nur mit `--yes`):
+
+```bash
+php scripts/restoreBackup.php /path/to/backup.zip --yes
+```
+
 ## Tests
 
 Automatisierte Integrationstests liegen im privaten Sibling-Repository [meldeliste-tests](https://github.com/Musikverein-Bonn-Duisdorf/meldeliste-tests) (Checkout neben `meldeliste/`). Setup und Ausführung sind dort dokumentiert.

--- a/backup.php
+++ b/backup.php
@@ -3,6 +3,26 @@ session_start();
 $_SESSION['page'] = 'backup';
 $_SESSION['adminpage'] = true;
 
+// Download must run before any HTML output (header.php)
+if(isset($_GET['download']) && $_GET['download'] === '1') {
+    include_once 'common/include.php';
+    mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($GLOBALS['conn']));
+    requireLoggedInOrRedirect();
+    if(!requirePermission('perm_editConfig')) {
+        denyAccess('Keine Berechtigung für Backup/Restore.');
+    }
+    require_once __DIR__.'/libs/backup.php';
+    try {
+        sendBackupDownload();
+    }
+    catch(Throwable $e) {
+        http_response_code(500);
+        header('Content-Type: text/plain; charset=utf-8');
+        echo 'Backup failed: '.$e->getMessage()."\n";
+        exit(1);
+    }
+}
+
 include_once 'common/header.php';
 
 if(!requirePermission('perm_editConfig')) {
@@ -13,15 +33,6 @@ require_once __DIR__.'/libs/backup.php';
 
 $flash = null;
 $restoreResult = null;
-
-if(isset($_GET['download']) && $_GET['download'] === '1') {
-    try {
-        sendBackupDownload();
-    }
-    catch(Throwable $e) {
-        $flash = array('type' => 'error', 'message' => 'Download fehlgeschlagen: '.$e->getMessage());
-    }
-}
 
 if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['restore_confirm'])) {
     if(empty($_POST['confirm_text']) || trim((string)$_POST['confirm_text']) !== 'RESTORE') {

--- a/backup.php
+++ b/backup.php
@@ -1,0 +1,106 @@
+<?php
+session_start();
+$_SESSION['page'] = 'backup';
+$_SESSION['adminpage'] = true;
+
+include_once 'common/header.php';
+
+if(!requirePermission('perm_editConfig')) {
+    denyAccess('Keine Berechtigung für Backup/Restore.');
+}
+
+require_once __DIR__.'/libs/backup.php';
+
+$flash = null;
+$restoreResult = null;
+
+if(isset($_GET['download']) && $_GET['download'] === '1') {
+    try {
+        sendBackupDownload();
+    }
+    catch(Throwable $e) {
+        $flash = array('type' => 'error', 'message' => 'Download fehlgeschlagen: '.$e->getMessage());
+    }
+}
+
+if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['restore_confirm'])) {
+    if(empty($_POST['confirm_text']) || trim((string)$_POST['confirm_text']) !== 'RESTORE') {
+        $flash = array('type' => 'error', 'message' => 'Bitte zur Bestätigung RESTORE eintippen.');
+    }
+    elseif(empty($_FILES['backup_zip']) || !is_uploaded_file($_FILES['backup_zip']['tmp_name'])) {
+        $flash = array('type' => 'error', 'message' => 'Keine ZIP-Datei hochgeladen.');
+    }
+    else {
+        try {
+            $restoreResult = restoreBackupZip($_FILES['backup_zip']['tmp_name'], true);
+            if(!empty($restoreResult['errors'])) {
+                $flash = array(
+                    'type' => 'error',
+                    'message' => 'Restore mit Fehlern: '.implode('; ', $restoreResult['errors']),
+                );
+            }
+            else {
+                $flash = array(
+                    'type' => 'ok',
+                    'message' => 'Restore erfolgreich ('.$restoreResult['statements'].' Statements'
+                        .($restoreResult['repaired'] ? ', Schema repariert' : '')
+                        .').',
+                );
+                $logentry = new Log;
+                $logentry->info('<b>Database restore</b> from uploaded backup ZIP');
+            }
+        }
+        catch(Throwable $e) {
+            $flash = array('type' => 'error', 'message' => 'Restore fehlgeschlagen: '.$e->getMessage());
+        }
+    }
+}
+
+$manifest = buildBackupManifest();
+$ver = $manifest['version'];
+$schema = $manifest['schemaVersion'];
+?>
+<div id="header" class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
+  <h2>Backup &amp; Restore</h2>
+</div>
+
+<div class="w3-container w3-margin-top">
+<?php if($flash) {
+    $panel = ($flash['type'] === 'ok') ? $GLOBALS['optionsDB']['colorSuccess'] : $GLOBALS['optionsDB']['colorLogError'];
+    echo '<div class="w3-panel '.$panel.'"><p>'.htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8').'</p></div>';
+} ?>
+
+  <div class="w3-card w3-padding w3-margin-bottom">
+    <h3>Aktueller Stand</h3>
+    <p>
+      Software-Version: <b><?php echo htmlspecialchars($ver['String'], ENT_QUOTES, 'UTF-8'); ?></b><br>
+      Schema: installiert <b><?php echo (int)$schema['installed']; ?></b>, Soll <b><?php echo (int)$schema['expected']; ?></b><br>
+      DB-Prefix: <code><?php echo htmlspecialchars($manifest['dbprefix'], ENT_QUOTES, 'UTF-8'); ?></code>
+    </p>
+  </div>
+
+  <div class="w3-card w3-padding w3-margin-bottom">
+    <h3>Backup herunterladen</h3>
+    <p>ZIP mit <code>manifest.json</code> (Versionsinfo) und <code>database.sql</code> (alle Tabellen mit DB-Prefix).</p>
+    <p>Remote-Cron-Beispiel:</p>
+    <pre class="w3-code w3-border w3-padding" style="white-space:pre-wrap;">curl -fsS "https://HOST/cron.php?id=CRONID&amp;cmd=backup" -o "backup-$(date +%F).zip"</pre>
+    <p><a class="w3-button w3-border <?php echo $GLOBALS['optionsDB']['colorBtnSubmit']; ?>" href="backup.php?download=1"><i class="fas fa-download"></i> Backup jetzt laden</a></p>
+  </div>
+
+  <div class="w3-card w3-padding w3-margin-bottom w3-pale-red">
+    <h3>Restore (destruktiv)</h3>
+    <p><b>Achtung:</b> Überschreibt die Datenbanktabellen mit dem Prefix. Vorher ein aktuelles Backup ziehen.</p>
+    <form method="post" enctype="multipart/form-data" action="backup.php" onsubmit="return confirm('Wirklich Restore ausführen? Die aktuelle Datenbank wird überschrieben.');">
+      <input type="hidden" name="restore_confirm" value="1">
+      <label>Backup-ZIP</label>
+      <input class="w3-input w3-border w3-margin-bottom" type="file" name="backup_zip" accept=".zip,application/zip" required>
+      <label>Zur Bestätigung <code>RESTORE</code> eingeben</label>
+      <input class="w3-input w3-border w3-margin-bottom" type="text" name="confirm_text" autocomplete="off" required>
+      <button type="submit" class="w3-button w3-border w3-red">Backup einspielen</button>
+    </form>
+  </div>
+</div>
+
+<?php
+include 'common/footer.php';
+?>

--- a/common/include.php
+++ b/common/include.php
@@ -44,4 +44,5 @@ include "libs/aushilfeShift.php";
 include "libs/AppmntFreeTextResponse.php";
 include "libs/listChunk.php";
 include "libs/evaluateStats.php";
+include "libs/backup.php";
 ?>

--- a/common/nav.php
+++ b/common/nav.php
@@ -165,6 +165,7 @@ if($u->hasInventories()) { ?>
           <?php if(requirePermission("perm_editConfig")) { ?>
           <a title="Konfiguration" alt="Konfiguration" href="config-menu.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPage('config');?>"><i class="fas fa-cogs"></i> Konfiguration</a>
           <a title="Updater" alt="Updater" href="updater.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPage('updater');?>"><i class="fas fa-code-branch"></i> Updater</a>
+          <a title="Backup" alt="Backup" href="backup.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPage('backup');?>"><i class="fas fa-database"></i> Backup</a>
           <?php } ?>
           <?php if(requirePermission("perm_showLog")) { ?>
           <a title="Statistik" alt="Statistik" href="evaluate.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPage('evaluate');?>"><i class="fas fa-chart-pie"></i> Statistik</a>

--- a/cron.php
+++ b/cron.php
@@ -1,21 +1,45 @@
 <?php
-echo date("Y-m-d H:i:s")."<br />\n";
-
 session_start();
 include 'common/include.php';
-if(!isset($_GET['id'])) die("no ID specified\n");
-if(!$_GET['id']==$GLOBALS['cronID']) die("ID invalid\n");
-if(!isset($_GET['cmd'])) die("no command specified\n");
+
+if(!isset($_GET['id'])) {
+    die("no ID specified\n");
+}
+if($_GET['id'] != $GLOBALS['cronID']) {
+    die("ID invalid\n");
+}
+if(!isset($_GET['cmd'])) {
+    die("no command specified\n");
+}
+
+$cmd = (string)$_GET['cmd'];
+
+// Binary download: no HTML preamble
+if($cmd === 'backup') {
+    require_once __DIR__.'/libs/backup.php';
+    mkAdmin();
+    try {
+        sendBackupDownload();
+    }
+    catch(Throwable $e) {
+        http_response_code(500);
+        header('Content-Type: text/plain; charset=utf-8');
+        echo "Backup failed: ".$e->getMessage()."\n";
+        exit(1);
+    }
+}
+
+echo date("Y-m-d H:i:s")."<br />\n";
 mkAdmin();
 
-switch($_GET['cmd']) {
+switch($cmd) {
 case "newAppmnts":
     echo "newAppmnts...\n";
     if($GLOBALS['optionsDB']['cronSendnewAppmnts'] == 0) {
         echo "new Appmnts not activated.\n";
         break;
     }
-    if(!checkCronDate($GLOBALS['optionsDB']['cronSendnewAppmntsDays'])) { 
+    if(!checkCronDate($GLOBALS['optionsDB']['cronSendnewAppmntsDays'])) {
         echo "No sendnewAppmnts today\n";
         break;
     }
@@ -100,7 +124,7 @@ case "reminder":
         echo "Reminder not activated.\n";
         break;
 	}
-	if(!checkCronDate($GLOBALS['optionsDB']['cronSendReminderDays'])) { 
+	if(!checkCronDate($GLOBALS['optionsDB']['cronSendReminderDays'])) {
         break;
 	}
 	$time = date("H:i");
@@ -120,7 +144,7 @@ case "reminder":
 	$row = mysqli_fetch_array($dbr);
 	$Nappmnts = $row['cnt'];
 
-	
+
 	$sql = sprintf("SELECT * FROM `%sUser` WHERE `getMail` = 1;",
     $GLOBALS['dbprefix']
 	);

--- a/libs/backup.php
+++ b/libs/backup.php
@@ -1,0 +1,340 @@
+<?php
+/**
+ * Database backup / restore helpers (MELD-90).
+ */
+
+/**
+ * @return array
+ */
+function buildBackupManifest() {
+    $version = isset($GLOBALS['version']) && is_array($GLOBALS['version'])
+        ? $GLOBALS['version']
+        : array('String' => '', 'Date' => '', 'Hash' => '');
+
+    $installed = null;
+    $expected = null;
+    if(class_exists('DatabaseManager')) {
+        try {
+            $mgr = new DatabaseManager();
+            $installed = $mgr->getInstalledSchemaVersion();
+            $expected = $mgr->getExpectedSchemaVersion();
+        }
+        catch(Throwable $e) {
+            // leave nulls
+        }
+    }
+
+    return array(
+        'app' => 'meldeliste',
+        'createdAt' => gmdate('c'),
+        'dbprefix' => isset($GLOBALS['dbprefix']) ? (string)$GLOBALS['dbprefix'] : '',
+        'version' => array(
+            'String' => isset($version['String']) ? (string)$version['String'] : '',
+            'Date' => isset($version['Date']) ? (string)$version['Date'] : '',
+            'Hash' => isset($version['Hash']) ? (string)$version['Hash'] : '',
+        ),
+        'schemaVersion' => array(
+            'installed' => $installed,
+            'expected' => $expected,
+        ),
+    );
+}
+
+/**
+ * List tables matching the configured db prefix.
+ *
+ * @return string[]
+ */
+function backupListPrefixedTables() {
+    $conn = $GLOBALS['conn'];
+    $prefix = isset($GLOBALS['dbprefix']) ? (string)$GLOBALS['dbprefix'] : '';
+    $like = mysqli_real_escape_string($conn, $prefix.'%');
+    $dbr = mysqli_query($conn, "SHOW TABLES LIKE '".$like."'");
+    if(!$dbr) {
+        sqlerror();
+        return array();
+    }
+    $tables = array();
+    while($row = mysqli_fetch_row($dbr)) {
+        if(!empty($row[0])) {
+            $tables[] = $row[0];
+        }
+    }
+    sort($tables);
+    return $tables;
+}
+
+/**
+ * Escape a SQL literal for dump INSERT statements.
+ *
+ * @param mixed $value
+ * @return string
+ */
+function backupSqlLiteral($value) {
+    if($value === null) {
+        return 'NULL';
+    }
+    if(is_int($value) || is_float($value)) {
+        return (string)$value;
+    }
+    return "'".mysqli_real_escape_string($GLOBALS['conn'], (string)$value)."'";
+}
+
+/**
+ * Build a full SQL dump for all prefixed tables.
+ *
+ * @return string
+ */
+function exportDatabaseSql() {
+    $conn = $GLOBALS['conn'];
+    $tables = backupListPrefixedTables();
+    $out = array();
+    $out[] = '-- Meldeliste database backup';
+    $out[] = '-- Created: '.gmdate('c');
+    $out[] = 'SET NAMES utf8mb4;';
+    $out[] = 'SET FOREIGN_KEY_CHECKS=0;';
+    $out[] = 'SET UNIQUE_CHECKS=0;';
+    $out[] = 'SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";';
+    $out[] = '';
+
+    foreach($tables as $table) {
+        $safe = str_replace('`', '``', $table);
+        $createRes = mysqli_query($conn, 'SHOW CREATE TABLE `'.$safe.'`');
+        if(!$createRes) {
+            sqlerror();
+            continue;
+        }
+        $createRow = mysqli_fetch_assoc($createRes);
+        $createSql = '';
+        if(is_array($createRow)) {
+            foreach($createRow as $k => $v) {
+                if(stripos((string)$k, 'Create') === 0) {
+                    $createSql = $v;
+                    break;
+                }
+            }
+        }
+        if($createSql === '') {
+            continue;
+        }
+
+        $out[] = '-- Table `'.$table.'`';
+        $out[] = 'DROP TABLE IF EXISTS `'.$safe.'`;';
+        $out[] = $createSql.';';
+        $out[] = '';
+
+        $dataRes = mysqli_query($conn, 'SELECT * FROM `'.$safe.'`');
+        if(!$dataRes) {
+            sqlerror();
+            continue;
+        }
+        $fields = array();
+        $fieldInfo = mysqli_fetch_fields($dataRes);
+        if($fieldInfo) {
+            foreach($fieldInfo as $f) {
+                $fields[] = '`'.str_replace('`', '``', $f->name).'`';
+            }
+        }
+        $batch = array();
+        $batchSize = 50;
+        while($row = mysqli_fetch_row($dataRes)) {
+            $vals = array();
+            foreach($row as $col) {
+                $vals[] = backupSqlLiteral($col);
+            }
+            $batch[] = '('.implode(',', $vals).')';
+            if(count($batch) >= $batchSize) {
+                $out[] = 'INSERT INTO `'.$safe.'` ('.implode(',', $fields).') VALUES';
+                $out[] = implode(",\n", $batch).';';
+                $out[] = '';
+                $batch = array();
+            }
+        }
+        if($batch) {
+            $out[] = 'INSERT INTO `'.$safe.'` ('.implode(',', $fields).') VALUES';
+            $out[] = implode(",\n", $batch).';';
+            $out[] = '';
+        }
+        mysqli_free_result($dataRes);
+    }
+
+    $out[] = 'SET FOREIGN_KEY_CHECKS=1;';
+    $out[] = 'SET UNIQUE_CHECKS=1;';
+    $out[] = '';
+    return implode("\n", $out);
+}
+
+/**
+ * Create a backup ZIP in a temp file.
+ *
+ * @return array{path:string,filename:string,manifest:array}
+ */
+function createBackupZipFile() {
+    if(!class_exists('ZipArchive')) {
+        throw new RuntimeException('PHP ZipArchive extension is required for backups.');
+    }
+
+    $manifest = buildBackupManifest();
+    $sql = exportDatabaseSql();
+    $stamp = gmdate('Y-m-d-His');
+    $filename = 'meldeliste-backup-'.$stamp.'.zip';
+    $path = tempnam(sys_get_temp_dir(), 'meldbackup_');
+    if($path === false) {
+        throw new RuntimeException('Could not create temporary file for backup.');
+    }
+    $zipPath = $path.'.zip';
+    @unlink($path);
+
+    $zip = new ZipArchive();
+    if($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+        throw new RuntimeException('Could not open ZIP for writing.');
+    }
+    $zip->addFromString('manifest.json', json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n");
+    $zip->addFromString('database.sql', $sql);
+    $zip->close();
+
+    return array(
+        'path' => $zipPath,
+        'filename' => $filename,
+        'manifest' => $manifest,
+    );
+}
+
+/**
+ * Send backup ZIP to the HTTP client and exit.
+ */
+function sendBackupDownload() {
+    $backup = createBackupZipFile();
+    $path = $backup['path'];
+    $filename = $backup['filename'];
+    $size = filesize($path);
+
+    if(function_exists('header_remove')) {
+        @header_remove();
+    }
+    header('Content-Type: application/zip');
+    header('Content-Disposition: attachment; filename="'.$filename.'"');
+    if($size !== false) {
+        header('Content-Length: '.$size);
+    }
+    header('Cache-Control: no-store');
+    readfile($path);
+    @unlink($path);
+    exit;
+}
+
+/**
+ * Split SQL dump into executable statements (naive but sufficient for our exporter).
+ *
+ * @param string $sql
+ * @return string[]
+ */
+function backupSplitSqlStatements($sql) {
+    $statements = array();
+    $buffer = '';
+    $lines = preg_split("/\r\n|\n|\r/", $sql);
+    foreach($lines as $line) {
+        $trim = ltrim($line);
+        if($trim === '' || strpos($trim, '--') === 0) {
+            continue;
+        }
+        $buffer .= $line."\n";
+        if(substr(rtrim($line), -1) === ';') {
+            $stmt = trim($buffer);
+            if($stmt !== '' && $stmt !== ';') {
+                $statements[] = $stmt;
+            }
+            $buffer = '';
+        }
+    }
+    $tail = trim($buffer);
+    if($tail !== '') {
+        $statements[] = $tail;
+    }
+    return $statements;
+}
+
+/**
+ * Execute a SQL dump against the current connection.
+ *
+ * @param string $sql
+ * @return array{statements:int,errors:string[]}
+ */
+function restoreDatabaseSql($sql) {
+    $conn = $GLOBALS['conn'];
+    $statements = backupSplitSqlStatements($sql);
+    $errors = array();
+    $ok = 0;
+
+    mysqli_query($conn, 'SET FOREIGN_KEY_CHECKS=0');
+    foreach($statements as $stmt) {
+        if(!mysqli_query($conn, $stmt)) {
+            $errors[] = mysqli_errno($conn).': '.mysqli_error($conn);
+            // continue to collect more errors but stop after a few
+            if(count($errors) >= 10) {
+                break;
+            }
+        }
+        else {
+            $ok++;
+        }
+    }
+    mysqli_query($conn, 'SET FOREIGN_KEY_CHECKS=1');
+
+    return array(
+        'statements' => $ok,
+        'errors' => $errors,
+    );
+}
+
+/**
+ * Restore from a backup ZIP path.
+ *
+ * @param string $zipPath
+ * @param bool $runRepair
+ * @return array{manifest:?array,statements:int,errors:string[],repaired:bool}
+ */
+function restoreBackupZip($zipPath, $runRepair = true) {
+    if(!class_exists('ZipArchive')) {
+        throw new RuntimeException('PHP ZipArchive extension is required for restore.');
+    }
+    if(!is_readable($zipPath)) {
+        throw new RuntimeException('Backup ZIP not readable: '.$zipPath);
+    }
+
+    $zip = new ZipArchive();
+    if($zip->open($zipPath) !== true) {
+        throw new RuntimeException('Could not open backup ZIP.');
+    }
+    $sql = $zip->getFromName('database.sql');
+    $manifestRaw = $zip->getFromName('manifest.json');
+    $zip->close();
+
+    if($sql === false || $sql === '') {
+        throw new RuntimeException('ZIP does not contain database.sql');
+    }
+
+    $manifest = null;
+    if($manifestRaw !== false && $manifestRaw !== '') {
+        $decoded = json_decode($manifestRaw, true);
+        if(is_array($decoded)) {
+            $manifest = $decoded;
+        }
+    }
+
+    $result = restoreDatabaseSql($sql);
+    $repaired = false;
+    if($runRepair && empty($result['errors']) && class_exists('DatabaseManager')) {
+        $mgr = new DatabaseManager();
+        $mgr->repair();
+        $repaired = true;
+    }
+
+    return array(
+        'manifest' => $manifest,
+        'statements' => $result['statements'],
+        'errors' => $result['errors'],
+        'repaired' => $repaired,
+    );
+}
+?>

--- a/scripts/restoreBackup.php
+++ b/scripts/restoreBackup.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * CLI restore from a meldeliste backup ZIP (MELD-90).
+ *
+ * Usage: php scripts/restoreBackup.php /path/to/backup.zip --yes
+ */
+if(php_sapi_name() !== 'cli') {
+    fwrite(STDERR, "CLI only.\n");
+    exit(1);
+}
+
+$root = dirname(__DIR__);
+$configFile = $root.'/common/config.php';
+if(!is_readable($configFile)) {
+    fwrite(STDERR, "Missing common/config.php — copy from common/config_sample.php\n");
+    exit(1);
+}
+
+$zipPath = isset($argv[1]) ? $argv[1] : '';
+$confirm = in_array('--yes', $argv, true);
+
+if($zipPath === '' || $zipPath === '--yes') {
+    fwrite(STDERR, "Usage: php scripts/restoreBackup.php /path/to/backup.zip --yes\n");
+    exit(1);
+}
+if(!$confirm) {
+    fwrite(STDERR, "Refusing to run without --yes (destructive).\n");
+    exit(1);
+}
+
+require_once $configFile;
+
+if(!function_exists('sqlerror')) {
+    function sqlerror() {
+        if(!isset($GLOBALS['conn']) || !mysqli_errno($GLOBALS['conn'])) return;
+        fwrite(STDERR, "SQL ERROR ".mysqli_errno($GLOBALS['conn']).": ".mysqli_error($GLOBALS['conn'])."\n");
+    }
+}
+
+require_once $root.'/config/ConfigDefaults.php';
+require_once $root.'/config/SchemaVersion.php';
+require_once $root.'/common/version.php';
+require_once $root.'/libs/helpers.php';
+require_once $root.'/libs/SQLtable.php';
+require_once $root.'/libs/DatabaseManager.php';
+require_once $root.'/libs/backup.php';
+
+if(isset($GLOBALS['conn']) && $GLOBALS['conn']) {
+    mysqli_set_charset($GLOBALS['conn'], 'utf8mb4');
+    @mysqli_query($GLOBALS['conn'], "SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci");
+    if(isset($sql['database'])) {
+        mysqli_select_db($GLOBALS['conn'], $sql['database']);
+    }
+}
+
+try {
+    $result = restoreBackupZip($zipPath, true);
+    if($result['manifest']) {
+        echo "Manifest version: ".(isset($result['manifest']['version']['String']) ? $result['manifest']['version']['String'] : '?')."\n";
+        echo "Manifest createdAt: ".(isset($result['manifest']['createdAt']) ? $result['manifest']['createdAt'] : '?')."\n";
+    }
+    echo "Statements OK: ".$result['statements']."\n";
+    echo "Schema repair: ".($result['repaired'] ? 'yes' : 'no')."\n";
+    if(!empty($result['errors'])) {
+        fwrite(STDERR, "Errors:\n");
+        foreach($result['errors'] as $err) {
+            fwrite(STDERR, "  ".$err."\n");
+        }
+        exit(1);
+    }
+    echo "Restore finished.\n";
+    exit(0);
+}
+catch(Throwable $e) {
+    fwrite(STDERR, $e->getMessage()."\n");
+    exit(1);
+}

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -210,6 +210,7 @@ $sections[] = array(
 '.(requirePermission('perm_editConfig') ? '
 <li><b>Konfiguration</b> – Farben, Texte, Feature-Schalter, Webhooks, …</li>
 <li><b>Updater</b> – Software-Update und Datenbank-Reparatur / Schema-Stand</li>
+<li><b>Backup</b> – Datenbank-ZIP herunterladen (inkl. Versionsinfo) oder wieder einspielen; Remote-Abruf auch per <code>cron.php?cmd=backup</code></li>
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung)</li>


### PR DESCRIPTION
## Summary
- ZIP-Backup (manifest.json + database.sql) über Admin-UI und `cron.php?cmd=backup`
- Restore über Admin-UI (Bestätigung `RESTORE`) und CLI `scripts/restoreBackup.php`
- Download-Header vor HTML, damit der Browser die ZIP als Datei speichert

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-90

## Test plan
- [ ] System → Backup: ZIP lädt als Datei herunter (nicht als Text)
- [ ] ZIP enthält `manifest.json` (Version/Schema) und `database.sql`
- [ ] Cron: `cron.php?id=…&cmd=backup` liefert ZIP
- [ ] Restore mit Test-ZIP (Staging) und Bestätigung `RESTORE`
- [ ] Ohne `perm_editConfig` kein Zugriff


Made with [Cursor](https://cursor.com)