### PR TITLE
MELD-124: Besitzer-Wording auf Eigentümer ändern

### DIFF
--- a/insurance.php
+++ b/insurance.php
@@ -45,7 +45,7 @@ if(!requirePermission("perm_showInventories") && !requirePermission("perm_showIn
   <div class="w3-col l2 m2 s2 w3-center w3-border-right list-sort" data-sort="model" data-type="string">Modell</div>
   <div class="w3-col l2 m1 s1 w3-center w3-border-right list-sort" data-sort="serial" data-type="string">Seriennummer</div>
   <div class="w3-col l1 m1 s1 w3-center w3-border-right list-sort" data-sort="zeitwert" data-type="number">Zeitwert</div>
-  <div class="w3-col l2 m1 s1 w3-center w3-border-right list-sort" data-sort="owner" data-type="string">Besitzer</div>
+  <div class="w3-col l2 m1 s1 w3-center w3-border-right list-sort" data-sort="owner" data-type="string">Eigentümer</div>
 </div>
 <div id="Liste">
 <?php

--- a/insuranceExport.php
+++ b/insuranceExport.php
@@ -20,7 +20,7 @@ $columns = array(
     'purchaseDate' => 'Kaufdatum',
     'purchasePrize' => 'Anschaffungswert',
     'zeitwert' => 'Zeitwert',
-    'owner' => 'Besitzer',
+    'owner' => 'Eigentümer',
 );
 $numCols = array('purchasePrize' => true, 'zeitwert' => true);
 

--- a/inventories.php
+++ b/inventories.php
@@ -79,7 +79,7 @@ if(requirePermission("perm_showInventories")) {
       <input name="PurchasePrize" step="0.01" value="0.00" min="0" type="number" class="w3-input w3-col l4 m6 s12 <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?>"/>
     </div>
     <div class="w3-row w3-padding">
-      <div class="w3-col l4 m6 s12"><b>Besitzer</b></div>
+      <div class="w3-col l4 m6 s12"><b>Eigentümer</b></div>
       <select class="w3-col l4 m6 s12 w3-input <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?>" name="Owner">
 	<?php echo UserOptionAll(0); ?>
       </select>

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -186,6 +186,7 @@ function getNextRegInventoryNumber($inventoryTypeId = 0) {
     return RegNumber::nextForType($inventoryTypeId);
 }
 
+/** Display name for Inventories.Owner (UI: Eigentümer). MELD-124: rename column/helper when DB is renamed. */
 function getOwner($index) {
     if($index == 0) {
         return $GLOBALS['optionsDB']['orgNameShort'];

--- a/libs/instruments.php
+++ b/libs/instruments.php
@@ -90,7 +90,7 @@ class Instruments
         if($this->SerialNr != $old->SerialNr) $str .= ', Seriennummer: '.$old->SerialNr.' &rArr; <b>'.$this->SerialNr.'</b>';
         if($this->PurchaseDate != $old->PurchaseDate) $str .= ', Kaufdatum: '.germanDate($old->PurchaseDate,0).' &rArr; <b>'.germanDate($this->PurchaseDate,0).'</b>';
         if($this->PurchasePrize != $old->PurchasePrize) $str .= ', Kaufpreis: '.mkPrize($old->PurchasePrize).' &rArr; <b>'.mkPrize($this->PurchasePrize).'</b>';
-        if($this->Owner != $old->Owner) $str .= ', Besitzer: '.getOwner((int)$old->Owner).' &rArr; <b>'.getOwner((int)$this->Owner).'</b>';
+        if($this->Owner != $old->Owner) $str .= ', Eigentümer: '.getOwner((int)$old->Owner).' &rArr; <b>'.getOwner((int)$this->Owner).'</b>';
         if(boolsDiffer($this->Insurance, $old->Insurance)) $str .= ', Versichert: '.bool2string($old->Insurance).' &rArr; <b>'.bool2string($this->Insurance).'</b>';
         if($this->Comment != $old->Comment) $str .= ', Kommentar: '.$old->Comment.' &rArr; <b>'.$this->Comment.'</b>';
         return $str;
@@ -118,7 +118,7 @@ class Instruments
         $prize = mkPrize($this->PurchasePrize);
         logAppendFilled($parts, 'Kaufpreis', $prize, (string)$prize);
         if((int)$this->Owner > 0) {
-            $parts[] = logPart('Besitzer', getOwner((int)$this->Owner));
+            $parts[] = logPart('Eigentümer', getOwner((int)$this->Owner));
         }
         logAppendTrue($parts, 'Versichert', $this->Insurance);
         logAppendFilled($parts, 'Kommentar', $this->Comment, (string)$this->Comment);
@@ -490,8 +490,8 @@ class Instruments
         // Zeitwert (immer Anzeige)
         $str .= $this->modalDetailRow($indent, 'Zeitwert', $this->modalDisplayText(mkPrize($this->getCurrentValue())));
 
-        // Besitzer
-        $str .= $this->modalDetailRow($indent, 'Besitzer', $canEdit
+        // Eigentümer
+        $str .= $this->modalDetailRow($indent, 'Eigentümer', $canEdit
             ? '<select class="w3-select w3-border w3-input" name="Owner">'.userOptionAll($this->Owner).'</select>'
             : $this->modalDisplayText(getOwner($this->Owner))
         );

--- a/libs/inventories.php
+++ b/libs/inventories.php
@@ -122,7 +122,7 @@ class Inventories
         if($this->SerialNr != $old->SerialNr) $str .= ', Seriennummer: '.$old->SerialNr.' &rArr; <b>'.$this->SerialNr.'</b>';
         if($this->PurchaseDate != $old->PurchaseDate) $str .= ', Kaufdatum: '.germanDate($old->PurchaseDate,0).' &rArr; <b>'.germanDate($this->PurchaseDate,0).'</b>';
         if($this->PurchasePrize != $old->PurchasePrize) $str .= ', Kaufpreis: '.mkPrize($old->PurchasePrize).' &rArr; <b>'.mkPrize($this->PurchasePrize).'</b>';
-        if($this->Owner != $old->Owner) $str .= ', Besitzer: '.getOwner((int)$old->Owner).' &rArr; <b>'.getOwner((int)$this->Owner).'</b>';
+        if($this->Owner != $old->Owner) $str .= ', Eigentümer: '.getOwner((int)$old->Owner).' &rArr; <b>'.getOwner((int)$this->Owner).'</b>';
         if(boolsDiffer($this->Insurance, $old->Insurance)) $str .= ', Versichert: '.bool2string($old->Insurance).' &rArr; <b>'.bool2string($this->Insurance).'</b>';
         if($this->Comment != $old->Comment) $str .= ', Kommentar: '.$old->Comment.' &rArr; <b>'.$this->Comment.'</b>';
         return $str;
@@ -153,7 +153,7 @@ class Inventories
         $prize = mkPrize($this->PurchasePrize);
         logAppendFilled($parts, 'Kaufpreis', $prize, (string)$prize);
         if((int)$this->Owner > 0) {
-            $parts[] = logPart('Besitzer', getOwner((int)$this->Owner));
+            $parts[] = logPart('Eigentümer', getOwner((int)$this->Owner));
         }
         logAppendTrue($parts, 'Versichert', $this->Insurance);
         logAppendFilled($parts, 'Kommentar', $this->Comment, (string)$this->Comment);
@@ -518,7 +518,7 @@ class Inventories
             : $this->modalDisplayText(mkPrize($this->PurchasePrize))
         );
 
-        $str .= $this->modalDetailRow($indent, 'Besitzer', $canEdit
+        $str .= $this->modalDetailRow($indent, 'Eigentümer', $canEdit
             ? '<select class="w3-select w3-border w3-input" name="Owner">'.UserOptionAll((int)$this->Owner).'</select>'
             : $this->modalDisplayText(getOwner((int)$this->Owner))
         );


### PR DESCRIPTION
## Summary
- Sichtbares Wording „Besitzer“ → „Eigentümer“ bei Inventar/Instrumenten (Formulare, Modals, Logs, Versicherungsliste/-export)
- DB-Spalte `Owner` unverändert; Spalten-Rename für spätere Schema-Migration vorgemerkt
- Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-124

## Test plan
- [ ] Inventar anlegen/bearbeiten: Label „Eigentümer“
- [ ] Instrument-Modal: Label „Eigentümer“
- [ ] Versicherungsliste + Export-Spalte „Eigentümer“


Made with [Cursor](https://cursor.com)