### PR TITLE
MELD-61: Visibility-Migration, Labels, Discord-Checkbox

### DIFF
--- a/config/ConfigDefaults.php
+++ b/config/ConfigDefaults.php
@@ -570,6 +570,12 @@ function getConfigDefaults() {
             'Description' => 'Instrument-RegNumbers dem INSTR-Kreis zugeordnet',
         ),
         array(
+            'Parameter' => 'visibilitySpecFromPublishedMigrated',
+            'Value' => '0',
+            'Type' => 'bool',
+            'Description' => 'Termine.published nach VisibilitySpec (Alle User) migriert',
+        ),
+        array(
             'Parameter' => 'SchemaVersion',
             'Value' => '0',
             'Type' => 'int',

--- a/config/DBconfig.json
+++ b/config/DBconfig.json
@@ -195,7 +195,8 @@
 	"open": {"Type": "int", "Default": 1},
 	"new": {"Type": "int", "Default": 1},
 	"defaultFreeText": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
-	"VisibilitySpec": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"}
+	"VisibilitySpec": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
+	"PostDiscord": {"Type": "tinyint", "Default": 0}
     },
     "User": {
 	"Index": {"Type": "int", "Extra": "AUTO_INCREMENT"},

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -3,5 +3,5 @@
  * Expected DB schema version number (MELD-51).
  * Bump when DBconfig.json, DatabaseManager migrations, or ConfigDefaults.php change.
  */
-return 10;
+return 11;
 ?>

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -3,5 +3,5 @@
  * Expected DB schema version number (MELD-51).
  * Bump when DBconfig.json, DatabaseManager migrations, or ConfigDefaults.php change.
  */
-return 11;
+return 12;
 ?>

--- a/js/mailRecipients.js
+++ b/js/mailRecipients.js
@@ -7,8 +7,8 @@
   var GROUP_LABELS = {
     musicians: 'Alle Musiker',
     members: 'Alle Vereinsmitglieder',
-    nonmembers: 'alle Nicht-Mitglieder',
-    users: 'alle User'
+    nonmembers: 'Alle Nicht-Mitglieder',
+    users: 'Alle User'
   };
   var GROUP_IDS = ['musicians', 'members', 'nonmembers', 'users'];
 

--- a/libs/DatabaseManager.php
+++ b/libs/DatabaseManager.php
@@ -631,86 +631,128 @@ class DatabaseManager
     }
 
     /**
-     * MELD-61: fold legacy Termine.published and MailJob.MemberOnly/Register into Spec JSON
-     * before those columns are dropped.
+     * MELD-61: fold legacy Termine.published into VisibilitySpec (Alle User / versteckt).
+     * Idempotent via config flag; recovers if published was already dropped with empty specs.
      */
     private function migrateAudienceLegacyColumns() {
         if(!class_exists('AudienceSpec')) {
             require_once dirname(__DIR__).'/libs/audienceSpec.php';
         }
 
+        $flag = 'visibilitySpecFromPublishedMigrated';
         $termine = new SQLtable('Termine');
         if($termine->exists() && $termine->columnExists('VisibilitySpec')) {
-            $hasPublished = $termine->columnExists('published');
-            $sql = sprintf(
-                'SELECT `Index`, `VisibilitySpec`%s FROM `%sTermine`;',
-                $hasPublished ? ', `published`' : '',
-                $GLOBALS['dbprefix']
-            );
-            $dbr = mysqli_query($GLOBALS['conn'], $sql);
-            $updated = 0;
-            if($dbr) {
+            $already = $this->getConfigFlag($flag);
+            if($already) {
+                $this->addReport('data', 'Termine.VisibilitySpec', 'ok', 'Sichtbarkeit bereits aus published migriert');
+            }
+            else {
+                $hasPublished = $termine->columnExists('published');
                 $defaultJson = json_encode(AudienceSpec::defaultVisibilitySpec());
-                while($row = mysqli_fetch_array($dbr, MYSQLI_ASSOC)) {
-                    $id = (int)$row['Index'];
-                    if(!$hasPublished) {
-                        continue;
-                    }
-                    $spec = AudienceSpec::normalize(
-                        isset($row['VisibilitySpec']) ? $row['VisibilitySpec'] : null,
-                        array('allowMailGroups' => true, 'defaultGroups' => null)
+                $sql = sprintf(
+                    'SELECT `Index`, `VisibilitySpec`%s FROM `%sTermine`;',
+                    $hasPublished ? ', `published`' : '',
+                    $GLOBALS['dbprefix']
+                );
+                $dbr = mysqli_query($GLOBALS['conn'], $sql);
+                $toAlleUser = 0;
+                $toHidden = 0;
+                $errors = 0;
+                if(!$dbr) {
+                    $this->addReport(
+                        'data',
+                        'Termine.VisibilitySpec',
+                        'error',
+                        'Migration konnte Termine nicht lesen',
+                        mysqli_errno($GLOBALS['conn']).': '.mysqli_error($GLOBALS['conn'])
                     );
-                    $published = (int)$row['published'];
-                    $want = null;
-                    if($published > 0) {
-                        if(AudienceSpec::isEmpty($spec)) {
-                            $want = $defaultJson;
-                        }
-                    }
-                    else {
-                        // unpublished → hidden (empty VisibilitySpec)
+                }
+                else {
+                    while($row = mysqli_fetch_array($dbr, MYSQLI_ASSOC)) {
+                        $id = (int)$row['Index'];
                         $rawVis = isset($row['VisibilitySpec']) ? $row['VisibilitySpec'] : null;
-                        if($rawVis !== null && $rawVis !== '') {
-                            $want = '';
+                        $spec = AudienceSpec::normalize($rawVis, array(
+                            'allowMailGroups' => true,
+                            'defaultGroups' => null,
+                        ));
+                        $isEmpty = AudienceSpec::isEmpty($spec);
+
+                        $wantAlleUser = false;
+                        $wantHidden = false;
+                        if($hasPublished) {
+                            $published = (int)$row['published'];
+                            if($published > 0) {
+                                if($isEmpty) {
+                                    $wantAlleUser = true;
+                                }
+                            }
+                            else {
+                                // unpublished → versteckt
+                                if($rawVis !== null && $rawVis !== '') {
+                                    $wantHidden = true;
+                                }
+                            }
                         }
-                    }
-                    if($want === null) {
-                        continue;
-                    }
-                    if($want === '') {
-                        $update = sprintf(
-                            'UPDATE `%sTermine` SET `VisibilitySpec` = NULL WHERE `Index` = %d;',
-                            $GLOBALS['dbprefix'],
-                            $id
-                        );
-                    }
-                    else {
-                        $update = sprintf(
-                            'UPDATE `%sTermine` SET `VisibilitySpec` = "%s" WHERE `Index` = %d;',
-                            $GLOBALS['dbprefix'],
-                            mysqli_real_escape_string($GLOBALS['conn'], $want),
-                            $id
-                        );
-                    }
-                    if(mysqli_query($GLOBALS['conn'], $update)) {
-                        $updated++;
-                    }
-                    else {
-                        $this->addReport(
-                            'data',
-                            'Termine.VisibilitySpec',
-                            'error',
-                            'Migration Termin #'.$id.' fehlgeschlagen',
-                            mysqli_errno($GLOBALS['conn']).': '.mysqli_error($GLOBALS['conn'])
-                        );
+                        else {
+                            // Recovery: published already gone — empty Spec was former „sichtbar“
+                            if($isEmpty) {
+                                $wantAlleUser = true;
+                            }
+                        }
+
+                        if(!$wantAlleUser && !$wantHidden) {
+                            continue;
+                        }
+                        if($wantHidden) {
+                            $update = sprintf(
+                                'UPDATE `%sTermine` SET `VisibilitySpec` = NULL WHERE `Index` = %d;',
+                                $GLOBALS['dbprefix'],
+                                $id
+                            );
+                        }
+                        else {
+                            $update = sprintf(
+                                'UPDATE `%sTermine` SET `VisibilitySpec` = \'%s\' WHERE `Index` = %d;',
+                                $GLOBALS['dbprefix'],
+                                mysqli_real_escape_string($GLOBALS['conn'], $defaultJson),
+                                $id
+                            );
+                        }
+                        if(mysqli_query($GLOBALS['conn'], $update)) {
+                            if($wantHidden) {
+                                $toHidden++;
+                            }
+                            else {
+                                $toAlleUser++;
+                            }
+                        }
+                        else {
+                            $errors++;
+                            $this->addReport(
+                                'data',
+                                'Termine.VisibilitySpec',
+                                'error',
+                                'Migration Termin #'.$id.' fehlgeschlagen',
+                                mysqli_errno($GLOBALS['conn']).': '.mysqli_error($GLOBALS['conn'])
+                            );
+                        }
                     }
                 }
-            }
-            if($updated > 0) {
-                $this->addReport('data', 'Termine.VisibilitySpec', 'fixed', $updated.' Termin(e) VisibilitySpec migriert');
-            }
-            elseif($hasPublished) {
-                $this->addReport('data', 'Termine.VisibilitySpec', 'ok', 'VisibilitySpec bereits migriert');
+
+                if($errors === 0) {
+                    $this->setConfigFlag($flag, true, 'published/VisibilitySpec-Migration (MELD-61) erledigt');
+                    $this->addReport(
+                        'data',
+                        'Termine.VisibilitySpec',
+                        ($toAlleUser + $toHidden) > 0 ? 'fixed' : 'ok',
+                        sprintf(
+                            'Sichtbarkeit migriert: %d → Alle User, %d → versteckt%s',
+                            $toAlleUser,
+                            $toHidden,
+                            $hasPublished ? '' : ' (Recovery ohne published-Spalte)'
+                        )
+                    );
+                }
             }
         }
 
@@ -753,7 +795,7 @@ class DatabaseManager
                             'mailGroups' => $spec['mailGroups'],
                         ));
                         $update = sprintf(
-                            'UPDATE `%sMailJob` SET `RecipientSpec` = "%s" WHERE `Index` = %d;',
+                            'UPDATE `%sMailJob` SET `RecipientSpec` = \'%s\' WHERE `Index` = %d;',
                             $GLOBALS['dbprefix'],
                             mysqli_real_escape_string($GLOBALS['conn'], $payload),
                             $id
@@ -780,6 +822,69 @@ class DatabaseManager
                 }
             }
         }
+    }
+
+    /**
+     * @param string $param
+     * @return bool
+     */
+    private function getConfigFlag($param) {
+        $configTable = new SQLtable('config');
+        if(!$configTable->exists()) {
+            return false;
+        }
+        $sql = sprintf(
+            "SELECT `Value` FROM `%sconfig` WHERE `Parameter` = '%s' LIMIT 1;",
+            $GLOBALS['dbprefix'],
+            mysqli_real_escape_string($GLOBALS['conn'], $param)
+        );
+        $dbr = mysqli_query($GLOBALS['conn'], $sql);
+        $row = $dbr ? mysqli_fetch_array($dbr) : null;
+        if(!$row || !isset($row['Value'])) {
+            return false;
+        }
+        return (string)$row['Value'] === '1' || (string)$row['Value'] === 'true';
+    }
+
+    /**
+     * @param string $param
+     * @param bool $value
+     * @param string $description
+     */
+    private function setConfigFlag($param, $value, $description = '') {
+        $configTable = new SQLtable('config');
+        if(!$configTable->exists()) {
+            return;
+        }
+        $val = $value ? '1' : '0';
+        $escParam = mysqli_real_escape_string($GLOBALS['conn'], $param);
+        $escDesc = mysqli_real_escape_string($GLOBALS['conn'], $description);
+        $sql = sprintf(
+            "SELECT `Parameter` FROM `%sconfig` WHERE `Parameter` = '%s' LIMIT 1;",
+            $GLOBALS['dbprefix'],
+            $escParam
+        );
+        $dbr = mysqli_query($GLOBALS['conn'], $sql);
+        $row = $dbr ? mysqli_fetch_array($dbr) : null;
+        if($row && isset($row['Parameter'])) {
+            $update = sprintf(
+                "UPDATE `%sconfig` SET `Value` = '%s'%s WHERE `Parameter` = '%s';",
+                $GLOBALS['dbprefix'],
+                $val,
+                $description !== '' ? ", `Description` = '".$escDesc."'" : '',
+                $escParam
+            );
+            mysqli_query($GLOBALS['conn'], $update);
+            return;
+        }
+        $insert = sprintf(
+            "INSERT INTO `%sconfig` (`Parameter`, `Value`, `Type`, `Description`) VALUES ('%s', '%s', 'bool', '%s');",
+            $GLOBALS['dbprefix'],
+            $escParam,
+            $val,
+            $escDesc !== '' ? $escDesc : $escParam
+        );
+        mysqli_query($GLOBALS['conn'], $insert);
     }
 
     /**

--- a/libs/audienceSpec.php
+++ b/libs/audienceSpec.php
@@ -41,6 +41,21 @@ class AudienceSpec
     }
 
     /**
+     * True when spec is exactly the „Alle User“ role chip (no registers/users/groups extras).
+     *
+     * @param mixed $spec
+     * @return bool
+     */
+    public static function isAlleUserSpec($spec) {
+        $norm = self::normalize($spec, array('allowMailGroups' => true, 'defaultGroups' => null));
+        return count($norm['groups']) === 1
+            && $norm['groups'][0] === 'users'
+            && empty($norm['registers'])
+            && empty($norm['users'])
+            && empty($norm['mailGroups']);
+    }
+
+    /**
      * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[]}
      */
     public static function emptySpec() {

--- a/libs/audienceSpec.php
+++ b/libs/audienceSpec.php
@@ -17,6 +17,30 @@ class AudienceSpec
     }
 
     /**
+     * Canonical UI labels for role chips (consistent capitalization).
+     *
+     * @return array<string,string>
+     */
+    public static function groupLabels() {
+        return array(
+            'musicians' => 'Alle Musiker',
+            'members' => 'Alle Vereinsmitglieder',
+            'nonmembers' => 'Alle Nicht-Mitglieder',
+            'users' => 'Alle User',
+        );
+    }
+
+    /**
+     * @param string $groupId
+     * @return string
+     */
+    public static function groupLabel($groupId) {
+        $labels = self::groupLabels();
+        $groupId = (string)$groupId;
+        return isset($labels[$groupId]) ? $labels[$groupId] : $groupId;
+    }
+
+    /**
      * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[]}
      */
     public static function emptySpec() {
@@ -300,19 +324,13 @@ class AudienceSpec
             return $items;
         }
 
-        $groupLabels = array(
-            'musicians' => 'Alle Musiker',
-            'members' => 'Alle Vereinsmitglieder',
-            'nonmembers' => 'alle Nicht-Mitglieder',
-            'users' => 'alle User',
-        );
         foreach(self::allowedGroupIds() as $gid) {
             $spec = self::emptySpec();
             $spec['groups'] = array($gid);
             if(in_array($userId, self::resolveUserIds($spec, false), true)) {
                 $items[] = array(
                     'type' => 'group',
-                    'label' => isset($groupLabels[$gid]) ? $groupLabels[$gid] : $gid,
+                    'label' => self::groupLabel($gid),
                 );
             }
         }
@@ -324,7 +342,7 @@ class AudienceSpec
             if($regName !== '' && strtolower(trim($regName)) !== 'keins') {
                 $items[] = array(
                     'type' => 'register',
-                    'label' => $regName,
+                    'label' => 'Register: '.$regName,
                 );
             }
         }
@@ -334,7 +352,7 @@ class AudienceSpec
             if(in_array($userId, $memberIds, true)) {
                 $items[] = array(
                     'type' => 'mailGroup',
-                    'label' => (string)$g->Name,
+                    'label' => 'Gruppe: '.(string)$g->Name,
                 );
             }
         }
@@ -359,29 +377,24 @@ class AudienceSpec
             return '—';
         }
         $bits = array();
-        $groupLabels = array(
-            'musicians' => 'Alle Musiker',
-            'members' => 'Alle Vereinsmitglieder',
-            'nonmembers' => 'alle Nicht-Mitglieder',
-            'users' => 'Alle User',
-        );
         if($allowMailGroups) {
             foreach($norm['mailGroups'] as $gid) {
                 $g = new MailGroup();
                 $g->load_by_id((int)$gid);
                 if((int)$g->Index) {
-                    $bits[] = (string)$g->Name;
+                    $bits[] = 'Gruppe: '.(string)$g->Name;
                 }
             }
         }
         foreach($norm['groups'] as $gid) {
-            $bits[] = isset($groupLabels[$gid]) ? $groupLabels[$gid] : $gid;
+            $bits[] = self::groupLabel($gid);
         }
         foreach($norm['registers'] as $rid) {
             $r = new Register();
             $r->load_by_id((int)$rid);
             if((int)$r->Index) {
-                $bits[] = html_entity_decode((string)$r->Name, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $name = html_entity_decode((string)$r->Name, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $bits[] = 'Register: '.$name;
             }
         }
         foreach($norm['users'] as $uid) {
@@ -408,12 +421,6 @@ class AudienceSpec
             'defaultGroups' => null,
         ));
         $chips = array();
-        $groupLabels = array(
-            'musicians' => 'Alle Musiker',
-            'members' => 'Alle Vereinsmitglieder',
-            'nonmembers' => 'alle Nicht-Mitglieder',
-            'users' => 'Alle User',
-        );
         if($allowMailGroups) {
             foreach($norm['mailGroups'] as $gid) {
                 $g = new MailGroup();
@@ -426,7 +433,7 @@ class AudienceSpec
         foreach($norm['groups'] as $gid) {
             $chips[] = array(
                 'type' => 'group',
-                'label' => isset($groupLabels[$gid]) ? $groupLabels[$gid] : $gid,
+                'label' => self::groupLabel($gid),
             );
         }
         foreach($norm['registers'] as $rid) {
@@ -511,16 +518,14 @@ class AudienceSpec
         $includeMailGroups = !array_key_exists('includeMailGroups', $opts) || !empty($opts['includeMailGroups']);
 
         $catalog = array(
-            'groups' => array(
-                array('id' => 'musicians', 'label' => 'Alle Musiker', 'meta' => 'Rolle'),
-                array('id' => 'members', 'label' => 'Alle Vereinsmitglieder', 'meta' => 'Rolle'),
-                array('id' => 'nonmembers', 'label' => 'alle Nicht-Mitglieder', 'meta' => 'Rolle'),
-                array('id' => 'users', 'label' => 'alle User', 'meta' => 'Rolle'),
-            ),
+            'groups' => array(),
             'registers' => array(),
             'users' => array(),
             'mailGroups' => array(),
         );
+        foreach(self::groupLabels() as $id => $label) {
+            $catalog['groups'][] = array('id' => $id, 'label' => $label, 'meta' => 'Rolle');
+        }
 
         $sqlReg = sprintf(
             'SELECT `Index`, `Name` FROM `%sRegister` WHERE LOWER(TRIM(`Name`)) != "keins" ORDER BY `Sortierung`, `Name`;',

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -1,7 +1,7 @@
 <?php
 class Termin
 {
-    private $_data = array('Index' => null, 'Datum' => null, 'EndDatum' => null, 'Uhrzeit' => null, 'Uhrzeit2' => null, 'Abfahrt' => null, 'Capacity' => null, 'Vehicle' => 1, 'Name' => null, 'Auftritt' => null, 'Ort1' => null, 'Ort2' => null, 'Ort3' => null, 'Ort4' => null, 'Beschreibung' => null, 'Shifts' => null, 'open' => 1, 'Wert' => null, 'Children' => null, 'Guests' => null, 'new' => null, 'vName' => null, 'defaultFreeText' => null, 'VisibilitySpec' => null);
+    private $_data = array('Index' => null, 'Datum' => null, 'EndDatum' => null, 'Uhrzeit' => null, 'Uhrzeit2' => null, 'Abfahrt' => null, 'Capacity' => null, 'Vehicle' => 1, 'Name' => null, 'Auftritt' => null, 'Ort1' => null, 'Ort2' => null, 'Ort3' => null, 'Ort4' => null, 'Beschreibung' => null, 'Shifts' => null, 'open' => 1, 'Wert' => null, 'Children' => null, 'Guests' => null, 'new' => null, 'vName' => null, 'defaultFreeText' => null, 'VisibilitySpec' => null, 'PostDiscord' => 0);
     /** @var array<int,int>|null */
     private $_meldungenCountsByWert = null;
     /** @var int|null */
@@ -34,6 +34,7 @@ class Termin
 	    case 'new':
         case 'defaultFreeText':
         case 'VisibilitySpec':
+        case 'PostDiscord':
             return $this->_data[$key];
             break;
         default:
@@ -48,6 +49,7 @@ class Termin
 	    case 'Children':
 	    case 'Guests':
         case 'Capacity':
+        case 'PostDiscord':
             $this->_data[$key] = (int)$val;
             break;
 	    case 'Datum':
@@ -111,6 +113,9 @@ class Termin
         if($oldVis !== $newVis) {
             $str.=", sichtbar für: ".htmlspecialchars($old->getVisibilityLabel(), ENT_QUOTES, 'UTF-8')
                 ." &rArr; <b>".htmlspecialchars($this->getVisibilityLabel(), ENT_QUOTES, 'UTF-8')."</b>";
+        }
+        if(boolsDiffer($this->PostDiscord, $old->PostDiscord)) {
+            $str.=", Discord: ".bool2string($old->PostDiscord)." &rArr; <b>".bool2string($this->PostDiscord)."</b>";
         }
         if(boolsDiffer($this->open, $old->open)) $str.=", open: ".bool2string($old->open)." &rArr; <b>".bool2string($this->open)."</b>";
         if(boolsDiffer($this->new, $old->new)) $str.=", neu: ".bool2string($old->new)." &rArr; <b>".bool2string($this->new)."</b>";
@@ -181,6 +186,9 @@ class Termin
             $parts[] = "Schichten: <b>".bool2string($this->Shifts)."</b>";
         }
         $parts[] = "sichtbar für: <b>".htmlspecialchars($this->getVisibilityLabel(), ENT_QUOTES, 'UTF-8')."</b>";
+        if((int)$this->PostDiscord) {
+            $parts[] = "Discord: <b>".bool2string($this->PostDiscord)."</b>";
+        }
         $parts[] = "offen: <b>".bool2string($this->open)."</b>";
         if($this->defaultFreeText !== null && $this->defaultFreeText !== '') {
             $parts[] = sprintf("FreeText: <b>%s</b>", $this->defaultFreeText);
@@ -195,7 +203,7 @@ class Termin
             $logentry->DBupdate($this->getChanges());
             $this->update();
 
-            if($this->isListed()) {
+            if($this->shouldPublishToDiscord()) {
                 $this->publishToDiscord(true);
             }
         }
@@ -207,6 +215,8 @@ class Termin
             if($this->isListed()) {
 	        $this->makeAlwaysYes();
         	$this->makeAlwaysMaybe();
+            }
+            if($this->shouldPublishToDiscord()) {
                 $this->publishToDiscord(false);
             }
         }
@@ -216,10 +226,29 @@ class Termin
     }
 
     /**
-     * Post appointment to Discord when listed (non-empty VisibilitySpec). Never echoes; logs errors only.
+     * Discord when listed and (Alle User visibility or PostDiscord checkbox).
+     */
+    public function shouldPublishToDiscord() {
+        if(!$this->isListed()) {
+            return false;
+        }
+        if(!class_exists('Discord') || !Discord::isConfigured()) {
+            return false;
+        }
+        if(AudienceSpec::isAlleUserSpec($this->getVisibilitySpecArray())) {
+            return true;
+        }
+        return (int)$this->PostDiscord > 0;
+    }
+
+    /**
+     * Post appointment to Discord when shouldPublishToDiscord(). Never echoes; logs errors only.
      * @param bool $isUpdate true for update message, false for new appointment
      */
     private function publishToDiscord($isUpdate) {
+        if(!$this->shouldPublishToDiscord()) {
+            return;
+        }
         $webhookUrl = isset($GLOBALS['optionsDB']['DiscordWebHookURL'])
             ? trim((string)$GLOBALS['optionsDB']['DiscordWebHookURL'])
             : '';
@@ -259,7 +288,7 @@ class Termin
         else {
             $end = "NULL";
         }
-        $sql = sprintf('INSERT INTO `%sTermine` (`Datum`, `EndDatum`, `Uhrzeit`, `Uhrzeit2`, `Abfahrt`, `Capacity`, `Vehicle`, `Name`, `Beschreibung`, `Shifts`, `Auftritt`, `Ort1`, `Ort2`, `Ort3`, `Ort4`, `open`, `defaultFreeText`, `VisibilitySpec`) VALUES ("%s", %s, %s, %s, %s, "%d", "%d", "%s", "%s", "%d", "%d", "%s", "%s", "%s", "%s", "%d", "%s", %s);',
+        $sql = sprintf('INSERT INTO `%sTermine` (`Datum`, `EndDatum`, `Uhrzeit`, `Uhrzeit2`, `Abfahrt`, `Capacity`, `Vehicle`, `Name`, `Beschreibung`, `Shifts`, `Auftritt`, `Ort1`, `Ort2`, `Ort3`, `Ort4`, `open`, `defaultFreeText`, `VisibilitySpec`, `PostDiscord`) VALUES ("%s", %s, %s, %s, %s, "%d", "%d", "%s", "%s", "%d", "%d", "%s", "%s", "%s", "%s", "%d", "%s", %s, "%d");',
         $GLOBALS['dbprefix'],
         mysqli_real_escape_string($GLOBALS['conn'], $this->Datum),
         $end,
@@ -278,7 +307,8 @@ class Termin
         mysqli_real_escape_string($GLOBALS['conn'], $this->Ort4),
                        $this->open,
                        mysqli_real_escape_string($GLOBALS['conn'], (string)$this->defaultFreeText),
-                       $this->sqlVisibilitySpec()
+                       $this->sqlVisibilitySpec(),
+                       (int)$this->PostDiscord
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
         sqlerror();
@@ -422,7 +452,7 @@ class Termin
         else {
             $end = "NULL";
         }
-        $sql = sprintf('UPDATE `%sTermine` SET `Datum` = "%s", `EndDatum` = %s, `Uhrzeit` = %s, `Uhrzeit2` = %s, `Abfahrt` = %s, `Capacity`= "%d", `Vehicle`= "%d", `Name` = "%s", `Beschreibung` = "%s", `Shifts` = "%d", `Auftritt` = "%d", `Ort1` = "%s", `Ort2` = "%s", `Ort3` = "%s", `Ort4` = "%s", `open` = "%d", `new` = "%d", `defaultFreeText` = "%s", `VisibilitySpec` = %s WHERE `Index` = "%d";',
+        $sql = sprintf('UPDATE `%sTermine` SET `Datum` = "%s", `EndDatum` = %s, `Uhrzeit` = %s, `Uhrzeit2` = %s, `Abfahrt` = %s, `Capacity`= "%d", `Vehicle`= "%d", `Name` = "%s", `Beschreibung` = "%s", `Shifts` = "%d", `Auftritt` = "%d", `Ort1` = "%s", `Ort2` = "%s", `Ort3` = "%s", `Ort4` = "%s", `open` = "%d", `new` = "%d", `defaultFreeText` = "%s", `VisibilitySpec` = %s, `PostDiscord` = "%d" WHERE `Index` = "%d";',
         $GLOBALS['dbprefix'],
         mysqli_real_escape_string($GLOBALS['conn'], $this->Datum),
         $end,
@@ -443,6 +473,7 @@ class Termin
         $this->new,
                        mysqli_real_escape_string($GLOBALS['conn'], (string)$this->defaultFreeText),
                        $this->sqlVisibilitySpec(),
+                       (int)$this->PostDiscord,
         $this->Index
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);

--- a/new-termin.php
+++ b/new-termin.php
@@ -149,14 +149,28 @@ $inputBg = $GLOBALS['optionsDB']['colorInputBackground'];
         <div id="terminVisibilityChips" class="mail-recipient-chips" aria-live="polite"></div>
         <input type="text" id="terminVisibilityInput" class="w3-input w3-border <?php echo $inputBg; ?>" placeholder="Gruppe, Rolle, Register oder Person tippen…" autocomplete="off" />
         <div id="terminVisibilitySuggest" class="mail-recipient-suggest" hidden></div>
+<?php
+  $visSpec = $fill ? $n->getVisibilitySpecArray() : AudienceSpec::defaultVisibilitySpec();
+?>
         <input type="hidden" name="visibilitySpec" id="terminVisibilitySpec" value="<?php
-          $visSpec = $fill ? $n->getVisibilitySpecArray() : AudienceSpec::defaultVisibilitySpec();
           echo htmlspecialchars(json_encode($visSpec), ENT_QUOTES, 'UTF-8');
         ?>" />
         <p class="w3-small w3-margin-top mail-recipient-count-line">
           <span id="terminVisibilityCount" class="mail-recipient-count" aria-live="polite">…</span>
         </p>
       </div>
+<?php if(Discord::isConfigured()) {
+    $postDiscordChecked = $fill
+      ? ((int)$n->PostDiscord > 0 || AudienceSpec::isAlleUserSpec($visSpec))
+      : true;
+?>
+      <div class="w3-margin-top termin-form-check">
+        <input type="hidden" name="PostDiscord" value="0">
+        <input class="w3-check" type="checkbox" name="PostDiscord" id="terminPostDiscord" value="1" <?php if($postDiscordChecked) echo "checked"; ?>>
+        <label for="terminPostDiscord">Auch auf Discord posten</label>
+        <span class="w3-small w3-text-gray termin-form-hint"> — bei <b>Alle User</b> automatisch; sonst nur wenn angehakt</span>
+      </div>
+<?php } ?>
     </div>
   </section>
   </div>
@@ -246,6 +260,28 @@ $terminVisibilityCatalog = AudienceSpec::buildCatalog(array(
     defaultGroups: [],
     jobId: 0
   });
+  var discordCb = document.getElementById('terminPostDiscord');
+  if(!discordCb) return;
+  function isAlleUserSpec(spec) {
+    return spec
+      && Array.isArray(spec.groups)
+      && spec.groups.length === 1
+      && spec.groups[0] === 'users'
+      && (!spec.registers || !spec.registers.length)
+      && (!spec.users || !spec.users.length)
+      && (!spec.mailGroups || !spec.mailGroups.length);
+  }
+  function syncTerminDiscordDefault() {
+    try {
+      discordCb.checked = isAlleUserSpec(MailRecipientChips.spec);
+    } catch(e) {}
+  }
+  var origRender = MailRecipientChips.render.bind(MailRecipientChips);
+  MailRecipientChips.render = function() {
+    origRender();
+    syncTerminDiscordDefault();
+  };
+  syncTerminDiscordDefault();
 })();
 </script>
 

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -176,6 +176,7 @@ $sections[] = array(
 <p>Unter Admin → <b>Termin erstellen</b> legst du neue Termine an. Das Formular ist in Abschnitte gegliedert (Was, Wann, Wo, Optionen): auf dem Smartphone untereinander, auf dem Tablet zweispaltig, am PC als vier Spalten nebeneinander.</p>
 <p>Das Flag <b>Besetzung</b> steuert, ob Registeraufschlüsselung und Orchesterdarstellung greifen – für Proben und Auftritte. Veranstaltungen ohne Besetzung (z.&nbsp;B. Grillfest, Radtour) brauchen das nicht (nur Manpower).</p>
 <p>Mit dem Chip-Feld <b>sichtbar für</b> steuerst du den Kreis (Standard: <b>Alle User</b>). Ohne Chips = versteckt – nur User mit Recht <b>Versteckte Termine anzeigen</b>. Mit Chips nur der gewählte Kreis (Rollen, Gruppen, Register, Personen); Admins mit dem genannten Recht sehen weiterhin alles.</p>
+<p>Discord-Posts (bei konfiguriertem Webhook) erfolgen bei Sichtbarkeit <b>Alle User</b> automatisch, sonst nur mit der Checkbox <b>Auch auf Discord posten</b>.</p>
 <p>Im <b>Archiv: Termine</b> findest du vergangene Termine (ebenfalls durchsuchbar). Aushilfen können am Termin ergänzt bzw. gelöscht werden, sofern freigegeben.</p>
 '
 );


### PR DESCRIPTION
## Summary
- Recovery-Migration: leere VisibilitySpec → Alle User (wenn `published` schon weg war)
- Einheitliche Rollen-Labels („Alle …“)
- Discord nur bei Alle User oder Checkbox „Auch auf Discord posten“ (Schema 12)

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-61

## Test plan
- [ ] Updater/Repair: Report zeigt Migration nach Alle User
- [ ] Chip-Labels: Alle Musiker / Alle User / Alle Nicht-Mitglieder
- [ ] Termin: Discord-Checkbox unter „sichtbar für“ (nur mit Webhook)
- [ ] Eingeschränkte Sichtbarkeit: Discord nur mit Checkbox


Made with [Cursor](https://cursor.com)