### PR TITLE
MELD-49: App-API Token-Login und Notify-Poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ Details zum Schema und zur Erstinstallation liefert die Install-Seite selbst.
 |--------|------------|
 | `master` | Produktion |
 | `dev` | Staging / Vorschau |
-| `MELD-<n>-…` | Feature-Branches |
+| `MELD-<n>-…` / `feature/MELD-<n>-…` | Feature-Branches |
+
+## Mobile App (Android)
+
+Die WebView-App **MVDApp** braucht schlanke JSON-Endpunkte für Token-Login und Notify-Poll (MELD-49).
+
+→ Spezifikation: [docs/app-api.md](docs/app-api.md)
 
 ## Backup
 

--- a/api/_bootstrap.php
+++ b/api/_bootstrap.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Shared bootstrap for JSON API endpoints (MELD-49).
+ */
+session_start();
+require_once dirname(__DIR__).'/common/include.php';
+mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($GLOBALS['conn']));
+
+header('Content-Type: application/json; charset=UTF-8');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+
+function apiJsonExit($payload, $httpCode = 200) {
+    http_response_code($httpCode);
+    echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+function apiRequireMethod($method) {
+    if(strtoupper($_SERVER['REQUEST_METHOD']) !== strtoupper($method)) {
+        apiJsonExit(array('error' => 'method_not_allowed'), 405);
+    }
+}
+?>

--- a/api/_bootstrap.php
+++ b/api/_bootstrap.php
@@ -2,7 +2,8 @@
 /**
  * Shared bootstrap for JSON API endpoints (MELD-49).
  */
-session_start();
+require_once dirname(__DIR__).'/libs/sessionBootstrap.php';
+meldeConfigureSession();
 require_once dirname(__DIR__).'/common/include.php';
 mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($GLOBALS['conn']));
 

--- a/api/auth/login.php
+++ b/api/auth/login.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * POST /api/auth/login.php
+ * Body (JSON or form): login, password, device (optional)
+ * Returns app token and establishes PHP session cookies for WebView.
+ */
+require_once dirname(__DIR__).'/_bootstrap.php';
+apiRequireMethod('POST');
+
+$json = readJsonRequestBody();
+$login = isset($json['login']) ? $json['login'] : (isset($_POST['login']) ? $_POST['login'] : '');
+$password = isset($json['password']) ? $json['password'] : (isset($_POST['password']) ? $_POST['password'] : '');
+$device = isset($json['device']) ? $json['device'] : (isset($_POST['device']) ? $_POST['device'] : 'Android');
+
+$login = trim((string)$login);
+if($login === '' || $password === null || $password === '') {
+    apiJsonExit(array('error' => 'invalid_credentials'), 401);
+}
+
+$sql = sprintf(
+    "SELECT * FROM `%sUser` WHERE `login` = '%s' AND `Deleted` != 1 LIMIT 1;",
+    $GLOBALS['dbprefix'],
+    mysqli_real_escape_string($GLOBALS['conn'], $login)
+);
+$dbr = mysqli_query($GLOBALS['conn'], $sql);
+sqlerror();
+$row = mysqli_fetch_assoc($dbr);
+if(!$row) {
+    apiJsonExit(array('error' => 'invalid_credentials'), 401);
+}
+$hash = (string)$row['Passhash'];
+if($hash === '' || !password_verify($password, $hash)) {
+    $logentry = new Log;
+    $logentry->error("App login not successful. Invalid password for username <b>".htmlspecialchars($login)."</b>.");
+    apiJsonExit(array('error' => 'invalid_credentials'), 401);
+}
+
+establishSessionFromUserRow($row, 'AppPassword');
+$token = createAppToken((int)$row['Index'], $device);
+if(!$token) {
+    apiJsonExit(array('error' => 'token_create_failed'), 500);
+}
+
+apiJsonExit(array(
+    'token' => $token,
+    'user' => array(
+        'id' => (int)$row['Index'],
+        'name' => $row['Vorname'].' '.$row['Nachname'],
+        'singleUsePW' => (bool)$row['singleUsePW'],
+    ),
+    'expires' => null,
+));
+?>

--- a/api/auth/revoke.php
+++ b/api/auth/revoke.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * POST /api/auth/revoke.php
+ * Revoke the current app token (device logout).
+ */
+require_once dirname(__DIR__).'/_bootstrap.php';
+apiRequireMethod('POST');
+
+$token = readAppTokenFromRequest();
+if($token === '') {
+    apiJsonExit(array('error' => 'missing_token'), 400);
+}
+
+$ok = revokeAppToken($token);
+if($ok && loggedIn()) {
+    session_destroy();
+}
+
+apiJsonExit(array('ok' => $ok));
+?>

--- a/api/auth/session.php
+++ b/api/auth/session.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * POST /api/auth/session.php
+ * Exchange app token → PHP session (Set-Cookie) for WebView auto-login.
+ * Auth: Authorization: Bearer <token> or JSON/form `token`.
+ */
+require_once dirname(__DIR__).'/_bootstrap.php';
+apiRequireMethod('POST');
+
+$token = readAppTokenFromRequest();
+if($token === '') {
+    apiJsonExit(array('error' => 'missing_token'), 400);
+}
+
+if(!validateAppToken($token)) {
+    apiJsonExit(array('error' => 'invalid_token'), 401);
+}
+
+apiJsonExit(array(
+    'ok' => true,
+    'user' => array(
+        'id' => (int)$_SESSION['userid'],
+        'name' => (string)$_SESSION['username'],
+        'singleUsePW' => !empty($_SESSION['singleUsePW']),
+    ),
+));
+?>

--- a/api/notify/poll.php
+++ b/api/notify/poll.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * GET /api/notify/poll.php?since=<ISO8601|MySQL datetime>
+ * Auth: Bearer token or existing PHP session.
+ * Returns MailOutbox events for local notifications (MELD-49 pull).
+ */
+require_once dirname(__DIR__).'/_bootstrap.php';
+
+if(strtoupper($_SERVER['REQUEST_METHOD']) !== 'GET') {
+    apiJsonExit(array('error' => 'method_not_allowed'), 405);
+}
+
+$userId = 0;
+if(loggedIn()) {
+    $userId = (int)$_SESSION['userid'];
+} else {
+    $token = readAppTokenFromRequest();
+    if($token === '' || !validateAppToken($token)) {
+        apiJsonExit(array('error' => 'unauthorized'), 401);
+    }
+    $userId = (int)$_SESSION['userid'];
+}
+
+$since = isset($_GET['since']) ? $_GET['since'] : '';
+$events = pollNotifyEvents($userId, $since);
+
+apiJsonExit(array(
+    'events' => $events,
+    'serverTime' => date('c'),
+    'unreadMail' => MailOutbox::countUnreadForUser($userId),
+));
+?>

--- a/common/include.php
+++ b/common/include.php
@@ -39,6 +39,7 @@ include "libs/audienceSpec.php";
 include "libs/mailJob.php";
 include "libs/mailOutbox.php";
 include "libs/mailGroup.php";
+include "libs/appToken.php";
 include "libs/ics.php";
 include "libs/usercalendar.php";
 include "libs/aushilfe.php";

--- a/config/DBconfig.json
+++ b/config/DBconfig.json
@@ -236,6 +236,16 @@
 	"Deleted": {"Type": "int", "Default": 0},
 	"DeletedOn": {"Type": "timestamp", "Null": "YES"}
     },
+    "AppTokens": {
+	"Index": {"Type": "int", "Extra": "AUTO_INCREMENT"},
+	"User": {"Type": "int"},
+	"TokenHash": {"Type": "text", "Collation": "utf8mb4_unicode_ci"},
+	"DeviceLabel": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
+	"Created": {"Type": "timestamp", "Default": "CURRENT_TIMESTAMP", "Extra": "DEFAULT_GENERATED"},
+	"LastUsed": {"Type": "timestamp", "Null": "YES", "Default": null},
+	"Expires": {"Type": "timestamp", "Null": "YES", "Default": null},
+	"Revoked": {"Type": "tinyint", "Default": 0}
+    },
     "vehicle": {
 	"Index": {"Type": "int", "Extra": "AUTO_INCREMENT"},
 	"Name": {"Type": "text", "Collation": "utf8mb4_unicode_ci"}

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -3,5 +3,5 @@
  * Expected DB schema version number (MELD-51).
  * Bump when DBconfig.json, DatabaseManager migrations, or ConfigDefaults.php change.
  */
-return 13;
+return 14;
 ?>

--- a/docs/app-api.md
+++ b/docs/app-api.md
@@ -6,9 +6,9 @@ Keine native Termine-/Melde-UI und keine große Domain-JSON-API im MVP.
 
 **Jira:** [MELD-49](https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-49)  
 **App-Repo:** `MVDApp` (Branch `feature/MELD-49-app-token-notify`)  
-**Backend-Branch (Entwurf):** `feature/MELD-49-app-api`
+**Backend-Branch:** `MELD-49-App-API`
 
-Nach Deploy: Schema-Repair/Updater ausführen (Schema-Version ≥ 13).
+Nach Deploy: Schema-Repair/Updater ausführen (Schema-Version ≥ **14**).
 
 ---
 
@@ -30,7 +30,7 @@ Die Website bleibt die UI. Die App lädt `https://meldeliste.…` im WebView, so
 ## Schema: `AppTokens`
 
 Eintrag in `config/DBconfig.json` (physisch `{dbprefix}AppTokens`).  
-`config/schema_version_number.php` auf **13** (oder höher) setzen, dann Repair.
+`config/schema_version_number.php` auf **14** (oder höher) setzen, dann Repair.
 
 | Spalte | Typ | Bedeutung |
 |--------|-----|-----------|
@@ -62,12 +62,13 @@ Referenz-Implementierung (Entwurf): `libs/appToken.php`.
 
 Stil wie bestehende JSON-Scripts (`mailStatus.php`):
 
-1. `session_start()`
+1. `meldeConfigureSession()` (über `api/_bootstrap.php`)
 2. `common/include.php`
 3. Header `Content-Type: application/json; charset=UTF-8`
 4. `Cache-Control: no-store, no-cache, must-revalidate`
 
 Pfade mit `.php` (kein URL-Rewrite nötig).
+Token nur per `Authorization: Bearer` oder JSON/Form-Body — **nicht** per Query-String.
 
 ### `POST /api/auth/login.php`
 

--- a/docs/app-api.md
+++ b/docs/app-api.md
@@ -1,0 +1,195 @@
+# Mobile App API (MELD-49)
+
+Anforderungen der Android-App **MVDApp** an das Meldeliste-Backend.
+Ziel: WebView-Shell mit persistentem Auto-Login und Benachrichtigungen per Pull.
+Keine native Termine-/Melde-UI und keine große Domain-JSON-API im MVP.
+
+**Jira:** [MELD-49](https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-49)  
+**App-Repo:** `MVDApp` (Branch `feature/MELD-49-app-token-notify`)  
+**Backend-Branch (Entwurf):** `feature/MELD-49-app-api`
+
+Nach Deploy: Schema-Repair/Updater ausführen (Schema-Version ≥ 13).
+
+---
+
+## Architektur (MVP)
+
+```
+App (Login)  →  POST /api/auth/login.php     →  App-Token speichern + Session-Cookie
+App (Start)  →  POST /api/auth/session.php   →  Token → PHP-Session → WebView
+App (Poll)   →  GET  /api/notify/poll.php    →  lokale Notifications (WorkManager)
+App (Logout) →  POST /api/auth/revoke.php    →  Token widerrufen
+```
+
+Die Website bleibt die UI. Die App lädt `https://meldeliste.…` im WebView, sobald die Session steht.
+
+**Später optional:** FCM Push (nicht Teil dieses MVP).
+
+---
+
+## Schema: `AppTokens`
+
+Eintrag in `config/DBconfig.json` (physisch `{dbprefix}AppTokens`).  
+`config/schema_version_number.php` auf **13** (oder höher) setzen, dann Repair.
+
+| Spalte | Typ | Bedeutung |
+|--------|-----|-----------|
+| `Index` | int AUTO_INCREMENT | Primärschlüssel |
+| `User` | int | FK → `User.Index` |
+| `TokenHash` | text | SHA-256 des Raw-Tokens (nie Klartext speichern) |
+| `DeviceLabel` | text NULL | z. B. Gerätename |
+| `Created` | timestamp | Anlage |
+| `LastUsed` | timestamp NULL | letzter erfolgreicher Exchange/Poll |
+| `Expires` | timestamp NULL | optional; `NULL` = kein Ablauf |
+| `Revoked` | tinyint Default 0 | Widerruf |
+
+Token erzeugen: `bin2hex(random_bytes(32))`, nur Hash in der DB.
+
+---
+
+## Auth-Helfer
+
+Session-Aufbau wie bei Passwort-/Link-Login in eine gemeinsame Funktion legen:
+
+- Session-Keys: `userid`, `Vorname`, `Nachname`, `username`, `singleUsePW`, `permissions`, `admin`
+- `recordLogin()` aufrufen
+
+Referenz-Implementierung (Entwurf): `libs/appToken.php`.
+
+---
+
+## Endpunkte
+
+Stil wie bestehende JSON-Scripts (`mailStatus.php`):
+
+1. `session_start()`
+2. `common/include.php`
+3. Header `Content-Type: application/json; charset=UTF-8`
+4. `Cache-Control: no-store, no-cache, must-revalidate`
+
+Pfade mit `.php` (kein URL-Rewrite nötig).
+
+### `POST /api/auth/login.php`
+
+**Body** (JSON oder Form):
+
+| Feld | Pflicht | Beschreibung |
+|------|---------|--------------|
+| `login` | ja | Benutzername |
+| `password` | ja | Passwort |
+| `device` | nein | Gerätebezeichnung |
+
+**Erfolg (200):** PHP-Session setzen (`Set-Cookie`) + neues App-Token anlegen.
+
+```json
+{
+  "token": "<raw-token>",
+  "user": {
+    "id": 1,
+    "name": "Max Mustermann",
+    "singleUsePW": false
+  },
+  "expires": null
+}
+```
+
+**Fehler:** `401` `{ "error": "invalid_credentials" }`
+
+### `POST /api/auth/session.php`
+
+Token → PHP-Session (Auto-Login beim App-Start).
+
+**Auth:** `Authorization: Bearer <token>` **oder** JSON/Form-Feld `token`.
+
+**Erfolg (200):**
+
+```json
+{
+  "ok": true,
+  "user": {
+    "id": 1,
+    "name": "Max Mustermann",
+    "singleUsePW": false
+  }
+}
+```
+
+**Fehler:** `400` `{ "error": "missing_token" }`, `401` `{ "error": "invalid_token" }`
+
+### `POST /api/auth/revoke.php`
+
+Token widerrufen (`Revoked = 1`), optional Session zerstören.
+
+**Auth:** wie bei `session.php`.
+
+**Erfolg:** `{ "ok": true }` bzw. `{ "ok": false }`
+
+### `GET /api/notify/poll.php?since=<ISO8601|MySQL-datetime>`
+
+**Auth:** Bearer-Token **oder** bestehende PHP-Session.
+
+**Quelle (MVP):** `MailOutbox` für den User:
+
+- `DeletedByUser = 0`
+- `Status IN ('pending','sending','sent')`
+- bei gesetztem `since`: `Created > since`
+- Limit sinnvoll (z. B. 50)
+
+**Erfolg (200):**
+
+```json
+{
+  "events": [
+    {
+      "id": "mail-123",
+      "type": "mail",
+      "title": "Betreff",
+      "body": "Neue Nachricht in der Meldeliste",
+      "created": "2026-07-19T10:00:00+02:00",
+      "unread": true,
+      "url": "meine-mails.php"
+    }
+  ],
+  "serverTime": "2026-07-19T11:00:00+02:00",
+  "unreadMail": 2
+}
+```
+
+Die App speichert `serverTime` als nächsten `since`-Cursor und zeigt lokale Notifications.
+
+**Fehler:** `401` `{ "error": "unauthorized" }`
+
+---
+
+## Explizit nicht im MVP
+
+- Native Screens / parallele JSON-API für Termine und Melden
+- FCM / Device-Register
+- iOS-spezifische Backend-Extras
+
+---
+
+## Test-Checklist
+
+- [ ] Schema-Repair → Tabelle `{prefix}AppTokens` existiert
+- [ ] Login mit gültigen Credentials liefert Token + `Set-Cookie`
+- [ ] Login mit ungültigen Credentials → `401`
+- [ ] Session-Exchange mit Token → Browser/WebView lädt `index.php` eingeloggt
+- [ ] Poll ohne/`since` liefert MailOutbox-Events
+- [ ] Revoke → erneuter Exchange schlägt fehl (`401`)
+
+---
+
+## Dateien (Entwurf auf `feature/MELD-49-app-api`)
+
+| Pfad | Rolle |
+|------|--------|
+| `config/DBconfig.json` | Tabelle `AppTokens` |
+| `config/schema_version_number.php` | Version 13 |
+| `libs/appToken.php` | Token-/Session-Helfer, Poll-Query |
+| `libs/helpers.php` | Login nutzt gemeinsame Session-Funktion |
+| `api/_bootstrap.php` | JSON-Bootstrap |
+| `api/auth/login.php` | Login |
+| `api/auth/session.php` | Session-Exchange |
+| `api/auth/revoke.php` | Widerruf |
+| `api/notify/poll.php` | Notify-Poll |

--- a/libs/appToken.php
+++ b/libs/appToken.php
@@ -149,9 +149,7 @@ function readAppTokenFromRequest() {
     if(isset($_POST['token'])) {
         return (string)$_POST['token'];
     }
-    if(isset($_GET['token'])) {
-        return (string)$_GET['token'];
-    }
+    // Do not accept tokens via GET (logs, Referer leakage).
     return '';
 }
 

--- a/libs/appToken.php
+++ b/libs/appToken.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * App token helpers for WebView auto-login (MELD-49).
+ * Raw tokens are returned once; only SHA-256 hashes are stored.
+ */
+
+function hashAppToken($rawToken) {
+    return hash('sha256', (string)$rawToken);
+}
+
+/**
+ * Establish the same PHP session keys as password / link login.
+ */
+function establishSessionFromUserRow($row, $via = 'Password') {
+    $_SESSION['userid'] = (int)$row['Index'];
+    $_SESSION['Vorname'] = $row['Vorname'];
+    $_SESSION['Nachname'] = $row['Nachname'];
+    $_SESSION['username'] = $row['Vorname']." ".$row['Nachname'];
+    $_SESSION['singleUsePW'] = (bool)$row['singleUsePW'];
+    $logentry = new Log;
+    $logentry->info("Login via ".$via.".");
+    recordLogin();
+    $_SESSION['permissions'] = loadPermissions($row['Index']);
+    $_SESSION['admin'] = isAdmin() ? 1 : 0;
+    return true;
+}
+
+/**
+ * Create a new app token for a user. Returns the raw token (store client-side only).
+ */
+function createAppToken($userId, $deviceLabel = '') {
+    $userId = (int)$userId;
+    if($userId <= 0) {
+        return null;
+    }
+    $raw = bin2hex(random_bytes(32));
+    $hash = hashAppToken($raw);
+    $device = mysqli_real_escape_string($GLOBALS['conn'], substr((string)$deviceLabel, 0, 200));
+    $sql = sprintf(
+        "INSERT INTO `%sAppTokens` (`User`, `TokenHash`, `DeviceLabel`, `Revoked`) VALUES (%d, '%s', '%s', 0);",
+        $GLOBALS['dbprefix'],
+        $userId,
+        mysqli_real_escape_string($GLOBALS['conn'], $hash),
+        $device
+    );
+    mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    if(!mysqli_insert_id($GLOBALS['conn'])) {
+        return null;
+    }
+    return $raw;
+}
+
+/**
+ * Look up a valid (non-revoked, non-expired) app token. Returns user row or null.
+ */
+function findUserByAppToken($rawToken) {
+    $rawToken = trim((string)$rawToken);
+    if($rawToken === '' || strlen($rawToken) < 32) {
+        return null;
+    }
+    $hash = hashAppToken($rawToken);
+    $sql = sprintf(
+        "SELECT u.*, t.`Index` AS `TokenIndex`
+         FROM `%sAppTokens` t
+         INNER JOIN `%sUser` u ON u.`Index` = t.`User`
+         WHERE t.`TokenHash` = '%s'
+           AND t.`Revoked` = 0
+           AND (t.`Expires` IS NULL OR t.`Expires` > CURRENT_TIMESTAMP())
+           AND u.`Deleted` != 1
+         LIMIT 1;",
+        $GLOBALS['dbprefix'],
+        $GLOBALS['dbprefix'],
+        mysqli_real_escape_string($GLOBALS['conn'], $hash)
+    );
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    $row = mysqli_fetch_assoc($dbr);
+    if(!$row) {
+        return null;
+    }
+    $upd = sprintf(
+        "UPDATE `%sAppTokens` SET `LastUsed` = CURRENT_TIMESTAMP() WHERE `Index` = %d;",
+        $GLOBALS['dbprefix'],
+        (int)$row['TokenIndex']
+    );
+    mysqli_query($GLOBALS['conn'], $upd);
+    return $row;
+}
+
+/**
+ * Exchange app token for a PHP session. Returns true on success.
+ */
+function validateAppToken($rawToken) {
+    $_SESSION['userid'] = 0;
+    $row = findUserByAppToken($rawToken);
+    if(!$row) {
+        $logentry = new Log;
+        $logentry->error("Login not successful. Invalid or revoked app token.");
+        return false;
+    }
+    return establishSessionFromUserRow($row, 'AppToken');
+}
+
+/**
+ * Revoke a single app token (logout from this device).
+ */
+function revokeAppToken($rawToken) {
+    $rawToken = trim((string)$rawToken);
+    if($rawToken === '') {
+        return false;
+    }
+    $hash = hashAppToken($rawToken);
+    $sql = sprintf(
+        "UPDATE `%sAppTokens` SET `Revoked` = 1 WHERE `TokenHash` = '%s' AND `Revoked` = 0;",
+        $GLOBALS['dbprefix'],
+        mysqli_real_escape_string($GLOBALS['conn'], $hash)
+    );
+    mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    return mysqli_affected_rows($GLOBALS['conn']) > 0;
+}
+
+/**
+ * Read Bearer token from Authorization header or JSON/form `token` field.
+ */
+function readAppTokenFromRequest() {
+    $header = '';
+    if(isset($_SERVER['HTTP_AUTHORIZATION'])) {
+        $header = $_SERVER['HTTP_AUTHORIZATION'];
+    } elseif(isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+        $header = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+    } elseif(function_exists('apache_request_headers')) {
+        $headers = apache_request_headers();
+        foreach($headers as $k => $v) {
+            if(strtolower($k) === 'authorization') {
+                $header = $v;
+                break;
+            }
+        }
+    }
+    if(preg_match('/^\s*Bearer\s+(\S+)\s*$/i', $header, $m)) {
+        return $m[1];
+    }
+    $json = readJsonRequestBody();
+    if(isset($json['token']) && is_string($json['token'])) {
+        return $json['token'];
+    }
+    if(isset($_POST['token'])) {
+        return (string)$_POST['token'];
+    }
+    if(isset($_GET['token'])) {
+        return (string)$_GET['token'];
+    }
+    return '';
+}
+
+/**
+ * Parse JSON request body once (cached).
+ */
+function readJsonRequestBody() {
+    static $cached = null;
+    if($cached !== null) {
+        return $cached;
+    }
+    $cached = array();
+    $raw = file_get_contents('php://input');
+    if($raw === false || $raw === '') {
+        return $cached;
+    }
+    $decoded = json_decode($raw, true);
+    if(is_array($decoded)) {
+        $cached = $decoded;
+    }
+    return $cached;
+}
+
+/**
+ * Poll notification events for a user since a timestamp (ISO or MySQL datetime).
+ */
+function pollNotifyEvents($userId, $since) {
+    $userId = (int)$userId;
+    $events = array();
+    $sinceSql = null;
+    $since = trim((string)$since);
+    if($since !== '') {
+        $ts = strtotime($since);
+        if($ts !== false) {
+            $sinceSql = date('Y-m-d H:i:s', $ts);
+        }
+    }
+
+    $whereSince = '';
+    if($sinceSql !== null) {
+        $whereSince = sprintf(
+            " AND o.`Created` > '%s'",
+            mysqli_real_escape_string($GLOBALS['conn'], $sinceSql)
+        );
+    }
+
+    $sql = sprintf(
+        "SELECT o.`Index`, o.`Subject`, o.`Created`, o.`Status`, o.`ReadAt`
+         FROM `%sMailOutbox` o
+         WHERE o.`User` = %d
+           AND o.`DeletedByUser` = 0
+           AND o.`Status` IN ('pending','sending','sent')
+           %s
+         ORDER BY o.`Created` ASC
+         LIMIT 50;",
+        $GLOBALS['dbprefix'],
+        $userId,
+        $whereSince
+    );
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    while($row = mysqli_fetch_assoc($dbr)) {
+        $events[] = array(
+            'id' => 'mail-'.(int)$row['Index'],
+            'type' => 'mail',
+            'title' => (string)$row['Subject'],
+            'body' => 'Neue Nachricht in der Meldeliste',
+            'created' => date('c', strtotime($row['Created'])),
+            'unread' => empty($row['ReadAt']),
+            'url' => 'meine-mails.php',
+        );
+    }
+
+    return $events;
+}
+?>

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -856,18 +856,8 @@ function validateLink($hash) {
     );
     $dbr = mysqli_query($GLOBALS['conn'], $sql);
     sqlerror();
-    while($row = mysqli_fetch_array($dbr)) {
-        $_SESSION['userid'] = $row['Index'];
-        $_SESSION['Vorname'] = $row['Vorname'];
-        $_SESSION['Nachname'] = $row['Nachname'];
-        $_SESSION['username'] = $row['Vorname']." ".$row['Nachname'];
-        $_SESSION['singleUsePW'] = (bool)$row['singleUsePW'];
-        $logentry = new Log;
-        $logentry->info("Login via Link.");
-        recordLogin();
-        $_SESSION['permissions'] = loadPermissions($row['Index']);
-        $_SESSION['admin'] = isAdmin() ? 1 : 0;
-        return true;
+    while($row = mysqli_fetch_assoc($dbr)) {
+        return establishSessionFromUserRow($row, 'Link');
     }
     $logentry = new Log;
     $logentry->error("Login not successful. Invalid hash for login via link <b>".htmlspecialchars($hash)."</b>.");
@@ -890,17 +880,7 @@ function validateUser($login, $password) {
     while($row = mysqli_fetch_assoc($dbr)) {
         $hash = (string)$row['Passhash'];
         if($hash !== '' && password_verify($password, $hash)) {
-            $_SESSION['userid'] = $row['Index'];
-            $_SESSION['Vorname'] = $row['Vorname'];
-            $_SESSION['Nachname'] = $row['Nachname'];
-            $_SESSION['username'] = $row['Vorname']." ".$row['Nachname'];
-            $_SESSION['singleUsePW'] = (bool)$row['singleUsePW'];
-            $logentry = new Log;
-            $logentry->info("Login via Password.");
-            recordLogin();
-            $_SESSION['permissions'] = loadPermissions($row['Index']);
-            $_SESSION['admin'] = isAdmin() ? 1 : 0;
-            return true;
+            return establishSessionFromUserRow($row, 'Password');
         }
     }
     $logentry = new Log;

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -112,6 +112,7 @@ $sections[] = array(
 <p>Halte insbesondere E-Mail und Instrument aktuell – davon hängen Benachrichtigungen und die Orchesterdarstellung ab.</p>
 <p>Unter <b>Gruppenzugehörigkeit</b> siehst du, welchen Rollen (z.&nbsp;B. Alle Musiker), welchem Register und welchen benannten Gruppen du zugeordnet bist – relevant für Mail und Termin-Sichtbarkeit.</p>
 <p>Falls du ein Einmal-Passwort erhalten hast, wirst du nach dem Login zum Ändern des Passworts aufgefordert.</p>
+<p>Die Android-App speichert nach dem Login ein Gerätetoken und meldet dich beim nächsten Öffnen automatisch an. Abmelden in der App widerruft dieses Token.</p>
 '
 );
 


### PR DESCRIPTION
## Summary
- AppTokens-Schema (Version **14**) und JSON-API für WebView-Auto-Login (`/api/auth/*`) sowie Notify-Poll (`/api/notify/poll.php`)
- Session-Bootstrap wie MELD-105; Tokens nicht mehr per GET
- Doku in `docs/app-api.md`, kurzer Hinweis in der Hilfe
- Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-49

## Test plan
- [ ] Nach Deploy: Updater/Schema-Repair (Schema ≥ 14)
- [ ] `POST /api/auth/login.php` mit gültigem Login → Token + Session-Cookie
- [ ] `POST /api/auth/session.php` mit Bearer-Token → Session
- [ ] `GET /api/notify/poll.php` mit Token → JSON events
- [ ] `POST /api/auth/revoke.php` → Token ungültig
- [ ] Android Debug-Build gegen diese_dev-URL (`-PmeldeBaseUrl=…`)


Made with [Cursor](https://cursor.com)