### PR TITLE
MELD-103: Mailübersicht Status/Aktion-Spalten ausrichten

### DIFF
--- a/groups.php
+++ b/groups.php
@@ -55,8 +55,8 @@ foreach($groups as $g) {
 ?>
     <div class="mail-list-item">
       <div class="mail-list-primary"><?php echo htmlspecialchars((string)$g->Name, ENT_QUOTES, 'UTF-8'); ?></div>
-      <div><?php echo $count; ?> <span class="w3-small w3-text-gray">(<?php echo $countMail; ?> mit Mail)</span></div>
-      <div>
+      <div class="mail-list-status"><?php echo $count; ?> <span class="w3-small w3-text-gray">(<?php echo $countMail; ?> mit Mail)</span></div>
+      <div class="mail-list-actions">
         <a class="w3-button w3-small w3-blue" href="group-edit.php?id=<?php echo $id; ?>">Bearbeiten</a>
         <form method="post" style="display:inline;" onsubmit="return confirm('Gruppe wirklich löschen?');">
           <input type="hidden" name="Index" value="<?php echo $id; ?>" />

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -285,12 +285,16 @@
 
 /* Email-Listen und -Ansicht (MELD-59 Follow-up) */
 .mail-list {
-  display: block;
+  display: grid;
+  /* Shared tracks so header Status/Aktion align with every row */
+  grid-template-columns: minmax(0, 1fr) 10.5rem 22rem;
+  column-gap: 1rem;
 }
 
 .mail-list-item {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr) 10.5rem 22rem;
+  grid-column: 1 / -1;
   grid-template-areas:
     "primary status actions"
     "meta status actions";
@@ -320,6 +324,7 @@
   grid-area: status;
   white-space: nowrap;
   text-align: right;
+  justify-self: stretch;
 }
 
 .mail-list-actions {
@@ -329,6 +334,7 @@
   gap: 0.35rem;
   justify-content: flex-end;
   align-items: center;
+  justify-self: stretch;
 }
 
 .mail-list-actions form {
@@ -338,10 +344,28 @@
 
 .mail-list-header {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr) 10.5rem 22rem;
+  grid-column: 1 / -1;
   gap: 0.25rem 1rem;
   padding: 0.5rem;
   font-weight: bold;
+  align-items: center;
+}
+
+.mail-list-header > div:nth-child(2),
+.mail-list-header > div:nth-child(3) {
+  text-align: right;
+}
+
+@supports (grid-template-columns: subgrid) {
+  .mail-list {
+    grid-template-columns: minmax(0, 1fr) max-content max-content;
+  }
+
+  .mail-list-header,
+  .mail-list-item {
+    grid-template-columns: subgrid;
+  }
 }
 
 .mail-body-content {


### PR DESCRIPTION
## Summary
- Mail-Listen teilen gemeinsame Grid-Spalten (feste Breiten, Subgrid wo verfügbar)
- Kopfzeile Status/Aktion fluchtet mit den Zeilen
- Gruppenliste nutzt dieselben Status/Actions-Klassen

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-103

## Test plan
- [ ] mail.php Übersicht: Status- und Aktion-Spalten fluchten mit der Kopfzeile
- [ ] Zeilen mit unterschiedlicher Button-Anzahl prüfen
- [ ] groups.php Liste weiterhin ok
- [ ] Schmale Ansicht (Header ausgeblendet) ok


Made with [Cursor](https://cursor.com)