### PR TITLE
MELD-102: Mail-Entwurf behält Gruppen-Empfänger

### DIFF
--- a/mail.php
+++ b/mail.php
@@ -162,13 +162,12 @@ if(isset($_GET['deleted'])) {
 
 $recipientSpec = $job ? $job->getRecipientSpecArray() : MailJob::defaultRecipientSpecArray();
 // Neue / leere Entwürfe: Alle Musiker vorauswählen und im Job speichern
+// (mailGroups zählen mit — sonst würden reine Gruppen-Chips überschrieben)
 if(
     $job
     && $job->Status === 'draft'
     && !(int)$job->Termin
-    && !count($recipientSpec['groups'])
-    && !count($recipientSpec['registers'])
-    && !count($recipientSpec['users'])
+    && AudienceSpec::isEmpty($recipientSpec)
 ) {
     $recipientSpec = MailJob::defaultRecipientSpecArray();
     $job->setRecipientSpecArray($recipientSpec);


### PR DESCRIPTION
## Summary
- Leer-Prüfung für Default „Alle Musiker“ nutzt jetzt `AudienceSpec::isEmpty()` (inkl. `mailGroups`)
- Entwürfe nur mit benannten Gruppen werden beim Speichern/Neuladen nicht mehr überschrieben

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-102

## Test plan
- [ ] Entwurf: nur eine benannte Gruppe als Empfänger → Speichern → Gruppe bleibt
- [ ] Neuer leerer Entwurf ohne Chips → weiterhin „Alle Musiker“
- [ ] Entwurf mit Register/Personen/Rollen → Speichern behält Spec


Made with [Cursor](https://cursor.com)