### PR TITLE
MELD-96: Tabellen sortierbar machen

### DIFF
--- a/getList.php
+++ b/getList.php
@@ -14,6 +14,8 @@ if(!isset($_SESSION['userid']) || !(int)$_SESSION['userid']) {
 $type = isset($_GET['type']) ? (string)$_GET['type'] : '';
 $cursor = isset($_GET['cursor']) ? (string)$_GET['cursor'] : '';
 $limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 50;
+$sort = isset($_GET['sort']) ? (string)$_GET['sort'] : '';
+$dir = isset($_GET['dir']) ? (string)$_GET['dir'] : 'asc';
 
 $result = array('html' => '', 'nextCursor' => $cursor, 'hasMore' => false);
 
@@ -60,7 +62,7 @@ case 'musiker':
         header('X-Has-More: 0');
         exit;
     }
-    $result = listChunkUsers('musiker', $cursor !== '' ? (int)$cursor : 0, $limit);
+    $result = listChunkUsers('musiker', $cursor !== '' ? (int)$cursor : 0, $limit, $sort, $dir);
     break;
 
 case 'users':
@@ -69,7 +71,7 @@ case 'users':
         header('X-Has-More: 0');
         exit;
     }
-    $result = listChunkUsers('users', $cursor !== '' ? (int)$cursor : 0, $limit);
+    $result = listChunkUsers('users', $cursor !== '' ? (int)$cursor : 0, $limit, $sort, $dir);
     break;
 
 case 'mitglied':
@@ -78,7 +80,7 @@ case 'mitglied':
         header('X-Has-More: 0');
         exit;
     }
-    $result = listChunkUsers('mitglied', $cursor !== '' ? (int)$cursor : 0, $limit);
+    $result = listChunkUsers('mitglied', $cursor !== '' ? (int)$cursor : 0, $limit, $sort, $dir);
     break;
 
 default:

--- a/insurance.php
+++ b/insurance.php
@@ -37,14 +37,14 @@ if(!requirePermission("perm_showInventories") && !requirePermission("perm_showIn
   <input class="w3-input w3-border w3-padding w3-col l6 m12 s12" type="text" placeholder="Nach Instrument suchen..." id="filterString" onkeyup="filterMusiker()" style="flex:1 1 16rem;">
   <a class="w3-button w3-border <?php echo $GLOBALS['optionsDB']['colorBtnSubmit']; ?>" href="insuranceExport.php" target="_blank" rel="noopener">Übersicht für Versicherung</a>
 </div>
-  <div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small w3-hide-medium">
-  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="regnumber" data-type="number"><b>Inventarnummer</b></div>
-  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="instrument" data-type="string"><b>Instrument</b></div>
-  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="vendor" data-type="string"><b>Hersteller</b></div>
-  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="model" data-type="string"><b>Modell</b></div>
-  <div class="w3-col l2 m1 s1 w3-center w3-border-right list-sort" data-sort="serial" data-type="string"><b>Seriennummer</b></div>
-  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="zeitwert" data-type="number"><b>Zeitwert</b></div>
-  <div class="w3-col l2 m1 s1 w3-center w3-border-right list-sort" data-sort="owner" data-type="string"><b>Besitzer</b></div>
+<div id="listHeader" class="list-header w3-row w3-hide-small w3-hide-medium">
+  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="regnumber" data-type="number">Inventarnummer</div>
+  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="instrument" data-type="string">Instrument</div>
+  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="vendor" data-type="string">Hersteller</div>
+  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="model" data-type="string">Modell</div>
+  <div class="w3-col l2 m1 s1 w3-center w3-border-right list-sort" data-sort="serial" data-type="string">Seriennummer</div>
+  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="zeitwert" data-type="number">Zeitwert</div>
+  <div class="w3-col l2 m1 s1 w3-center w3-border-right list-sort" data-sort="owner" data-type="string">Besitzer</div>
 </div>
 <div id="Liste">
 <?php

--- a/insurance.php
+++ b/insurance.php
@@ -37,14 +37,14 @@ if(!requirePermission("perm_showInventories") && !requirePermission("perm_showIn
   <input class="w3-input w3-border w3-padding w3-col l6 m12 s12" type="text" placeholder="Nach Instrument suchen..." id="filterString" onkeyup="filterMusiker()" style="flex:1 1 16rem;">
   <a class="w3-button w3-border <?php echo $GLOBALS['optionsDB']['colorBtnSubmit']; ?>" href="insuranceExport.php" target="_blank" rel="noopener">Übersicht für Versicherung</a>
 </div>
-  <div class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small w3-hide-medium">
-  <div class="w3-col l1 m1 s1 w3-center w3-border-right"><b>Inventarnummer</b></div>
-  <div class="w3-col l2 m2 s2 w3-center w3-border-right"><b>Instrument</b></div>
-  <div class="w3-col l2 m2 s2 w3-center w3-border-right"><b>Hersteller</b></div>
-  <div class="w3-col l2 m2 s2 w3-center w3-border-right"><b>Modell</b></div>
-  <div class="w3-col l2 m1 s1 w3-center w3-border-right"><b>Seriennummer</b></div>
-  <div class="w3-col l1 m1 s1 w3-center w3-border-right"><b>Zeitwert</b></div>
-  <div class="w3-col l2 m1 s1 w3-center w3-border-right"><b>Besitzer</b></div>
+  <div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small w3-hide-medium">
+  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="regnumber" data-type="number"><b>Inventarnummer</b></div>
+  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="instrument" data-type="string"><b>Instrument</b></div>
+  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="vendor" data-type="string"><b>Hersteller</b></div>
+  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="model" data-type="string"><b>Modell</b></div>
+  <div class="w3-col l2 m1 s1 w3-center w3-border-right list-sort" data-sort="serial" data-type="string"><b>Seriennummer</b></div>
+  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="zeitwert" data-type="number"><b>Zeitwert</b></div>
+  <div class="w3-col l2 m1 s1 w3-center w3-border-right list-sort" data-sort="owner" data-type="string"><b>Besitzer</b></div>
 </div>
 <div id="Liste">
 <?php
@@ -68,6 +68,8 @@ if(!requirePermission("perm_showInventories") && !requirePermission("perm_showIn
 ?>
 </div>
 <script src="js/filterInstruments.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script src="js/sortList.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script>bindListSort({ headerId: 'listHeader', listId: 'Liste', mode: 'client' });</script>
 
 <?php
  include "common/footer.php";

--- a/inventories.php
+++ b/inventories.php
@@ -97,14 +97,14 @@ if(requirePermission("perm_showInventories")) {
     </div>
   </form>
 </div>
-<div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small w3-hide-medium">
-  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="regnumber" data-type="number"><b>Inventarnummer</b></div>
-  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="typ" data-type="string"><b>Typ</b></div>
-  <div class="w3-col l2 m4 s4 w3-center w3-border-right list-sort" data-sort="description" data-type="string"><b>Beschreibung</b></div>
-  <div class="w3-col l2 m4 s4 w3-center w3-border-right list-sort" data-sort="comment" data-type="string"><b>Kommentar</b></div>
-  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="purchasedate" data-type="date"><b>Kaufdatum</b></div>
-  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="purchaseprize" data-type="number"><b>Kaufpreis</b></div>
-  <div class="w3-col l3 m2 s2 w3-center w3-border-right list-sort" data-sort="loan" data-type="string"><b>ausgeliehen an</b></div>
+<div id="listHeader" class="list-header w3-row w3-hide-small w3-hide-medium">
+  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="regnumber" data-type="number">Inventarnummer</div>
+  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="typ" data-type="string">Typ</div>
+  <div class="w3-col l2 m4 s4 w3-center w3-border-right list-sort" data-sort="description" data-type="string">Beschreibung</div>
+  <div class="w3-col l2 m4 s4 w3-center w3-border-right list-sort" data-sort="comment" data-type="string">Kommentar</div>
+  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="purchasedate" data-type="date">Kaufdatum</div>
+  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="purchaseprize" data-type="number">Kaufpreis</div>
+  <div class="w3-col l3 m2 s2 w3-center w3-border-right list-sort" data-sort="loan" data-type="string">ausgeliehen an</div>
 </div>
 <div id="Liste">
 <?php

--- a/inventories.php
+++ b/inventories.php
@@ -97,15 +97,14 @@ if(requirePermission("perm_showInventories")) {
     </div>
   </form>
 </div>
-<div class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small w3-hide-medium">
-  <div class="w3-col l1 m1 s1 w3-center w3-border-right"><b>Inventarnummer</b></div>
-  <div class="w3-col l2 m2 s2 w3-center w3-border-right"><b>Typ</b></div>
-  <div class="w3-col l2 m4 s4 w3-center w3-border-right"><b>Beschreibung</b></div>
-  <div class="w3-col l2 m4 s4 w3-center w3-border-right"><b>Kommentar</b></div>
-  <div class="w3-col l1 m1 s1 w3-center w3-border-right"><b>Kaufdatum</b></div>
-  <div class="w3-col l1 m1 s1 w3-center w3-border-right"><b>Kaufpreis</b></div>
-  <div class="w3-col l3 m2 s2 w3-center w3-border-right"><b>ausgeliehen an</b></div>
-</div>
+<div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small w3-hide-medium">
+  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="regnumber" data-type="number"><b>Inventarnummer</b></div>
+  <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="typ" data-type="string"><b>Typ</b></div>
+  <div class="w3-col l2 m4 s4 w3-center w3-border-right list-sort" data-sort="description" data-type="string"><b>Beschreibung</b></div>
+  <div class="w3-col l2 m4 s4 w3-center w3-border-right list-sort" data-sort="comment" data-type="string"><b>Kommentar</b></div>
+  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="purchasedate" data-type="date"><b>Kaufdatum</b></div>
+  <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="purchaseprize" data-type="number"><b>Kaufpreis</b></div>
+  <div class="w3-col l3 m2 s2 w3-center w3-border-right list-sort" data-sort="loan" data-type="string"><b>ausgeliehen an</b></div>
 </div>
 <div id="Liste">
 <?php
@@ -125,6 +124,8 @@ if(requirePermission("perm_showInventories")) {
 ?>
 </div>
 <script src="js/filterInstruments.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script src="js/sortList.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script>bindListSort({ headerId: 'listHeader', listId: 'Liste', mode: 'client' });</script>
 <script>
 var nextRegByType = <?php echo json_encode(RegNumber::nextMapForInventoryTypes()); ?>;
 var prefixByType = <?php

--- a/js/infiniteScroll.js
+++ b/js/infiniteScroll.js
@@ -3,6 +3,8 @@
  * Expects #Liste and #listSentinel with data-list-type, data-cursor, data-has-more.
  * Optional data-filter-fn: name of global filter function to re-run after append.
  * Optional data-extra: query string fragment (e.g. user=123).
+ * Optional data-sort / data-dir: server-side sort for user lists (MELD-96).
+ * Exposes window.listInfiniteReload(sort, dir) to reset and reload from offset 0.
  */
 (function() {
     var loading = false;
@@ -81,6 +83,33 @@
         }
     }
 
+    function clearRows(list, sentinel) {
+        var nodes = [];
+        var i;
+        for(i = 0; i < list.children.length; i++) {
+            nodes.push(list.children[i]);
+        }
+        for(i = 0; i < nodes.length; i++) {
+            if(nodes[i] !== sentinel) {
+                list.removeChild(nodes[i]);
+            }
+        }
+    }
+
+    function buildUrl(sentinel, cursor) {
+        var type = sentinel.getAttribute('data-list-type') || '';
+        var url = 'getList.php?type=' + encodeURIComponent(type)
+            + '&cursor=' + encodeURIComponent(cursor)
+            + '&limit=50';
+        var extra = sentinel.getAttribute('data-extra');
+        if(extra) url += '&' + extra;
+        var sort = sentinel.getAttribute('data-sort');
+        var dir = sentinel.getAttribute('data-dir');
+        if(sort) url += '&sort=' + encodeURIComponent(sort);
+        if(dir) url += '&dir=' + encodeURIComponent(dir);
+        return url;
+    }
+
     function loadMore() {
         var sentinel = getSentinel();
         var list = getList();
@@ -94,12 +123,6 @@
         loading = true;
         if(observer) observer.unobserve(sentinel);
         setStatus(MSG_LOADING, true);
-
-        var url = 'getList.php?type=' + encodeURIComponent(type)
-            + '&cursor=' + encodeURIComponent(cursor)
-            + '&limit=50';
-        var extra = sentinel.getAttribute('data-extra');
-        if(extra) url += '&' + extra;
 
         var xhr;
         if(window.XMLHttpRequest) {
@@ -148,9 +171,25 @@
                 }, 100);
             }
         };
-        xhr.open('GET', url, true);
+        xhr.open('GET', buildUrl(sentinel, cursor), true);
         xhr.send();
     }
+
+    function reloadFromStart(sort, dir) {
+        var sentinel = getSentinel();
+        var list = getList();
+        if(!sentinel || !list) return;
+        if(observer) observer.unobserve(sentinel);
+        loading = false;
+        if(sort) sentinel.setAttribute('data-sort', sort);
+        if(dir) sentinel.setAttribute('data-dir', dir);
+        clearRows(list, sentinel);
+        sentinel.setAttribute('data-cursor', '0');
+        sentinel.setAttribute('data-has-more', '1');
+        loadMore();
+    }
+
+    window.listInfiniteReload = reloadFromStart;
 
     function init() {
         var sentinel = getSentinel();

--- a/js/sortList.js
+++ b/js/sortList.js
@@ -1,0 +1,130 @@
+/**
+ * Sortable list headers for w3-row lists (MELD-96).
+ *
+ * Client mode (full load):
+ *   bindListSort({ headerId: 'listHeader', listId: 'Liste' });
+ *   Rows: .list-row with data-sort-{key}
+ *   Header cells: .list-sort data-sort="key" data-type="string|number|date"
+ *
+ * Server mode (infinite scroll):
+ *   bindListSort({ headerId: 'listHeader', mode: 'server' });
+ *   Uses window.listInfiniteReload(sort, dir) from infiniteScroll.js
+ */
+(function (global) {
+    'use strict';
+
+    function compareValues(av, bv, type, dir) {
+        var mul = dir === 'asc' ? 1 : -1;
+        if (type === 'number') {
+            av = Number(av);
+            bv = Number(bv);
+            if (!isFinite(av)) av = 0;
+            if (!isFinite(bv)) bv = 0;
+            if (av === bv) return 0;
+            return (av < bv ? -1 : 1) * mul;
+        }
+        if (type === 'date') {
+            av = av ? String(av) : '';
+            bv = bv ? String(bv) : '';
+            if (av === bv) return 0;
+            return (av < bv ? -1 : 1) * mul;
+        }
+        av = av == null || av === '' ? '' : String(av);
+        bv = bv == null || bv === '' ? '' : String(bv);
+        return av.localeCompare(bv, 'de', { sensitivity: 'base', numeric: true }) * mul;
+    }
+
+    function paintHeaders(header, state) {
+        var cells = header.querySelectorAll('.list-sort');
+        Array.prototype.forEach.call(cells, function (cell) {
+            var label = cell.getAttribute('data-label');
+            if (!label) {
+                label = (cell.textContent || '').replace(/\s*[▲▼]\s*$/, '').trim();
+                cell.setAttribute('data-label', label);
+            }
+            if (cell.getAttribute('data-sort') === state.key) {
+                cell.textContent = label + (state.dir === 'asc' ? ' ▲' : ' ▼');
+            } else {
+                cell.textContent = label;
+            }
+        });
+    }
+
+    function sortClient(list, key, type, dir) {
+        var rows = [];
+        var children = list.children;
+        var i;
+        for (i = 0; i < children.length; i++) {
+            var el = children[i];
+            if (el.id === 'listSentinel') continue;
+            if (el.nodeType !== 1) continue;
+            if (!el.classList || !el.classList.contains('list-row')) continue;
+            rows.push(el);
+        }
+        rows.sort(function (a, b) {
+            var av = a.getAttribute('data-sort-' + key);
+            var bv = b.getAttribute('data-sort-' + key);
+            return compareValues(av, bv, type, dir);
+        });
+        var sentinel = document.getElementById('listSentinel');
+        for (i = 0; i < rows.length; i++) {
+            if (sentinel && sentinel.parentNode === list) {
+                list.insertBefore(rows[i], sentinel);
+            } else {
+                list.appendChild(rows[i]);
+            }
+        }
+    }
+
+    function bindListSort(opts) {
+        opts = opts || {};
+        var headerId = opts.headerId || 'listHeader';
+        var listId = opts.listId || 'Liste';
+        var mode = opts.mode || 'client';
+        var header = document.getElementById(headerId);
+        if (!header) return;
+
+        var state = {
+            key: opts.defaultKey || '',
+            dir: opts.defaultDir || 'asc',
+            type: opts.defaultType || 'string'
+        };
+
+        Array.prototype.forEach.call(header.querySelectorAll('.list-sort'), function (cell) {
+            if (!cell.getAttribute('data-label')) {
+                cell.setAttribute('data-label', (cell.textContent || '').replace(/\s*[▲▼]\s*$/, '').trim());
+            }
+            cell.addEventListener('click', function () {
+                var key = cell.getAttribute('data-sort');
+                if (!key) return;
+                var type = cell.getAttribute('data-type') || 'string';
+                if (state.key === key) {
+                    state.dir = state.dir === 'asc' ? 'desc' : 'asc';
+                } else {
+                    state.key = key;
+                    state.type = type;
+                    state.dir = type === 'number' ? 'desc' : 'asc';
+                }
+                paintHeaders(header, state);
+                if (mode === 'server') {
+                    if (typeof global.listInfiniteReload === 'function') {
+                        global.listInfiniteReload(state.key, state.dir);
+                    }
+                } else {
+                    var list = document.getElementById(listId);
+                    if (list) sortClient(list, state.key, state.type, state.dir);
+                }
+            });
+        });
+
+        if (state.key) {
+            paintHeaders(header, state);
+            if (mode === 'client') {
+                var list = document.getElementById(listId);
+                if (list) sortClient(list, state.key, state.type, state.dir);
+            }
+        }
+    }
+
+    global.bindListSort = bindListSort;
+})(window);

--- a/libs/instruments.php
+++ b/libs/instruments.php
@@ -786,6 +786,15 @@ class Instruments
         }
         $line->class=$GLOBALS['optionsDB']['HoverEffect'];
         $line->class="w3-mobile w3-border-bottom w3-border-black";
+        $zeitwert = $this->getCurrentValue($row['PurchasePrize']);
+        $owner = getOwner($row['Owner']);
+        $line->extraAttrs = 'data-sort-regnumber="'.htmlspecialchars((string)(int)$row['RegNumber'], ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-instrument="'.htmlspecialchars((string)$row['iName'], ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-vendor="'.htmlspecialchars((string)$row['Vendor'], ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-model="'.htmlspecialchars((string)$row['Model'], ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-serial="'.htmlspecialchars((string)$row['SerialNr'], ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-zeitwert="'.htmlspecialchars((string)$zeitwert, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-owner="'.htmlspecialchars((string)$owner, ENT_QUOTES, 'UTF-8').'"';
         $str=$str.$line->open();
         
         $indent++;
@@ -828,14 +837,14 @@ class Instruments
         $field->indent=$indent;
         $field->class="w3-center w3-border-right list-secondary";
         $field->col(1,3,12);
-        $field->body=mkPrize($this->getCurrentValue($row['PurchasePrize']));
+        $field->body=mkPrize($zeitwert);
         $str=$str.$field->print();
 
         $field = new div;
         $field->indent=$indent;
         $field->class="w3-center w3-border-right list-meta w3-hide-medium";
         $field->col(2,1,12);
-        $field->body=getOwner($row['Owner']);
+        $field->body=$owner;
         $str=$str.$field->print();
 
         $str=$str.$line->close();

--- a/libs/inventories.php
+++ b/libs/inventories.php
@@ -336,6 +336,15 @@ class Inventories
         }
         $line->class=$GLOBALS['optionsDB']['HoverEffect'];
         $line->class="w3-mobile w3-border-bottom w3-border-black";
+        $typLabel = !empty($row['instName']) ? $row['instName'] : $row['iTyp'];
+        $loanName = $this->getActiveLoanNameShort();
+        $line->extraAttrs = 'data-sort-regnumber="'.htmlspecialchars((string)(int)$row['RegNumber'], ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-typ="'.htmlspecialchars((string)$typLabel, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-description="'.htmlspecialchars((string)$row['Description'], ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-comment="'.htmlspecialchars((string)$row['Comment'], ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-purchasedate="'.htmlspecialchars((string)$row['PurchaseDate'], ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-purchaseprize="'.htmlspecialchars((string)$row['PurchasePrize'], ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-loan="'.htmlspecialchars((string)$loanName, ENT_QUOTES, 'UTF-8').'"';
         $str=$str.$line->open();
         
         $indent++;
@@ -346,7 +355,6 @@ class Inventories
         $field->body='<b>'.RegNumber::displayInventory($row['Inventory'], $row['RegNumber']).'</b>';
         $str=$str.$field->print();
 
-        $typLabel = !empty($row['instName']) ? $row['instName'] : $row['iTyp'];
         $field = new div;
         $field->indent=$indent;
         $field->class="w3-center w3-border-right list-secondary";
@@ -392,7 +400,7 @@ class Inventories
         $field->indent=$indent;
         $field->class="w3-center list-secondary";
         $field->col(2,2,12);
-        $field->body=$this->getActiveLoanNameShort();
+        $field->body=$loanName;
         $str=$str.$field->print();
 
         $field = new div;

--- a/libs/listChunk.php
+++ b/libs/listChunk.php
@@ -229,43 +229,95 @@ function listChunkTermine($mode, $render, $cursor, $limit, $userId = 0) {
 }
 
 /**
- * User lists by offset (stable ORDER BY Nachname, Vorname, Index).
+ * User lists by offset.
  * @param string $kind musiker|users|mitglied
+ * @param string $sort Whitelisted column key (nachname|vorname|instrument|email|lastlogin|index)
+ * @param string $dir asc|desc
  */
-function listChunkUsers($kind, $offset, $limit) {
+function listChunkUsers($kind, $offset, $limit, $sort = '', $dir = 'asc') {
     $limit = listChunkLimit($limit);
     $offset = max(0, (int)$offset);
+    $dirSql = (strtolower((string)$dir) === 'desc') ? 'DESC' : 'ASC';
+    $sort = strtolower(trim((string)$sort));
+    $p = $GLOBALS['dbprefix'];
+
+    $orderMusiker = function($sort, $dirSql) use ($p) {
+        switch($sort) {
+        case 'vorname':
+            return '`Vorname` '.$dirSql.', `Nachname` ASC, `'.$p.'User`.`Index` ASC';
+        case 'instrument':
+            return '`iName` '.$dirSql.', `Nachname` ASC, `Vorname` ASC, `'.$p.'User`.`Index` ASC';
+        case 'email':
+            return '`Email` '.$dirSql.', `Nachname` ASC, `Vorname` ASC, `'.$p.'User`.`Index` ASC';
+        case 'lastlogin':
+            return '`LastLogin` '.$dirSql.', `Nachname` ASC, `Vorname` ASC, `'.$p.'User`.`Index` ASC';
+        case 'nachname':
+            return '`Nachname` '.$dirSql.', `Vorname` ASC, `'.$p.'User`.`Index` ASC';
+        default:
+            return '`Nachname` ASC, `Vorname` ASC, `'.$p.'User`.`Index` ASC';
+        }
+    };
+
+    $orderPlain = function($sort, $dirSql) {
+        switch($sort) {
+        case 'vorname':
+            return '`Vorname` '.$dirSql.', `Nachname` ASC, `Index` ASC';
+        case 'email':
+            return '`Email` '.$dirSql.', `Nachname` ASC, `Vorname` ASC, `Index` ASC';
+        case 'lastlogin':
+            return '`LastLogin` '.$dirSql.', `Nachname` ASC, `Vorname` ASC, `Index` ASC';
+        case 'index':
+            return '`Index` '.$dirSql;
+        case 'instrument':
+            return '`iName` '.$dirSql.', `Nachname` ASC, `Vorname` ASC, `Index` ASC';
+        case 'nachname':
+            return '`Nachname` '.$dirSql.', `Vorname` ASC, `Index` ASC';
+        default:
+            return '`Nachname` ASC, `Vorname` ASC, `Index` ASC';
+        }
+    };
 
     switch($kind) {
     case 'musiker':
+        $orderBy = $orderMusiker($sort, $dirSql);
         $sql = sprintf(
-            'SELECT `%sUser`.`Index` FROM `%sUser` INNER JOIN (SELECT `Index` AS `iIndex`, `Register` FROM `%sInstrument`) `%sInstrument` ON `Instrument` = `iIndex` INNER JOIN (SELECT `Index` AS `rIndex`, `Name` AS `rName` FROM `%sRegister`) `%sRegister` ON `Register` = `rIndex` WHERE `rName` != "keins" AND `Deleted` != 1 ORDER BY `Nachname`, `Vorname`, `%sUser`.`Index` LIMIT %d OFFSET %d;',
-            $GLOBALS['dbprefix'],
-            $GLOBALS['dbprefix'],
-            $GLOBALS['dbprefix'],
-            $GLOBALS['dbprefix'],
-            $GLOBALS['dbprefix'],
-            $GLOBALS['dbprefix'],
-            $GLOBALS['dbprefix'],
+            'SELECT `%sUser`.`Index` FROM `%sUser` INNER JOIN (SELECT `Index` AS `iIndex`, `Register`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `Instrument` = `iIndex` INNER JOIN (SELECT `Index` AS `rIndex`, `Name` AS `rName` FROM `%sRegister`) `%sRegister` ON `Register` = `rIndex` WHERE `rName` != "keins" AND `Deleted` != 1 ORDER BY %s LIMIT %d OFFSET %d;',
+            $p, $p, $p, $p, $p, $p,
+            $orderBy,
             $limit + 1,
             $offset
         );
         $lineMethod = 'printTableLine';
         break;
     case 'mitglied':
-        $sql = sprintf(
-            'SELECT `Index` FROM `%sUser` WHERE `Mitglied` = 1 AND `Instrument` > 0 AND `Deleted` != 1 ORDER BY `Nachname`, `Vorname`, `Index` LIMIT %d OFFSET %d;',
-            $GLOBALS['dbprefix'],
-            $limit + 1,
-            $offset
-        );
+        $orderBy = $orderPlain($sort, $dirSql);
+        if($sort === 'instrument') {
+            $sql = sprintf(
+                'SELECT `%sUser`.`Index` FROM `%sUser` LEFT JOIN (SELECT `Index` AS `iIndex`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `Instrument` = `iIndex` WHERE `Mitglied` = 1 AND `Instrument` > 0 AND `Deleted` != 1 ORDER BY %s LIMIT %d OFFSET %d;',
+                $p, $p, $p, $p,
+                $orderBy,
+                $limit + 1,
+                $offset
+            );
+        }
+        else {
+            $sql = sprintf(
+                'SELECT `Index` FROM `%sUser` WHERE `Mitglied` = 1 AND `Instrument` > 0 AND `Deleted` != 1 ORDER BY %s LIMIT %d OFFSET %d;',
+                $p,
+                $orderBy,
+                $limit + 1,
+                $offset
+            );
+        }
         $lineMethod = 'printTableLine';
         break;
     case 'users':
     default:
+        $orderBy = $orderPlain($sort === 'instrument' ? 'nachname' : $sort, $dirSql);
         $sql = sprintf(
-            'SELECT `Index` FROM `%sUser` WHERE `Deleted` != 1 ORDER BY `Nachname`, `Vorname`, `Index` LIMIT %d OFFSET %d;',
-            $GLOBALS['dbprefix'],
+            'SELECT `Index` FROM `%sUser` WHERE `Deleted` != 1 ORDER BY %s LIMIT %d OFFSET %d;',
+            $p,
+            $orderBy,
             $limit + 1,
             $offset
         );

--- a/libs/listChunk.php
+++ b/libs/listChunk.php
@@ -231,7 +231,7 @@ function listChunkTermine($mode, $render, $cursor, $limit, $userId = 0) {
 /**
  * User lists by offset.
  * @param string $kind musiker|users|mitglied
- * @param string $sort Whitelisted column key (nachname|vorname|instrument|email|lastlogin|index)
+ * @param string $sort Whitelisted column key (nachname|vorname|instrument|email|lastlogin|lastvisit|index)
  * @param string $dir asc|desc
  */
 function listChunkUsers($kind, $offset, $limit, $sort = '', $dir = 'asc') {
@@ -241,7 +241,15 @@ function listChunkUsers($kind, $offset, $limit, $sort = '', $dir = 'asc') {
     $sort = strtolower(trim((string)$sort));
     $p = $GLOBALS['dbprefix'];
 
-    $orderMusiker = function($sort, $dirSql) use ($p) {
+    $lastVisitJoin = sprintf(
+        'LEFT JOIN (SELECT `m`.`User` AS `lvUser`, MAX(`t`.`Datum`) AS `lastVisit` FROM `%sMeldungen` `m` INNER JOIN `%sTermine` `t` ON `m`.`Termin` = `t`.`Index` WHERE `m`.`Wert` = 1 AND `t`.`Datum` <= CURRENT_DATE() GROUP BY `m`.`User`) `lv` ON `lv`.`lvUser` = `%sUser`.`Index`',
+        $p,
+        $p,
+        $p
+    );
+    $lastVisitOrder = '(lastVisit IS NULL) ASC, lastVisit '.$dirSql;
+
+    $orderMusiker = function($sort, $dirSql) use ($p, $lastVisitOrder) {
         switch($sort) {
         case 'vorname':
             return '`Vorname` '.$dirSql.', `Nachname` ASC, `'.$p.'User`.`Index` ASC';
@@ -251,6 +259,8 @@ function listChunkUsers($kind, $offset, $limit, $sort = '', $dir = 'asc') {
             return '`Email` '.$dirSql.', `Nachname` ASC, `Vorname` ASC, `'.$p.'User`.`Index` ASC';
         case 'lastlogin':
             return '`LastLogin` '.$dirSql.', `Nachname` ASC, `Vorname` ASC, `'.$p.'User`.`Index` ASC';
+        case 'lastvisit':
+            return $lastVisitOrder.', `Nachname` ASC, `Vorname` ASC, `'.$p.'User`.`Index` ASC';
         case 'nachname':
             return '`Nachname` '.$dirSql.', `Vorname` ASC, `'.$p.'User`.`Index` ASC';
         default:
@@ -258,7 +268,7 @@ function listChunkUsers($kind, $offset, $limit, $sort = '', $dir = 'asc') {
         }
     };
 
-    $orderPlain = function($sort, $dirSql) {
+    $orderPlain = function($sort, $dirSql) use ($lastVisitOrder) {
         switch($sort) {
         case 'vorname':
             return '`Vorname` '.$dirSql.', `Nachname` ASC, `Index` ASC';
@@ -266,6 +276,8 @@ function listChunkUsers($kind, $offset, $limit, $sort = '', $dir = 'asc') {
             return '`Email` '.$dirSql.', `Nachname` ASC, `Vorname` ASC, `Index` ASC';
         case 'lastlogin':
             return '`LastLogin` '.$dirSql.', `Nachname` ASC, `Vorname` ASC, `Index` ASC';
+        case 'lastvisit':
+            return $lastVisitOrder.', `Nachname` ASC, `Vorname` ASC, `Index` ASC';
         case 'index':
             return '`Index` '.$dirSql;
         case 'instrument':
@@ -277,12 +289,16 @@ function listChunkUsers($kind, $offset, $limit, $sort = '', $dir = 'asc') {
         }
     };
 
+    $needLastVisit = ($sort === 'lastvisit');
+    $needInstrument = ($sort === 'instrument');
+
     switch($kind) {
     case 'musiker':
         $orderBy = $orderMusiker($sort, $dirSql);
         $sql = sprintf(
-            'SELECT `%sUser`.`Index` FROM `%sUser` INNER JOIN (SELECT `Index` AS `iIndex`, `Register`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `Instrument` = `iIndex` INNER JOIN (SELECT `Index` AS `rIndex`, `Name` AS `rName` FROM `%sRegister`) `%sRegister` ON `Register` = `rIndex` WHERE `rName` != "keins" AND `Deleted` != 1 ORDER BY %s LIMIT %d OFFSET %d;',
+            'SELECT `%sUser`.`Index` FROM `%sUser` INNER JOIN (SELECT `Index` AS `iIndex`, `Register`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `Instrument` = `iIndex` INNER JOIN (SELECT `Index` AS `rIndex`, `Name` AS `rName` FROM `%sRegister`) `%sRegister` ON `Register` = `rIndex` %s WHERE `rName` != "keins" AND `Deleted` != 1 ORDER BY %s LIMIT %d OFFSET %d;',
             $p, $p, $p, $p, $p, $p,
+            $needLastVisit ? $lastVisitJoin : '',
             $orderBy,
             $limit + 1,
             $offset
@@ -291,10 +307,11 @@ function listChunkUsers($kind, $offset, $limit, $sort = '', $dir = 'asc') {
         break;
     case 'mitglied':
         $orderBy = $orderPlain($sort, $dirSql);
-        if($sort === 'instrument') {
+        if($needInstrument || $needLastVisit) {
             $sql = sprintf(
-                'SELECT `%sUser`.`Index` FROM `%sUser` LEFT JOIN (SELECT `Index` AS `iIndex`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `Instrument` = `iIndex` WHERE `Mitglied` = 1 AND `Instrument` > 0 AND `Deleted` != 1 ORDER BY %s LIMIT %d OFFSET %d;',
+                'SELECT `%sUser`.`Index` FROM `%sUser` LEFT JOIN (SELECT `Index` AS `iIndex`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `Instrument` = `iIndex` %s WHERE `Mitglied` = 1 AND `Instrument` > 0 AND `Deleted` != 1 ORDER BY %s LIMIT %d OFFSET %d;',
                 $p, $p, $p, $p,
+                $needLastVisit ? $lastVisitJoin : '',
                 $orderBy,
                 $limit + 1,
                 $offset
@@ -314,13 +331,25 @@ function listChunkUsers($kind, $offset, $limit, $sort = '', $dir = 'asc') {
     case 'users':
     default:
         $orderBy = $orderPlain($sort === 'instrument' ? 'nachname' : $sort, $dirSql);
-        $sql = sprintf(
-            'SELECT `Index` FROM `%sUser` WHERE `Deleted` != 1 ORDER BY %s LIMIT %d OFFSET %d;',
-            $p,
-            $orderBy,
-            $limit + 1,
-            $offset
-        );
+        if($needLastVisit) {
+            $sql = sprintf(
+                'SELECT `%sUser`.`Index` FROM `%sUser` %s WHERE `Deleted` != 1 ORDER BY %s LIMIT %d OFFSET %d;',
+                $p, $p,
+                $lastVisitJoin,
+                $orderBy,
+                $limit + 1,
+                $offset
+            );
+        }
+        else {
+            $sql = sprintf(
+                'SELECT `Index` FROM `%sUser` WHERE `Deleted` != 1 ORDER BY %s LIMIT %d OFFSET %d;',
+                $p,
+                $orderBy,
+                $limit + 1,
+                $offset
+            );
+        }
         $lineMethod = 'printUserTableLine';
         break;
     }

--- a/libs/user.php
+++ b/libs/user.php
@@ -564,17 +564,25 @@ class User
     }
 
     public function printTableLine() {
+        $lastVisit = $this->getLastVisit();
+        $attrs = ' data-sort-nachname="'.htmlspecialchars((string)$this->Nachname, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-vorname="'.htmlspecialchars((string)$this->Vorname, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-name="'.htmlspecialchars(trim($this->Vorname.' '.$this->Nachname), ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-instrument="'.htmlspecialchars((string)$this->iName, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-email="'.htmlspecialchars((string)$this->Email, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-lastlogin="'.htmlspecialchars((string)$this->LastLogin, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-lastvisit="'.htmlspecialchars((string)$lastVisit, ENT_QUOTES, 'UTF-8').'"';
         if($this->Mitglied) {
-            echo "<div class=\"w3-row list-row ".$GLOBALS['optionsDB']['HoverEffect']." w3-padding ".$GLOBALS['optionsDB']['colorUserMember']." w3-mobile w3-border-bottom w3-border-black\">\n";
+            echo "<div class=\"w3-row list-row ".$GLOBALS['optionsDB']['HoverEffect']." w3-padding ".$GLOBALS['optionsDB']['colorUserMember']." w3-mobile w3-border-bottom w3-border-black\"".$attrs.">\n";
         }
         else {
-            echo "<div class=\"w3-row list-row ".$GLOBALS['optionsDB']['HoverEffect']." w3-padding ".$GLOBALS['optionsDB']['colorUserNoMember']." w3-mobile w3-border-bottom w3-border-black\">\n";
+            echo "<div class=\"w3-row list-row ".$GLOBALS['optionsDB']['HoverEffect']." w3-padding ".$GLOBALS['optionsDB']['colorUserNoMember']." w3-mobile w3-border-bottom w3-border-black\"".$attrs.">\n";
         }
         echo "  <div onclick=\"openModal('user', ".$this->Index.")\" class=\"w3-col l3 m6 s12 w3-container list-primary\"><b>".$this->Vorname." ".$this->Nachname."</b></div>\n";
         echo "  <div class=\"w3-col l2 m6 s12 w3-container list-secondary\">".$this->iName."</div>\n";
         echo "  <div class=\"w3-col l3 m12 s12 w3-container list-secondary\"><a href=\"mailto:".$this->Email."\">".$this->Email."</a></div>\n";
         echo "  <div class=\"w3-col l2 m6 s12 w3-container list-meta\">".germanDate($this->LastLogin, 1)."</div>\n";
-        echo "  <div class=\"w3-col l2 m6 s12 w3-container list-meta\">".germanDate($this->getLastVisit(), 1)."</div>\n";
+        echo "  <div class=\"w3-col l2 m6 s12 w3-container list-meta\">".germanDate($lastVisit, 1)."</div>\n";
         echo "</div>\n";
     }
 
@@ -586,12 +594,20 @@ class User
         if(!$this->Instrument) {
             $main->class=$GLOBALS['optionsDB']['colorDisabled'];
         }
+        $lastVisit = $this->getLastVisit();
+        $main->extraAttrs = 'data-sort-index="'.htmlspecialchars((string)(int)$this->Index, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-nachname="'.htmlspecialchars((string)$this->Nachname, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-vorname="'.htmlspecialchars((string)$this->Vorname, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-name="'.htmlspecialchars(trim($this->Vorname.' '.$this->Nachname), ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-email="'.htmlspecialchars((string)$this->Email, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-lastlogin="'.htmlspecialchars((string)$this->LastLogin, ENT_QUOTES, 'UTF-8').'"'
+            .' data-sort-lastvisit="'.htmlspecialchars((string)$lastVisit, ENT_QUOTES, 'UTF-8').'"';
         echo $main->open();
         echo "  <div class=\"w3-col l1 m2 s12 w3-container list-meta\">".$this->Index."</div>\n";
         echo "  <div class=\"w3-col l3 m5 s12 w3-container list-primary\"><b>".$this->Vorname." ".$this->Nachname."</b></div>\n";
         echo "  <div class=\"w3-col l3 m5 s12 w3-container list-secondary\"><a href=\"mailto:".$this->Email."\">".$this->Email."</a></div>\n";
         echo "  <div class=\"w3-col l2 m6 s12 w3-container list-meta\">".germanDate($this->LastLogin, 1)."</div>\n";
-        echo "  <div class=\"w3-col l2 m6 s12 w3-container list-meta\">".germanDate($this->getLastVisit(), 1)."</div>\n";
+        echo "  <div class=\"w3-col l2 m6 s12 w3-container list-meta\">".germanDate($lastVisit, 1)."</div>\n";
         echo $main->close();
     }
 };

--- a/mitglied.php
+++ b/mitglied.php
@@ -33,6 +33,13 @@ $nMusiker = $row['Count'];
 <div>
 <input class="w3-input w3-border w3-padding" type="text" placeholder="Nach Musiker suchen..." id="filterString" onkeyup="filterMusiker()">
 </div>
+<div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small">
+  <div class="w3-col l3 m6 s12 w3-container list-sort" data-sort="nachname" data-type="string"><b>Name</b></div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string"><b>Instrument</b></div>
+  <div class="w3-col l3 m12 s12 w3-container list-sort" data-sort="email" data-type="string"><b>E-Mail</b></div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date"><b>Letzter Login</b></div>
+  <div class="w3-col l2 m6 s12 w3-container"><b>Letzte Teilnahme</b></div>
+</div>
 <div id="Liste">
 <?php
 $chunk = listChunkUsers('mitglied', 0, 50);
@@ -41,7 +48,9 @@ echo listChunkRenderSentinel('mitglied', $chunk['nextCursor'], $chunk['hasMore']
 ?>
 </div>
 <script src="js/filterMusiker.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script src="js/sortList.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <script src="js/infiniteScroll.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script>bindListSort({ headerId: 'listHeader', mode: 'server', defaultKey: 'nachname', defaultDir: 'asc', defaultType: 'string' });</script>
 
 <?php
 include 'common/footer.php';

--- a/mitglied.php
+++ b/mitglied.php
@@ -33,12 +33,12 @@ $nMusiker = $row['Count'];
 <div>
 <input class="w3-input w3-border w3-padding" type="text" placeholder="Nach Musiker suchen..." id="filterString" onkeyup="filterMusiker()">
 </div>
-<div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small">
-  <div class="w3-col l3 m6 s12 w3-container list-sort" data-sort="nachname" data-type="string"><b>Name</b></div>
-  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string"><b>Instrument</b></div>
-  <div class="w3-col l3 m12 s12 w3-container list-sort" data-sort="email" data-type="string"><b>E-Mail</b></div>
-  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date"><b>Letzter Login</b></div>
-  <div class="w3-col l2 m6 s12 w3-container"><b>Letzte Teilnahme</b></div>
+<div id="listHeader" class="list-header w3-row w3-hide-small">
+  <div class="w3-col l3 m6 s12 w3-container list-sort" data-sort="nachname" data-type="string">Name</div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string">Instrument</div>
+  <div class="w3-col l3 m12 s12 w3-container list-sort" data-sort="email" data-type="string">E-Mail</div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date">Letzter Login</div>
+  <div class="w3-col l2 m6 s12 w3-container">Letzte Teilnahme</div>
 </div>
 <div id="Liste">
 <?php

--- a/mitglied.php
+++ b/mitglied.php
@@ -38,7 +38,7 @@ $nMusiker = $row['Count'];
   <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string">Instrument</div>
   <div class="w3-col l3 m12 s12 w3-container list-sort" data-sort="email" data-type="string">E-Mail</div>
   <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date">Letzter Login</div>
-  <div class="w3-col l2 m6 s12 w3-container">Letzte Teilnahme</div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastvisit" data-type="date">Letzte Teilnahme</div>
 </div>
 <div id="Liste">
 <?php

--- a/musiker.php
+++ b/musiker.php
@@ -48,12 +48,12 @@ $nMusiker = $row['Count'];
 <div>
 <input class="w3-input w3-border w3-padding" type="text" placeholder="Nach Musiker suchen..." id="filterString" onkeyup="filterMusiker()">
 </div>
-<div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small">
-  <div class="w3-col l3 m6 s12 w3-container list-sort" data-sort="nachname" data-type="string"><b>Name</b></div>
-  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string"><b>Instrument</b></div>
-  <div class="w3-col l3 m12 s12 w3-container list-sort" data-sort="email" data-type="string"><b>E-Mail</b></div>
-  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date"><b>Letzter Login</b></div>
-  <div class="w3-col l2 m6 s12 w3-container"><b>Letzte Teilnahme</b></div>
+<div id="listHeader" class="list-header w3-row w3-hide-small">
+  <div class="w3-col l3 m6 s12 w3-container list-sort" data-sort="nachname" data-type="string">Name</div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string">Instrument</div>
+  <div class="w3-col l3 m12 s12 w3-container list-sort" data-sort="email" data-type="string">E-Mail</div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date">Letzter Login</div>
+  <div class="w3-col l2 m6 s12 w3-container">Letzte Teilnahme</div>
 </div>
 <div id="Liste">
 <?php

--- a/musiker.php
+++ b/musiker.php
@@ -53,7 +53,7 @@ $nMusiker = $row['Count'];
   <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string">Instrument</div>
   <div class="w3-col l3 m12 s12 w3-container list-sort" data-sort="email" data-type="string">E-Mail</div>
   <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date">Letzter Login</div>
-  <div class="w3-col l2 m6 s12 w3-container">Letzte Teilnahme</div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastvisit" data-type="date">Letzte Teilnahme</div>
 </div>
 <div id="Liste">
 <?php

--- a/musiker.php
+++ b/musiker.php
@@ -48,6 +48,13 @@ $nMusiker = $row['Count'];
 <div>
 <input class="w3-input w3-border w3-padding" type="text" placeholder="Nach Musiker suchen..." id="filterString" onkeyup="filterMusiker()">
 </div>
+<div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small">
+  <div class="w3-col l3 m6 s12 w3-container list-sort" data-sort="nachname" data-type="string"><b>Name</b></div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string"><b>Instrument</b></div>
+  <div class="w3-col l3 m12 s12 w3-container list-sort" data-sort="email" data-type="string"><b>E-Mail</b></div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date"><b>Letzter Login</b></div>
+  <div class="w3-col l2 m6 s12 w3-container"><b>Letzte Teilnahme</b></div>
+</div>
 <div id="Liste">
 <?php
 $chunk = listChunkUsers('musiker', 0, 50);
@@ -56,7 +63,9 @@ echo listChunkRenderSentinel('musiker', $chunk['nextCursor'], $chunk['hasMore'],
 ?>
 </div>
 <script src="js/filterMusiker.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script src="js/sortList.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <script src="js/infiniteScroll.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script>bindListSort({ headerId: 'listHeader', mode: 'server', defaultKey: 'nachname', defaultDir: 'asc', defaultType: 'string' });</script>
 
 <?php
 include 'common/footer.php';

--- a/no-mitglied.php
+++ b/no-mitglied.php
@@ -33,6 +33,13 @@ $nMusiker = $row['Count'];
 <div>
 <input class="w3-input w3-border w3-padding" type="text" placeholder="Nach Musiker suchen..." id="filterString" onkeyup="filterMusiker()">
 </div>
+<div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small">
+  <div class="w3-col l3 m6 s12 w3-container list-sort" data-sort="nachname" data-type="string"><b>Name</b></div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string"><b>Instrument</b></div>
+  <div class="w3-col l3 m12 s12 w3-container list-sort" data-sort="email" data-type="string"><b>E-Mail</b></div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date"><b>Letzter Login</b></div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastvisit" data-type="date"><b>Letzte Teilnahme</b></div>
+</div>
 <div id="Liste">
 <?php
 $sql = sprintf('SELECT `Index` FROM `%sUser` WHERE `Mitglied` = 0  AND `Instrument` > 0 AND `Deleted` != 1 ORDER BY `Nachname`, `Vorname`;',
@@ -48,6 +55,8 @@ while($row = mysqli_fetch_array($dbr)) {
 ?>
 </div>
 <script src="js/filterMusiker.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script src="js/sortList.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script>bindListSort({ headerId: 'listHeader', listId: 'Liste', mode: 'client' });</script>
 
 <?php
 include 'common/footer.php';

--- a/no-mitglied.php
+++ b/no-mitglied.php
@@ -33,12 +33,12 @@ $nMusiker = $row['Count'];
 <div>
 <input class="w3-input w3-border w3-padding" type="text" placeholder="Nach Musiker suchen..." id="filterString" onkeyup="filterMusiker()">
 </div>
-<div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small">
-  <div class="w3-col l3 m6 s12 w3-container list-sort" data-sort="nachname" data-type="string"><b>Name</b></div>
-  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string"><b>Instrument</b></div>
-  <div class="w3-col l3 m12 s12 w3-container list-sort" data-sort="email" data-type="string"><b>E-Mail</b></div>
-  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date"><b>Letzter Login</b></div>
-  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastvisit" data-type="date"><b>Letzte Teilnahme</b></div>
+<div id="listHeader" class="list-header w3-row w3-hide-small">
+  <div class="w3-col l3 m6 s12 w3-container list-sort" data-sort="nachname" data-type="string">Name</div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string">Instrument</div>
+  <div class="w3-col l3 m12 s12 w3-container list-sort" data-sort="email" data-type="string">E-Mail</div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date">Letzter Login</div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastvisit" data-type="date">Letzte Teilnahme</div>
 </div>
 <div id="Liste">
 <?php

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1456,6 +1456,39 @@ body.insurance-print {
   text-decoration: underline;
 }
 
+/* Sortierbare Listenköpfe (MELD-96): Format + sticky beim Scrollen */
+#listHeader,
+.list-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  margin: 0;
+  background: #009688;
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+  border-bottom: none !important;
+}
+
+#listHeader > div,
+.list-header > div {
+  padding-top: 0.55rem;
+  padding-bottom: 0.55rem;
+  color: inherit;
+  border-color: rgba(255, 255, 255, 0.35) !important;
+}
+
+#listHeader .list-sort,
+.list-header .list-sort {
+  color: #fff;
+}
+
+#listHeader .list-sort:hover,
+.list-header .list-sort:hover {
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.12);
+}
+
 .eval-charts,
 .eval-tables {
   display: grid;

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1456,12 +1456,13 @@ body.insurance-print {
   text-decoration: underline;
 }
 
-/* Sortierbare Listenköpfe (MELD-96): Format + sticky beim Scrollen */
+/* Sortierbare Listenköpfe (MELD-96): Format + sticky beim Scrollen
+   z-index unter Nav/Admin-Dropdowns (admin-nav: 10/12), damit Menüs nicht verdeckt werden */
 #listHeader,
 .list-header {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 2;
   margin: 0;
   background: #009688;
   color: #fff;

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1446,6 +1446,16 @@ body.insurance-print {
   white-space: nowrap;
 }
 
+.list-sort {
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.list-sort:hover {
+  text-decoration: underline;
+}
+
 .eval-charts,
 .eval-tables {
   display: grid;

--- a/users.php
+++ b/users.php
@@ -33,12 +33,12 @@ $nMusiker = $row['Count'];
 <div>
 <input class="w3-input w3-border w3-padding" type="text" placeholder="Nach Musiker suchen..." id="filterString" onkeyup="filterLog()">
 </div>
-<div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small">
-  <div class="w3-col l1 m2 s12 w3-container list-sort" data-sort="index" data-type="number"><b>ID</b></div>
-  <div class="w3-col l3 m5 s12 w3-container list-sort" data-sort="nachname" data-type="string"><b>Name</b></div>
-  <div class="w3-col l3 m5 s12 w3-container list-sort" data-sort="email" data-type="string"><b>E-Mail</b></div>
-  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date"><b>Letzter Login</b></div>
-  <div class="w3-col l2 m6 s12 w3-container"><b>Letzte Teilnahme</b></div>
+<div id="listHeader" class="list-header w3-row w3-hide-small">
+  <div class="w3-col l1 m2 s12 w3-container list-sort" data-sort="index" data-type="number">ID</div>
+  <div class="w3-col l3 m5 s12 w3-container list-sort" data-sort="nachname" data-type="string">Name</div>
+  <div class="w3-col l3 m5 s12 w3-container list-sort" data-sort="email" data-type="string">E-Mail</div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date">Letzter Login</div>
+  <div class="w3-col l2 m6 s12 w3-container">Letzte Teilnahme</div>
 </div>
 <div id="Liste">
 <?php

--- a/users.php
+++ b/users.php
@@ -38,7 +38,7 @@ $nMusiker = $row['Count'];
   <div class="w3-col l3 m5 s12 w3-container list-sort" data-sort="nachname" data-type="string">Name</div>
   <div class="w3-col l3 m5 s12 w3-container list-sort" data-sort="email" data-type="string">E-Mail</div>
   <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date">Letzter Login</div>
-  <div class="w3-col l2 m6 s12 w3-container">Letzte Teilnahme</div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastvisit" data-type="date">Letzte Teilnahme</div>
 </div>
 <div id="Liste">
 <?php

--- a/users.php
+++ b/users.php
@@ -33,6 +33,13 @@ $nMusiker = $row['Count'];
 <div>
 <input class="w3-input w3-border w3-padding" type="text" placeholder="Nach Musiker suchen..." id="filterString" onkeyup="filterLog()">
 </div>
+<div id="listHeader" class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small">
+  <div class="w3-col l1 m2 s12 w3-container list-sort" data-sort="index" data-type="number"><b>ID</b></div>
+  <div class="w3-col l3 m5 s12 w3-container list-sort" data-sort="nachname" data-type="string"><b>Name</b></div>
+  <div class="w3-col l3 m5 s12 w3-container list-sort" data-sort="email" data-type="string"><b>E-Mail</b></div>
+  <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="lastlogin" data-type="date"><b>Letzter Login</b></div>
+  <div class="w3-col l2 m6 s12 w3-container"><b>Letzte Teilnahme</b></div>
+</div>
 <div id="Liste">
 <?php
 $chunk = listChunkUsers('users', 0, 50);
@@ -41,7 +48,9 @@ echo listChunkRenderSentinel('users', $chunk['nextCursor'], $chunk['hasMore'], '
 ?>
 </div>
 <script src="js/filterLog.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script src="js/sortList.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <script src="js/infiniteScroll.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script>bindListSort({ headerId: 'listHeader', mode: 'server', defaultKey: 'nachname', defaultDir: 'asc', defaultType: 'string' });</script>
 
 <?php
 include 'common/footer.php';

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -156,7 +156,7 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 '.(requirePermission('perm_showUsers') ? '
-<li><b>Registerübersicht / Musikerliste / Userliste</b> – Personen suchen, filtern und öffnen (Register-Überschrift in Registerfarbe)</li>
+<li><b>Registerübersicht / Musikerliste / Userliste</b> – Personen suchen, filtern und öffnen (Register-Überschrift in Registerfarbe); Spaltenköpfe sortieren die Liste</li>
 '.(!empty($optionsDB['showMembers']) ? '<li><b>Mitgliederliste</b> – nur Vereinsmitglieder</li>' : '').'
 '.(!empty($optionsDB['showNonMembers']) ? '<li><b>Nicht-Mitgliederliste</b></li>' : '').'
 ' : '').'
@@ -196,8 +196,8 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 '.(requirePermission('perm_showInventories') ? '
-<li><b>Inventar</b> – Bestände anzeigen, Details und Ausleihen</li>
-<li><b>Versicherung</b> – versicherte Stücke; Klick öffnet das Inventar-Modal; „Übersicht für Versicherung“ öffnet eine druck-/PDF-fähige Tabelle (Spalten per Checkbox wählen, dann kopieren oder als PDF speichern)</li>
+<li><b>Inventar</b> – Bestände anzeigen, Details und Ausleihen; Spaltenköpfe sortieren die Liste</li>
+<li><b>Versicherung</b> – versicherte Stücke; Klick öffnet das Inventar-Modal; Spalten sortierbar; „Übersicht für Versicherung“ öffnet eine druck-/PDF-fähige Tabelle (Spalten per Checkbox wählen, dann kopieren oder als PDF speichern)</li>
 ' : '').'
 '.(requirePermission('perm_editInventories') ? '
 <li><b>Inventar-Typen</b> – Typen und Nummernkreise pflegen</li>


### PR DESCRIPTION
## Summary
- Sortierbare Spaltenköpfe für Musiker-, Mitglieder-, User-, Nicht-Mitglieder-, Inventar- und Versicherungslisten
- Client-Sort für vollständige Listen; Server-`ORDER BY` + Reload für Infinite-Scroll-Listen
- Sticky Listenköpfe unter dem Admin-Menü (`z-index`); Hilfe-Guide aktualisiert

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-96

## Test plan
- [ ] Musikerliste: Spaltenköpfe klicken (Name, Instrument, letzte Anwesenheit, …), Sortierrichtung umschalten, Infinite Scroll weiter laden
- [ ] Inventar/Versicherung: Client-Sort prüfen
- [ ] Admin-Menü öffnen: Dropdown nicht von sticky Kopfzeile verdeckt
- [ ] Hilfe-Guide erwähnt Sortierung


Made with [Cursor](https://cursor.com)