### PR TITLE
MELD-131: Remote-Backup über eigenes backupToken

### DIFF
--- a/backup.php
+++ b/backup.php
@@ -97,8 +97,10 @@ $schema = $manifest['schemaVersion'];
   <div class="w3-card w3-padding w3-margin-bottom">
     <h3>Backup herunterladen</h3>
     <p>ZIP mit <code>manifest.json</code> (Versionsinfo) und <code>database.sql</code> (alle Tabellen mit DB-Prefix).</p>
-    <p>CLI-Backup (Cron):</p>
+    <p>CLI-Backup (Cron auf dem App-Server):</p>
     <pre class="w3-code w3-border w3-padding" style="white-space:pre-wrap;">php cron.php CRONID backup &gt; backup-$(date +%F).zip</pre>
+    <p>Remote-HTTP (nur mit eigenem <code>$backupToken</code> in <code>config.php</code>, mind. 32 Zeichen; nicht der allgemeine Cron-<code>$cronID</code>):</p>
+    <pre class="w3-code w3-border w3-padding" style="white-space:pre-wrap;">curl -fsS "https://HOST/cron.php?id=BACKUPTOKEN&amp;cmd=backup" -o backup.zip</pre>
     <p>Im Browser: Backup über die Schaltfläche unten (Benötigt Berechtigung „Konfiguration bearbeiten“).</p>
     <p><a class="w3-button w3-border <?php echo $GLOBALS['optionsDB']['colorBtnSubmit']; ?>" href="backup.php?download=1"><i class="fas fa-download"></i> Backup jetzt laden</a></p>
   </div>

--- a/common/config_sample.php
+++ b/common/config_sample.php
@@ -25,10 +25,15 @@ mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($conn))
 
 $cronID = 'xxxx-xxxx-xxxx-xxxx';
 
+// Dedicated secret for remote HTTP backup (cron.php?cmd=backup). Opt-in: leave empty to keep HTTP backup disabled.
+// Generate e.g.: openssl rand -hex 32  (must be at least 32 characters). Do not reuse $cronID.
+$backupToken = '';
+
 $googlemapsapi = "xxxx-xxxx-xxxx-xxxx";
 
 global $mailconfig;
 global $cronID;
+global $backupToken;
 global $dbprefix;
 global $googlemapsapi;
 ?>

--- a/cron.php
+++ b/cron.php
@@ -14,26 +14,30 @@ require_once __DIR__.'/libs/sessionBootstrap.php';
 meldeConfigureSession();
 include 'common/include.php';
 
-if(!isset($_GET['id'])) {
-    die("no ID specified\n");
-}
-if($_GET['id'] != $GLOBALS['cronID']) {
-    die("ID invalid\n");
-}
 if(!isset($_GET['cmd'])) {
     die("no command specified\n");
 }
 
 $cmd = (string)$_GET['cmd'];
 
-// Binary download: CLI only (HTTP backup via backup.php)
+// Binary download: CLI uses cronID; HTTP uses dedicated $backupToken (MELD-131)
 if($cmd === 'backup') {
-    if(PHP_SAPI !== 'cli') {
-        http_response_code(403);
-        header('Content-Type: text/plain; charset=utf-8');
-        die("Backup via HTTP disabled; use backup.php or CLI: php cron.php <cronId> backup\n");
+    if(PHP_SAPI === 'cli') {
+        if(!isset($_GET['id']) || (string)$_GET['id'] !== (string)$GLOBALS['cronID']) {
+            die("ID invalid\n");
+        }
     }
-    require_once __DIR__.'/libs/backup.php';
+    else {
+        $provided = backupHttpExtractProvidedToken();
+        if(!backupHttpTokenValid($provided)) {
+            http_response_code(403);
+            header('Content-Type: text/plain; charset=utf-8');
+            if(!backupHttpTokenConfigured()) {
+                die("HTTP backup disabled: set \$backupToken in config.php (min ".BACKUP_HTTP_TOKEN_MIN_LEN." chars), or use backup.php / CLI: php cron.php <cronId> backup\n");
+            }
+            die("HTTP backup unauthorized: invalid backup token\n");
+        }
+    }
     mkAdmin();
     try {
         sendBackupDownload();
@@ -44,6 +48,13 @@ if($cmd === 'backup') {
         echo "Backup failed: ".$e->getMessage()."\n";
         exit(1);
     }
+}
+
+if(!isset($_GET['id'])) {
+    die("no ID specified\n");
+}
+if($_GET['id'] != $GLOBALS['cronID']) {
+    die("ID invalid\n");
 }
 
 if(PHP_SAPI === 'cli') {

--- a/libs/backup.php
+++ b/libs/backup.php
@@ -1,7 +1,62 @@
 <?php
 /**
- * Database backup / restore helpers (MELD-90).
+ * Database backup / restore helpers (MELD-90 / MELD-131).
  */
+
+/** Minimum length for HTTP remote backup token (opt-in). */
+define('BACKUP_HTTP_TOKEN_MIN_LEN', 32);
+
+/**
+ * Configured HTTP backup token, or empty if unset.
+ */
+function backupHttpTokenConfiguredValue() {
+    if(!isset($GLOBALS['backupToken'])) {
+        return '';
+    }
+    return trim((string)$GLOBALS['backupToken']);
+}
+
+/**
+ * Whether a usable HTTP backup token is configured.
+ */
+function backupHttpTokenConfigured() {
+    return strlen(backupHttpTokenConfiguredValue()) >= BACKUP_HTTP_TOKEN_MIN_LEN;
+}
+
+/**
+ * Token from query id=… or Authorization: Bearer ….
+ */
+function backupHttpExtractProvidedToken() {
+    if(isset($_GET['id']) && (string)$_GET['id'] !== '') {
+        return (string)$_GET['id'];
+    }
+    $header = '';
+    if(!empty($_SERVER['HTTP_AUTHORIZATION'])) {
+        $header = (string)$_SERVER['HTTP_AUTHORIZATION'];
+    }
+    elseif(!empty($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+        $header = (string)$_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+    }
+    if(preg_match('/^Bearer\s+(\S+)/i', $header, $m)) {
+        return $m[1];
+    }
+    return '';
+}
+
+/**
+ * Validate a provided HTTP backup token (timing-safe). Never accepts $cronID.
+ */
+function backupHttpTokenValid($provided) {
+    $provided = (string)$provided;
+    if($provided === '' || !backupHttpTokenConfigured()) {
+        return false;
+    }
+    $expected = backupHttpTokenConfiguredValue();
+    if(strlen($provided) !== strlen($expected)) {
+        return false;
+    }
+    return hash_equals($expected, $provided);
+}
 
 /**
  * @return array

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -223,7 +223,7 @@ $sections[] = array(
 <li><b>Konfiguration</b> – Farben, Texte, Feature-Schalter, Webhooks, …</li>
 <li><b>Plattform / SSO</b> – <code>ssoRedirectAllowlist</code>, <code>urlNotenarchiv</code> und <code>urlMitgliederverwaltung</code> für einmalige SSO-Tickets zu Schwester-Modulen (Nav-Links erscheinen bei gesetzter URL)</li>
 <li><b>Updater</b> – Software-Update und Datenbank-Reparatur / Schema-Stand</li>
-<li><b>Backup</b> – Datenbank-ZIP herunterladen (inkl. Versionsinfo) oder wieder einspielen; im Browser über <code>Backup</code>, per CLI mit <code>php cron.php CRONID backup</code> (HTTP-Abruf über <code>cron.php</code> ist deaktiviert)</li>
+<li><b>Backup</b> – Datenbank-ZIP herunterladen (inkl. Versionsinfo) oder wieder einspielen; im Browser über <code>Backup</code>, per CLI mit <code>php cron.php CRONID backup</code>; automatisiert remote nur mit eigenem <code>$backupToken</code> in <code>config.php</code> (mind. 32 Zeichen) über <code>cron.php?id=…&amp;cmd=backup</code> — nicht mit dem allgemeinen Cron-ID</li>
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung)</li>


### PR DESCRIPTION
## Summary
- HTTP-Backup wieder über `cron.php?cmd=backup`, nur mit eigenem `$backupToken` (≥32 Zeichen, `hash_equals`)
- Nicht über allgemeinen `$cronID`; CLI und Admin-UI unverändert
- Hilfe und `config_sample` ergänzt

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-131

## Test plan
- [ ] Ohne `$backupToken`: HTTP-Backup → 403
- [ ] Mit Token: `curl …/cron.php?id=TOKEN&cmd=backup` → ZIP
- [ ] Mit `$cronID` statt Token → 403
- [ ] CLI `php cron.php CRONID backup` weiter OK

Made with [Cursor](https://cursor.com)