### PR TITLE
MELD-129: Inventar-Leihen korrekt im Log erfassen

### DIFF
--- a/libs/inventories.php
+++ b/libs/inventories.php
@@ -222,15 +222,22 @@ class Inventories
 
     public function delete() {
         if(!$this->Index) return false;
-        $logentry = new Log;
-        $logentry->DBdelete($this->getVars());
 
-        $sql = sprintf('DELETE FROM `%sInventoriesLoans` WHERE `Inventory` = "%d";',
+        // Log each loan before cascade-remove (MELD-129)
+        $sql = sprintf('SELECT `Index` FROM `%sInventoriesLoans` WHERE `Inventory` = "%d";',
         $GLOBALS['dbprefix'],
         (int)$this->Index
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
         sqlerror();
+        while($dbr && ($row = mysqli_fetch_array($dbr))) {
+            $loan = new InventoriesLoan;
+            $loan->load_by_id($row['Index']);
+            if($loan->Index) $loan->delete();
+        }
+
+        $logentry = new Log;
+        $logentry->DBdelete($this->getVars());
 
         $sql = sprintf('DELETE FROM `%sInventories` WHERE `Index` = "%d" LIMIT 1;',
         $GLOBALS['dbprefix'],

--- a/libs/inventoriesLoan.php
+++ b/libs/inventoriesLoan.php
@@ -40,39 +40,66 @@ class InventoriesLoan
         return true;
     }
 
+    /** Type label + RegNumber for log messages. */
+    private function inventoryLogLabel($inventoryId = null) {
+        $inv = new Inventories;
+        $inv->load_by_id($inventoryId !== null ? $inventoryId : $this->Inventory);
+        $typeName = $inv->getInventoryType();
+        $family = $inv->getInstrumentName();
+        if($family !== '') $typeName = $family;
+        return sprintf('(%d) <b>%s</b> %s',
+            (int)$inv->Index,
+            $typeName,
+            RegNumber::displayInventory($inv->Inventory, $inv->RegNumber)
+        );
+    }
+
     public function getChanges() {
-        $old = new Loan;
+        $old = new InventoriesLoan;
         $old->load_by_id($this->Index);
 
         $u = new User;
         $u->load_by_id($this->User);
 
-        $Inventory = new Inventories;
-        $Inventory->load_by_id($this->Inventory);
-        
-        $str = sprintf("InventoriesLoan-ID: %d, Inventory: (%d) <b>%s</b>, User: (%d) <b>%s</b>",
-        $this->Index,
-        $this->Inventory,
-        $Inventory->getInventoryType(),
-        $this->User,
-        $u->getName()
+        $str = sprintf('InventoriesLoan-ID: %d, Inventory: %s, User: (%d) <b>%s</b>',
+            (int)$this->Index,
+            $this->inventoryLogLabel(),
+            (int)$this->User,
+            $u->getName()
         );
-        if($this->StartDate != $old->StartDate) $str.=", StartDate: ".germanDate($old->StartDate,0)." &rArr; <b>".germanDate($this->StartDate,0)."</b>";
-        if($this->EndDate != $old->EndDate) $str.=", EndDate: ".germanDate($old->EndDate,0)." &rArr; <b>".germanDate($this->EndDate,0)."</b>";
+        if((int)$this->User !== (int)$old->User) {
+            $ou = new User;
+            $ou->load_by_id($old->User);
+            $str .= ', User: ('.(int)$old->User.') '.$ou->getName()
+                .' &rArr; <b>('.((int)$this->User).') '.$u->getName().'</b>';
+        }
+        if((int)$this->Inventory !== (int)$old->Inventory) {
+            $str .= ', Inventory: '.$this->inventoryLogLabel($old->Inventory)
+                .' &rArr; <b>'.$this->inventoryLogLabel().'</b>';
+        }
+        if($this->StartDate != $old->StartDate) {
+            $str .= ', StartDate: '.germanDate($old->StartDate, 0)
+                .' &rArr; <b>'.germanDate($this->StartDate, 0).'</b>';
+        }
+        if($this->EndDate != $old->EndDate) {
+            $str .= ', EndDate: '.germanDate($old->EndDate, 0)
+                .' &rArr; <b>'.germanDate($this->EndDate, 0).'</b>';
+        }
+        if($this->ContractFile != $old->ContractFile) {
+            $str .= ', ContractFile: '.$old->ContractFile
+                .' &rArr; <b>'.$this->ContractFile.'</b>';
+        }
 
         return $str;
     }
 
     public function getVars() {
-        $Inventory = new Inventories;
-        $Inventory->load_by_id($this->Inventory);
-
         $u = new User;
         $u->load_by_id($this->User);
 
         $parts = array();
         $parts[] = sprintf('InventoriesLoan-ID: %d', (int)$this->Index);
-        $parts[] = sprintf('Inventory: (%d) <b>%s</b>', (int)$this->Inventory, $Inventory->getInventoryType());
+        $parts[] = 'Inventory: '.$this->inventoryLogLabel();
         $parts[] = sprintf('User: (%d) <b>%s</b>', (int)$this->User, $u->getName());
         $start = germanDate($this->StartDate, 0);
         logAppendFilled($parts, 'StartDate', $start, (string)$start);


### PR DESCRIPTION
## Summary
- Fix `InventoriesLoan::getChanges()` (lud fälschlich Legacy-`Loan`) so Leihe-Änderungen wieder in `Log` landen
- Log-Texte mit Inventarnummer; Diffs für User, Inventory, Start/EndDate, ContractFile
- Beim Inventar-Löschen zugehörige Leihen einzeln loggen

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-129

## Test plan
- [ ] Neue Leihe anlegen → Insert im Log mit RegNumber + User
- [ ] Leihe beenden → Update mit EndDate-Diff
- [ ] Inventar mit Leihe löschen → Leihe-Delete + Inventar-Delete im Log

Made with [Cursor](https://cursor.com)