### PR TITLE
MELD-98: Weiße Kreise in der Orchesteransicht

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -95,7 +95,8 @@ function orchestraSeatVisual(wert) {
     // Halbtransparentes Rot, Schrift bewusst weiß und deckend
     if(wert === 2) return {color: '#f42316', opacity: '0.5', label: 'Absage', textColor: '#FFFFFF'};
     if(wert === 3) return {color: '#2196F3', opacity: '0.6', label: 'unsicher', textColor: null};
-    return {color: '#ffffff', opacity: '0.5', label: 'nicht gemeldet', textColor: null};
+    // Deckend weiß, damit Register-Bänder nicht durchscheinen (MELD-98)
+    return {color: '#ffffff', opacity: '1', label: 'nicht gemeldet', textColor: null};
 }
 
 /** Match PHP hexContrastText(): black or white against background luminance. */

--- a/libs/orchestra.php
+++ b/libs/orchestra.php
@@ -473,7 +473,8 @@ function orchestraSeatVisual($wert) {
     case 3:
         return array('color' => '#2196F3', 'opacity' => 0.6, 'label' => 'unsicher', 'textColor' => null);
     default:
-        return array('color' => '#ffffff', 'opacity' => 0.5, 'label' => 'nicht gemeldet', 'textColor' => null);
+        // Deckend weiß, damit Register-Bänder nicht durchscheinen (MELD-98)
+        return array('color' => '#ffffff', 'opacity' => 1, 'label' => 'nicht gemeldet', 'textColor' => null);
     }
 }
 


### PR DESCRIPTION
## Summary
- Nicht-rückgemeldete Orchester-Sitze deckend weiß (`opacity: 1`), damit Register-Bänder nicht durchscheinen
- Sync in PHP (`orchestraSeatVisual`) und JS (`modal.js`)

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-98

## Test plan
- [ ] Termin-Modal mit Orchester + Register-Bändern: nicht-rückgemeldete Sitze weiß (nicht getönt)
- [ ] Zusage/Absage/unsicher unverändert
- [ ] Statuswechsel per Klick im Modal aktualisiert die Farbe korrekt


Made with [Cursor](https://cursor.com)