### PR TITLE
MELD-95: Termine und Rückmeldungen durchsuchbar

### DIFF
--- a/archiv.php
+++ b/archiv.php
@@ -14,12 +14,18 @@ $chunk = listChunkTermine('past', 'response', '', 50, (int)$_SESSION['userid']);
 </div>
 <div class="w3-row">
   <div class="w3-panel w3-col l3 w3-left"></div>
-  <div class="w3-col l6 s12 m12" id="Liste" data-cron-id="<?php echo htmlspecialchars((string)$GLOBALS['cronID'], ENT_QUOTES, 'UTF-8'); ?>">
+  <div class="w3-col l6 s12 m12">
+    <div class="w3-container w3-padding-16" style="clear:both;">
+      <input class="w3-input w3-border w3-padding" type="text" placeholder="Termine suchen (Titel, Ort, Datum, Beschreibung)…" id="filterString" onkeyup="filterTermine()">
+    </div>
+    <div id="Liste" data-cron-id="<?php echo htmlspecialchars((string)$GLOBALS['cronID'], ENT_QUOTES, 'UTF-8'); ?>">
 <?php echo $chunk['html']; ?>
-<?php echo listChunkRenderSentinel('archiv', $chunk['nextCursor'], $chunk['hasMore']); ?>
+<?php echo listChunkRenderSentinel('archiv', $chunk['nextCursor'], $chunk['hasMore'], 'filterTermine'); ?>
+    </div>
   </div>
   <div class="w3-col l3"></div>
 </div>
+<script src="js/filterTermine.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <script src="js/infiniteScroll.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <?php
 include "common/footer.php";

--- a/index.php
+++ b/index.php
@@ -58,10 +58,14 @@ if(isset($_POST['proxy'])) {
 $chunkUser = isset($user) ? (int)$user : (int)$_SESSION['userid'];
 $chunk = listChunkTermine('future', 'basic', '', 50, $chunkUser);
 ?>
+<div class="w3-container w3-padding-16" style="clear:both;">
+<input class="w3-input w3-border w3-padding" type="text" placeholder="Termine suchen (Titel, Ort, Datum, Beschreibung)…" id="filterString" onkeyup="filterTermine()">
+</div>
 <div id="Liste" data-cron-id="<?php echo htmlspecialchars((string)$GLOBALS['cronID'], ENT_QUOTES, 'UTF-8'); ?>">
 <?php echo $chunk['html']; ?>
-<?php echo listChunkRenderSentinel('termine', $chunk['nextCursor'], $chunk['hasMore'], '', ' data-extra="user='.$chunkUser.'"'); ?>
+<?php echo listChunkRenderSentinel('termine', $chunk['nextCursor'], $chunk['hasMore'], 'filterTermine', ' data-extra="user='.$chunkUser.'"'); ?>
 </div>
+<script src="js/filterTermine.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <script src="js/infiniteScroll.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <?php
 include "common/footer.php";

--- a/js/filterTermine.js
+++ b/js/filterTermine.js
@@ -1,0 +1,23 @@
+function filterTermine() {
+    var input, filter, table, tr, i, txtValue, dataSearch;
+    input = document.getElementById("filterString");
+    if(!input) return;
+    filter = input.value.toUpperCase();
+    table = document.getElementById("Liste");
+    if(!table) return;
+    tr = table.children;
+    for (i = 0; i < tr.length; i++) {
+        if(tr[i].id === "listSentinel") continue;
+        if(tr[i].tagName !== "DIV") continue;
+        if(tr[i].className === "w3-modal" || tr[i].className === "w3-modal-content") continue;
+        dataSearch = tr[i].getAttribute("data-search");
+        txtValue = dataSearch || tr[i].textContent || tr[i].innerText || "";
+        if (txtValue.toUpperCase().indexOf(filter) > -1) {
+            tr[i].style.display = "";
+            tr[i].classList.remove("list-filtered-out");
+        } else {
+            tr[i].style.display = "none";
+            tr[i].classList.add("list-filtered-out");
+        }
+    }
+}

--- a/libs/div.php
+++ b/libs/div.php
@@ -1,7 +1,7 @@
 <?php
 class div
 {
-    private $_data = array('indent' => 0, 'tag' => 'div', 'name' => null, 'class' => null, 'body' => null, 'id' => null, 'style' => null, 'onclick' => null, 'bold' => false, 'value' => null, 'type' => null, 'min' => null, 'step' => null, 'default' => null, 'emptyBody' => false, 'href' => null, 'action' => null, 'method' => null, 'placeholder' => null, 'checked' => null);
+    private $_data = array('indent' => 0, 'tag' => 'div', 'name' => null, 'class' => null, 'body' => null, 'id' => null, 'style' => null, 'onclick' => null, 'bold' => false, 'value' => null, 'type' => null, 'min' => null, 'step' => null, 'default' => null, 'emptyBody' => false, 'href' => null, 'action' => null, 'method' => null, 'placeholder' => null, 'checked' => null, 'extraAttrs' => null);
     public function __get($key) {
         switch($key) {
 	    case 'indent':
@@ -24,6 +24,7 @@ class div
         case 'method':
         case 'placeholder':
         case 'checked':
+        case 'extraAttrs':
             return $this->_data[$key];
             break;
         default:
@@ -59,6 +60,7 @@ class div
         case 'method':
         case 'placeholder':
         case 'default':
+        case 'extraAttrs':
             if($val) {
                 $this->_data[$key] = trim($val);
             }
@@ -147,6 +149,9 @@ class div
         }
         if($this->checked) {
             $str=$str." checked";
+        }
+        if($this->extraAttrs) {
+            $str=$str." ".$this->extraAttrs;
         }
         $str=$str.">\n";
         if($this->body) {

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -319,6 +319,30 @@ class Termin
         if(!$this->EndDatum) return germanDate($this->Datum, 1);
         return germanDateSpan($this->Datum, $this->EndDatum);
     }
+
+    /**
+     * Plain text used by client-side Termin/Rückmeldungen search (data-search).
+     */
+    public function getSearchText() {
+        $parts = array(
+            (string)$this->Name,
+            (string)$this->Beschreibung,
+            (string)$this->getOrt(),
+            (string)$this->getGermanDate(),
+            (string)$this->Datum,
+            (string)$this->EndDatum,
+            (string)$this->Uhrzeit,
+            (string)$this->Uhrzeit2,
+        );
+        $parts = array_filter($parts, function($p) {
+            return $p !== '';
+        });
+        return preg_replace('/\s+/u', ' ', trim(implode(' ', $parts)));
+    }
+
+    public function getSearchDataAttr() {
+        return 'data-search="'.htmlspecialchars($this->getSearchText(), ENT_QUOTES, 'UTF-8').'"';
+    }
     protected function makeAlwaysYes() {
         if($this->Shifts) return;
         $users = explode(",", $GLOBALS['optionsDB']['alwaysYesNewAppmnts']);
@@ -1273,6 +1297,7 @@ class Termin
         $main->class=$this->mainColor();
         $main->class=$this->mainHover();
         if(!$this->published) $main->class=$GLOBALS['optionsDB']['styleAppmntUnpublished'];
+        $main->extraAttrs = $this->getSearchDataAttr();
         $str=$str.$main->open();
 
         $indent++;
@@ -1795,6 +1820,7 @@ class Termin
         $containerdiv->id="responseLine".$this->Index;
         $containerdiv->class="w3-margin-top w3-border w3-border-black w3-card";
         $containerdiv->class=$GLOBALS['optionsDB']['colorInputBackground'];
+        $containerdiv->extraAttrs = $this->getSearchDataAttr();
         $str=$str.$containerdiv->open();
         $indent++;
         
@@ -2187,7 +2213,7 @@ ORDER BY `Nachname`, `Vorname`;",
         }
 
         $modalOpen = "openModal('terminResponse', ".$this->Index.($filterregister ? ", ".$filterregister : "").")";
-        $str = "<div id=\"responseLine".$this->Index."\" data-termin=\"".$this->Index."\" data-register=\"".$filterregister."\" class=\"w3-card w3-border w3-margin-top w3-border-black ".$GLOBALS['optionsDB']['colorInputBackground']."\"><div onclick=\"".$modalOpen."\" class=\"w3-container w3-center\"><h3 class=\"w3-left\">".$this->Name."</h3><p class=\"w3-right\">".$this->getGermanDate()."</p></div>\n";
+        $str = "<div id=\"responseLine".$this->Index."\" data-termin=\"".$this->Index."\" data-register=\"".$filterregister."\" ".$this->getSearchDataAttr()." class=\"w3-card w3-border w3-margin-top w3-border-black ".$GLOBALS['optionsDB']['colorInputBackground']."\"><div onclick=\"".$modalOpen."\" class=\"w3-container w3-center\"><h3 class=\"w3-left\">".$this->Name."</h3><p class=\"w3-right\">".$this->getGermanDate()."</p></div>\n";
         $str=$str."<div onclick=\"".$modalOpen."\" class=\"w3-container w3-margin-bottom\">\n";
 
         if($this->Auftritt) {

--- a/mein-register.php
+++ b/mein-register.php
@@ -17,7 +17,11 @@ else {
 </div>
       <div class="w3-row">
                <div class="w3-panel w3-col l3 w3-left"></div>
-                        <div class="w3-col l6 s12 m12" id="Liste" data-cron-id="<?php echo htmlspecialchars((string)$GLOBALS['cronID'], ENT_QUOTES, 'UTF-8'); ?>">
+                        <div class="w3-col l6 s12 m12">
+<div class="w3-container w3-padding-16" style="clear:both;">
+<input class="w3-input w3-border w3-padding" type="text" placeholder="Termine suchen (Titel, Ort, Datum, Beschreibung)…" id="filterString" onkeyup="filterTermine()">
+</div>
+<div id="Liste" data-cron-id="<?php echo htmlspecialchars((string)$GLOBALS['cronID'], ENT_QUOTES, 'UTF-8'); ?>">
 <?php
 $now = date("Y-m-d");
 $sql = sprintf('SELECT `Index` FROM `%sTermine` WHERE `Datum` >= "%s" ORDER BY `Datum`, `Uhrzeit`;',
@@ -43,8 +47,10 @@ while($row = mysqli_fetch_array($dbr)) {
 }
 ?>
 </div>
+</div>
 <div class="w3-col l3"></div>
 </div>
+<script src="js/filterTermine.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <?php
 include "common/footer.php";
 ?>

--- a/meldungen.php
+++ b/meldungen.php
@@ -14,12 +14,18 @@ $chunk = listChunkTermine('future', 'response', '', 50, (int)$_SESSION['userid']
 </div>
 <div class="w3-row">
   <div class="w3-panel w3-col l3 w3-left"></div>
-  <div class="w3-col l6 s12 m12" id="Liste" data-cron-id="<?php echo htmlspecialchars((string)$GLOBALS['cronID'], ENT_QUOTES, 'UTF-8'); ?>">
+  <div class="w3-col l6 s12 m12">
+    <div class="w3-container w3-padding-16" style="clear:both;">
+      <input class="w3-input w3-border w3-padding" type="text" placeholder="Termine suchen (Titel, Ort, Datum, Beschreibung)…" id="filterString" onkeyup="filterTermine()">
+    </div>
+    <div id="Liste" data-cron-id="<?php echo htmlspecialchars((string)$GLOBALS['cronID'], ENT_QUOTES, 'UTF-8'); ?>">
 <?php echo $chunk['html']; ?>
-<?php echo listChunkRenderSentinel('meldungen', $chunk['nextCursor'], $chunk['hasMore']); ?>
+<?php echo listChunkRenderSentinel('meldungen', $chunk['nextCursor'], $chunk['hasMore'], 'filterTermine'); ?>
+    </div>
   </div>
   <div class="w3-col l3"></div>
 </div>
+<script src="js/filterTermine.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <script src="js/infiniteScroll.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <?php
 include "common/footer.php";

--- a/termine-archiv.php
+++ b/termine-archiv.php
@@ -56,10 +56,14 @@ if(isset($_POST['proxy'])) {
 }
 $chunk = listChunkTermine('past', 'basic', '', 50, isset($user) ? (int)$user : (int)$_SESSION['userid']);
 ?>
+<div class="w3-container w3-padding-16" style="clear:both;">
+<input class="w3-input w3-border w3-padding" type="text" placeholder="Termine suchen (Titel, Ort, Datum, Beschreibung)…" id="filterString" onkeyup="filterTermine()">
+</div>
 <div id="Liste">
 <?php echo $chunk['html']; ?>
-<?php echo listChunkRenderSentinel('termineArchiv', $chunk['nextCursor'], $chunk['hasMore']); ?>
+<?php echo listChunkRenderSentinel('termineArchiv', $chunk['nextCursor'], $chunk['hasMore'], 'filterTermine'); ?>
 </div>
+<script src="js/filterTermine.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <script src="js/infiniteScroll.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <?php
 include "common/footer.php";

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -59,6 +59,9 @@ $sections[] = array(
     'title' => 'Zu Terminen melden',
     'body' => '
 <p>Unter <b>Termine</b> (Startseite) kannst du dich zu Terminen eintragen:</p>
+<ul>
+<li>Über die Suchzeile findest du Termine nach Titel, Ort, Datum oder Beschreibung (auch im Termin-Archiv).</li>
+</ul>
 '.$meldeButtons.'
 <p>Tippe auf den gewünschten Status. Die Farbe am Termin zeigt deinen aktuellen Stand. Eine erneute Auswahl ändert die Meldung.</p>
 <p><b>Tipp:</b> Auch „vielleicht“ oder „nein“ sind wertvoll – offene Einträge erschweren die Planung.</p>
@@ -73,6 +76,9 @@ $sections[] = array(
     'title' => 'Mein Register',
     'body' => '
 <p>Unter <b>Mein Register</b> siehst du, wie sich die Musikerinnen und Musiker deines Registers zu Terminen gemeldet haben:</p>
+<ul>
+<li>Über die Suchzeile findest du Termine nach Titel, Ort, Datum oder Beschreibung.</li>
+</ul>
 '.$registerLegend.'
 <p>So erkennst du schnell Lücken in der Besetzung deines Registers.</p>
 '
@@ -137,7 +143,7 @@ $sections[] = array(
     'title' => 'Admin: Meldungen',
     'visible' => isAdmin() && requirePermission('perm_showResponse'),
     'body' => '
-<p>Unter Admin → <b>Meldungen</b> siehst du Rückmeldungen übergreifend; im <b>Archiv</b> vergangene Termine.</p>
+<p>Unter Admin → <b>Meldungen</b> siehst du Rückmeldungen übergreifend; im <b>Archiv</b> vergangene Termine. Beide Listen haben eine Suchzeile (Titel, Ort, Datum, Beschreibung).</p>
 <p>In Termin- und Register-Ansichten kannst du Rückmeldungs-Modals öffnen. Die Orchesterübersicht skaliert auf die Fensterbreite und zeigt die Besetzung farbig nach Meldestatus (Hover zeigt Name und Status). Mit <b>Nur aktive Besetzung</b> siehst du einen Sitzplan nur mit Zusagen und Unsicheren – ohne Lücken durch Absagen oder fehlende Meldungen.</p>
 '.(requirePermission('perm_editResponse') ? '<p>Mit Recht <b>Rückmeldungen bearbeiten</b> kannst du im Orchesterplan per Klick auf einen Kreis den Status durchschalten: (keine Meldung →) Zusage → Absage → unsicher → Zusage …</p>' : '').'
 '
@@ -168,7 +174,7 @@ $sections[] = array(
     'body' => '
 <p>Unter Admin → <b>Termin erstellen</b> legst du neue Termine an. Das Formular ist in Abschnitte gegliedert (Was, Wann, Wo, Optionen): auf dem Smartphone untereinander, auf dem Tablet zweispaltig, am PC als vier Spalten nebeneinander.</p>
 <p>Das Flag <b>Besetzung</b> steuert, ob Registeraufschlüsselung und Orchesterdarstellung greifen – für Proben und Auftritte. Veranstaltungen ohne Besetzung (z.&nbsp;B. Grillfest, Radtour) brauchen das nicht (nur Manpower).</p>
-<p>Im <b>Archiv: Termine</b> findest du vergangene Termine. Aushilfen können am Termin ergänzt bzw. gelöscht werden, sofern freigegeben.</p>
+<p>Im <b>Archiv: Termine</b> findest du vergangene Termine (ebenfalls durchsuchbar). Aushilfen können am Termin ergänzt bzw. gelöscht werden, sofern freigegeben.</p>
 '
 );
 


### PR DESCRIPTION
## Summary
- Suchfeld auf Termine, Termin-Archiv, Rückmeldungen, Archiv und Mein Register
- Filter nach Titel, Ort, Datum und Beschreibung (`data-search`)
- Hilfe-Guide aktualisiert

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-95

## Test plan
- [ ] Startseite: Suche nach Titel/Ort/Datum filtert die Liste
- [ ] Suche nach Beschreibungstext (nicht sichtbar in der Zeile) findet Termin
- [ ] Termin-Archiv, Meldungen, Archiv, Mein Register: gleiche Suche
- [ ] Infinite Scroll: Filter bleibt nach Nachladen aktiv


Made with [Cursor](https://cursor.com)