### PR TITLE
MELD-101: Orchester Absage-Rot ohne Register-Durchscheinen

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -92,8 +92,8 @@ function orchestraNextWert(wert) {
 function orchestraSeatVisual(wert) {
     wert = parseInt(wert, 10) || 0;
     if(wert === 1) return {color: '#4CAF50', opacity: '1', label: 'Zusage', textColor: null};
-    // Halbtransparentes Rot, Schrift bewusst weiß und deckend
-    if(wert === 2) return {color: '#f42316', opacity: '0.5', label: 'Absage', textColor: '#FFFFFF'};
+    // Deckend, aber weich wie früher 50% #f42316 über Weiß (kein Register-Durchscheinen)
+    if(wert === 2) return {color: '#fa918a', opacity: '1', label: 'Absage', textColor: null};
     if(wert === 3) return {color: '#2196F3', opacity: '0.6', label: 'unsicher', textColor: null};
     // Deckend weiß, damit Register-Bänder nicht durchscheinen (MELD-98)
     return {color: '#ffffff', opacity: '1', label: 'nicht gemeldet', textColor: null};

--- a/libs/orchestra.php
+++ b/libs/orchestra.php
@@ -468,8 +468,8 @@ function orchestraSeatVisual($wert) {
     case 1:
         return array('color' => '#4CAF50', 'opacity' => 1, 'label' => 'Zusage', 'textColor' => null);
     case 2:
-        // Halbtransparentes Rot, Schrift bewusst weiß und deckend
-        return array('color' => '#f42316', 'opacity' => 0.5, 'label' => 'Absage', 'textColor' => '#FFFFFF');
+        // Deckend, aber weich wie früher 50% #f42316 über Weiß (kein Register-Durchscheinen)
+        return array('color' => '#fa918a', 'opacity' => 1, 'label' => 'Absage', 'textColor' => null);
     case 3:
         return array('color' => '#2196F3', 'opacity' => 0.6, 'label' => 'unsicher', 'textColor' => null);
     default:


### PR DESCRIPTION
## Summary
- Absage-Sitze nutzen deckendes weiches Rot (`#fa918a`) statt halbtransparentem `#f42316`
- Register-Schlauch verfärbt Absagen nicht mehr; Helligkeit entspricht dem früheren 50%-Look

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-101

## Test plan
- [ ] Orchester-Modal mit Register-Bändern: Absagen prüfen (Farbe weich, nicht grell)
- [ ] Absage-Kreis nicht durch Registerfarbe getönt
- [ ] Status-Wechsel per Klick aktualisiert Farbe korrekt


Made with [Cursor](https://cursor.com)