### PR TITLE
MELD-104: Versendete Mails zeigen Verteiler

### DIFF
--- a/mail.php
+++ b/mail.php
@@ -673,6 +673,32 @@ function delFile(hash) {
     </div>
   </div>
 
+<?php
+    $jobTerminId = (int)$job->Termin;
+    $recipientSpecView = $job->getRecipientSpecArray();
+    $verteilerHtml = '';
+    if($jobTerminId > 0) {
+        $tView = new Termin;
+        $tView->load_by_id($jobTerminId);
+        if($tView->Index) {
+            $verteilerHtml = 'Alle Teilnehmer von '
+                .htmlspecialchars($tView->Name.' ('.$tView->getGermanDate().')', ENT_QUOTES, 'UTF-8');
+        }
+        else {
+            $verteilerHtml = 'Alle Teilnehmer von Termin #'.$jobTerminId;
+        }
+    }
+    else {
+        $verteilerHtml = AudienceSpec::renderChipsHtml($recipientSpecView, array(
+            'allowMailGroups' => true,
+            'ariaLabel' => 'Verteiler',
+            'emptyHtml' => '<span class="w3-text-gray">—</span>',
+        ));
+    }
+?>
+  <h4>Verteiler</h4>
+  <div class="w3-margin-bottom w3-padding-small"><?php echo $verteilerHtml; ?></div>
+
   <h4>Empfänger</h4>
   <div class="mail-list">
     <div class="mail-list-header <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -188,7 +188,7 @@ $sections[] = array(
     'body' => '
 <p>Unter Admin → <b>Email versenden</b> erstellst du Nachrichten an Verteiler oder einzelne Empfänger.</p>
 <p>Unter Admin → <b>Gruppen</b> legst du wiederverwendbare Gruppen an (Rollen, Register, Personen). Diese Gruppen kannst du beim Mailversand und bei der Termin-Sichtbarkeit als Chip auswählen.</p>
-<p>Mails werden in einer Warteschlange verarbeitet; den Versandstatus siehst du in der Admin-Ansicht. Empfänger finden die Nachricht unter <b>Meine Nachrichten</b>.</p>
+<p>Mails werden in einer Warteschlange verarbeitet; den Versandstatus siehst du in der Admin-Ansicht. Bei versendeten Mails siehst du den gewählten <b>Verteiler</b> (Rollen, Gruppen, Register bzw. Termin-Teilnehmer) sowie die Liste der einzelnen Empfänger. Empfänger finden die Nachricht unter <b>Meine Nachrichten</b>.</p>
 <p>Falls Discord angebunden ist, kann der Versand optional auch dort veröffentlicht werden (nur bei konfiguriertem Webhook).</p>
 '
 );


### PR DESCRIPTION
## Summary
- Detailansicht versendeter Mails: Block „Verteiler“ mit Chips (Rollen/Gruppen/Register/Personen) bzw. Termin-Teilnehmer-Text
- Outbox-Personenliste unverändert darunter
- Guide: Hinweis zur Verteileranzeige

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-104

## Test plan
- [ ] Versendete Mail ohne Termin: Verteiler-Chips entsprechen dem Entwurf
- [ ] Termin-Mail: „Alle Teilnehmer von …“
- [ ] Empfänger-Liste darunter weiterhin korrekt
- [ ] Hilfe Admin → E-Mails erwähnt Verteiler


Made with [Cursor](https://cursor.com)