### PR TITLE
MELD-57: Return-Token und PRG für Termine/Schichten/Mail

### DIFF
--- a/edit-shifts.php
+++ b/edit-shifts.php
@@ -1,34 +1,71 @@
 <?php
+ob_start();
 require_once __DIR__.'/libs/sessionBootstrap.php';
 meldeConfigureSession();
 $_SESSION['page']='shifts';
 $_SESSION['adminpage']=true;
-include "common/header.php";
+
+include_once 'common/include.php';
+mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($GLOBALS['conn']));
+requireLoggedInOrRedirect();
 if(!requirePermission("perm_editAppmnts")) {
     denyAccess();
 }
 
-if(isset($_POST['Termin'])) {
-    $n = new Termin;
-    $n->load_by_id($_POST['Termin']);
+$terminId = 0;
+if(isset($_GET['Termin'])) {
+    $terminId = (int)$_GET['Termin'];
+}
+elseif(isset($_POST['Termin'])) {
+    $terminId = (int)$_POST['Termin'];
+}
 
+if(isset($_POST['save']) || isset($_POST['delete'])) {
+    if($terminId < 1) {
+        setFlash('error', 'Kein Termin angegeben.');
+        redirectAfterPost('index.php');
+    }
+    $n = new Termin;
+    $n->load_by_id($terminId);
+    if(!$n->Index) {
+        setFlash('error', 'Termin nicht gefunden.');
+        redirectAfterPost('index.php');
+    }
     if(isset($_POST['save'])) {
         $s = new Shift;
         $s->load_by_id($_POST['save']);
         $s->fill_from_array($_POST);
         $s->save();
+        setFlash('success', 'Schicht gespeichert.');
     }
     if(isset($_POST['delete'])) {
         $s = new Shift;
         $s->load_by_id($_POST['delete']);
         $s->delete();
+        setFlash('success', 'Schicht gelöscht.');
     }
+    redirectAfterPost('edit-shifts.php?Termin='.$terminId);
 }
+
+// Opening via POST only → PRG to GET (browser back-safe)
+if($_SERVER['REQUEST_METHOD'] === 'POST' && $terminId > 0) {
+    redirectAfterPost('edit-shifts.php?Termin='.$terminId);
+}
+
+$n = new Termin;
+$n->load_by_id($terminId);
+if(!$n->Index) {
+    setFlash('error', 'Kein Termin zum Bearbeiten der Schichten.');
+    redirectAfterPost('index.php');
+}
+
+include "common/header.php";
 ?>
 <div class="w3-container w3-margin-bottom <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
     <h2>Schichten bearbeiten</h2>
 <p><?php echo $n->Name." (".germanDate($n->Datum, 1).")"; ?></p>
 </div>
+<?php echo renderFlashHtml(); ?>
 
 <?php echo $n->printShiftEdit(); ?>
 <div class="w3-container w3-margin-bottom w3-margin-top <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">

--- a/index.php
+++ b/index.php
@@ -1,9 +1,14 @@
 <?php
+ob_start();
 require_once __DIR__.'/libs/sessionBootstrap.php';
 meldeConfigureSession();
 $_SESSION['page']='home';
 $_SESSION['adminpage']=false;
-include "common/header.php";
+
+include_once 'common/include.php';
+mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($GLOBALS['conn']));
+requireLoggedInOrRedirect();
+
 if(isset($_POST['proxy'])) {
     $user = $_POST['proxy'];
     $proxy = new User;
@@ -13,28 +18,42 @@ else {
     $user = $_SESSION['userid'];
 }
 
+$mutated = false;
 if(isset($_POST['insert'])) {
     $n = new Termin;
     $n->fill_from_array($_POST);
     $n->save();
+    setFlash('success', 'Termin gespeichert.');
+    $mutated = true;
 }
 if(isset($_POST['delete'])) {
     $n = new Termin;
     $n->load_by_id($_POST['Index']);
     $n->delete();
+    setFlash('success', 'Termin gelöscht.');
+    $mutated = true;
 }
 if(isset($_POST['insertAushilfe'])) {
-        $aushilfe = new Aushilfe;
-        $aushilfe->fill_from_array($_POST);
-        $aushilfe->save();
+    $aushilfe = new Aushilfe;
+    $aushilfe->fill_from_array($_POST);
+    $aushilfe->save();
+    setFlash('success', 'Aushilfe gespeichert.');
+    $mutated = true;
 }
 if(isset($_POST['deleteAushilfe'])) {
-        $aushilfe = new Aushilfe;
-        $aushilfe->load_by_id((int)$_POST['Index']);
-        if($aushilfe->Index && requirePermission('perm_editAppmnts')) {
-            $aushilfe->delete();
-        }
+    $aushilfe = new Aushilfe;
+    $aushilfe->load_by_id((int)$_POST['Index']);
+    if($aushilfe->Index && requirePermission('perm_editAppmnts')) {
+        $aushilfe->delete();
+        setFlash('success', 'Aushilfe gelöscht.');
+        $mutated = true;
+    }
 }
+if($mutated) {
+    redirectAfterPost(resolvePostReturnUrl('index.php'));
+}
+
+include "common/header.php";
 ?>
 <script src="<?php echo assetUrl('js/getStatus.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/melde.js'); ?>"></script>
@@ -42,6 +61,7 @@ if(isset($_POST['deleteAushilfe'])) {
 <script src="<?php echo assetUrl('js/meldeshift.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/changeInstrument.js'); ?>"></script>
 
+<?php echo renderFlashHtml(); ?>
 <?php
 if(isset($_POST['proxy'])) {
 ?>

--- a/libs/form-response.php
+++ b/libs/form-response.php
@@ -262,7 +262,7 @@ function applyUserFormPostRedirect($defaultReturnUrl, $options = array()) {
     if(!$result['handled']) {
         return false;
     }
-    $returnTo = safeReturnUrl(isset($_POST['return_to']) ? $_POST['return_to'] : '', $defaultReturnUrl);
+    $returnTo = resolvePostReturnUrl($defaultReturnUrl);
     if($result['flash']) {
         setFlash($result['flash']['type'], $result['flash']['message']);
     }
@@ -280,7 +280,7 @@ function applyNewMusikerFormPostRedirect($defaultReturnUrl) {
     if(!$result['handled']) {
         return false;
     }
-    $returnTo = safeReturnUrl(isset($_POST['return_to']) ? $_POST['return_to'] : '', $defaultReturnUrl);
+    $returnTo = resolvePostReturnUrl($defaultReturnUrl);
     if($result['flash']) {
         setFlash($result['flash']['type'], $result['flash']['message']);
     }

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -1187,7 +1187,7 @@ function stripMailBodyGreeting($body, $vorname) {
     return $body;
 }
 
-/** Allowed return targets for form POST redirects (MELD-15). */
+/** Allowed return targets for form POST redirects (MELD-15 / MELD-57). */
 function allowedReturnUrls() {
     return array(
         'users.php',
@@ -1198,13 +1198,17 @@ function allowedReturnUrls() {
         'register.php',
         'mein-register.php',
         'index.php',
+        'termine-archiv.php',
         'user-voice.php',
         'groups.php',
         'group-edit.php',
         'inventories.php',
         'myinventories.php',
+        'insurance.php',
         'mail.php',
         'meine-mails.php',
+        'edit-shifts.php',
+        'new-termin.php',
     );
 }
 
@@ -1222,10 +1226,14 @@ function pageToReturnUrl($page) {
         'groups' => 'groups.php',
         'inventories' => 'inventories.php',
         'myinventories' => 'myinventories.php',
+        'insurance' => 'insurance.php',
         'mail' => 'mail.php',
         'meinemails' => 'meine-mails.php',
         'home' => 'index.php',
         'me' => 'index.php',
+        'termine-archiv' => 'termine-archiv.php',
+        'shifts' => 'edit-shifts.php',
+        'newtermin' => 'new-termin.php',
     );
     $page = (string)$page;
     return isset($map[$page]) ? $map[$page] : 'index.php';
@@ -1256,6 +1264,52 @@ function safeReturnUrl($url, $default = 'index.php') {
         return $base;
     }
     return $base.'?'.$m[2];
+}
+
+/**
+ * Store a return URL in the session and return an opaque token (MELD-57).
+ * Forms POST the token instead of a raw return URL when possible.
+ */
+function issueReturnToken($url) {
+    $url = safeReturnUrl($url, 'index.php');
+    if(!isset($_SESSION['return_tokens']) || !is_array($_SESSION['return_tokens'])) {
+        $_SESSION['return_tokens'] = array();
+    }
+    if(count($_SESSION['return_tokens']) > 40) {
+        $_SESSION['return_tokens'] = array_slice($_SESSION['return_tokens'], -25, null, true);
+    }
+    $token = bin2hex(random_bytes(16));
+    $_SESSION['return_tokens'][$token] = array(
+        'url' => $url,
+        'exp' => time() + 86400,
+    );
+    return $token;
+}
+
+/**
+ * Resolve and consume a one-time return token.
+ */
+function consumeReturnToken($token, $default = 'index.php') {
+    $token = (string)$token;
+    if($token === '' || empty($_SESSION['return_tokens'][$token]) || !is_array($_SESSION['return_tokens'][$token])) {
+        return $default;
+    }
+    $entry = $_SESSION['return_tokens'][$token];
+    unset($_SESSION['return_tokens'][$token]);
+    if(empty($entry['url']) || (isset($entry['exp']) && time() > (int)$entry['exp'])) {
+        return $default;
+    }
+    return safeReturnUrl($entry['url'], $default);
+}
+
+/**
+ * Prefer return_token (session), fall back to whitelisted return_to.
+ */
+function resolvePostReturnUrl($default = 'index.php') {
+    if(!empty($_POST['return_token'])) {
+        return consumeReturnToken($_POST['return_token'], $default);
+    }
+    return safeReturnUrl(isset($_POST['return_to']) ? $_POST['return_to'] : '', $default);
 }
 
 function setFlash($type, $message) {

--- a/libs/user.php
+++ b/libs/user.php
@@ -560,6 +560,7 @@ class User
             'registerLeadName' => $registerLeadName,
             'showEditButton' => ($forceEditButton || requirePermission("perm_editUsers")),
             'returnTo' => pageToReturnUrl(isset($_SESSION['page']) ? $_SESSION['page'] : 'musiker'),
+            'returnToken' => issueReturnToken(pageToReturnUrl(isset($_SESSION['page']) ? $_SESSION['page'] : 'musiker')),
         ));
     }
 

--- a/mail.php
+++ b/mail.php
@@ -24,7 +24,7 @@ MailJob::ensureSchema();
 $discordAvailable = Discord::isConfigured();
 
 $msg = '';
-$preview = false;
+$preview = isset($_GET['preview']);
 $job = null;
 $jobId = isset($_GET['id']) ? (int)$_GET['id'] : (isset($_POST['id']) ? (int)$_POST['id'] : 0);
 $terminParam = isset($_GET['termin']) ? (int)$_GET['termin'] : (isset($_POST['termin']) ? (int)$_POST['termin'] : 0);
@@ -119,11 +119,12 @@ if($job && $job->Status === 'draft' && (isset($_POST['save']) || isset($_POST['p
     $job->ensureAttachmentDir();
     $job->save();
 
-    if(isset($_POST['preview']) || isset($_POST['send'])) {
-        $preview = true;
-    }
     if(isset($_POST['save'])) {
-        $msg = '<div class="w3-container '.$GLOBALS['optionsDB']['colorLogEmail'].'"><h3>Entwurf #'.(int)$job->Index.' gespeichert.</h3></div>';
+        setFlash('success', 'Entwurf #'.(int)$job->Index.' gespeichert.');
+        redirectAfterPost('mail.php?id='.(int)$job->Index);
+    }
+    if(isset($_POST['preview'])) {
+        redirectAfterPost('mail.php?id='.(int)$job->Index.'&preview=1');
     }
     if(isset($_POST['send'])) {
         $mail = new Usermail;
@@ -142,6 +143,7 @@ if($job && $job->Status === 'draft' && (isset($_POST['save']) || isset($_POST['p
         }
         $msg = '<div class="w3-container '.$GLOBALS['optionsDB']['colorLogError'].'"><h3>Keine gültigen Emailadressen gefunden.</h3></div>';
         $job->load_by_id($job->Index);
+        $preview = true;
     }
 }
 
@@ -195,6 +197,7 @@ include_once 'common/header.php';
 <div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
   <h2>Email versenden</h2>
 </div>
+<?php echo renderFlashHtml(); ?>
 <?php echo $msg; ?>
 
 <div class="w3-container w3-padding">

--- a/new-musiker.php
+++ b/new-musiker.php
@@ -50,6 +50,9 @@ $returnTo = safeReturnUrl(
     isset($_GET['return_to']) ? $_GET['return_to'] : (isset($_POST['return_to']) ? $_POST['return_to'] : ''),
     'musiker.php'
 );
+$returnToken = !empty($_POST['return_token'])
+    ? (string)$_POST['return_token']
+    : issueReturnToken($returnTo);
 
 $fill = false;
 $n = new User;
@@ -109,6 +112,7 @@ $formAction = '';
     <input type="hidden" name="id" value="<?php echo (int)$userid; ?>">
 <?php } elseif($canEditUsers) { ?>
     <input type="hidden" name="return_to" value="<?php echo htmlspecialchars($returnTo, ENT_QUOTES, 'UTF-8'); ?>">
+    <input type="hidden" name="return_token" value="<?php echo htmlspecialchars($returnToken, ENT_QUOTES, 'UTF-8'); ?>">
 <?php } ?>
     <label>Vorname</label>
     <input class="w3-input w3-border <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?> w3-margin-bottom w3-mobile" name="Vorname" type="text" placeholder="Vorname" <?php if($fill) echo "value=\"".htmlspecialchars((string)$n->Vorname, ENT_QUOTES, 'UTF-8')."\""; ?> <?php echo $disabled; ?>>
@@ -241,6 +245,7 @@ if($showAppLoginLink) {
     <div class="w3-container w3-mobile">
     <form action="" method="POST">
     <input type="hidden" name="return_to" value="<?php echo htmlspecialchars($returnTo, ENT_QUOTES, 'UTF-8'); ?>">
+    <input type="hidden" name="return_token" value="<?php echo htmlspecialchars($returnToken, ENT_QUOTES, 'UTF-8'); ?>">
     <input type="hidden" name="Index" value="<?php echo (int)$n->Index; ?>">
     <div class="w3-row">
     <div class="w3-col l4 m4 s2 w3-center">&nbsp;</div>

--- a/termine-archiv.php
+++ b/termine-archiv.php
@@ -1,9 +1,14 @@
 <?php
+ob_start();
 require_once __DIR__.'/libs/sessionBootstrap.php';
 meldeConfigureSession();
 $_SESSION['page']='termine-archiv';
 $_SESSION['adminpage']=true;
-include "common/header.php";
+
+include_once 'common/include.php';
+mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($GLOBALS['conn']));
+requireLoggedInOrRedirect();
+
 if(isset($_POST['proxy'])) {
     $user = $_POST['proxy'];
     $proxy = new User;
@@ -13,34 +18,49 @@ else {
     $user = $_SESSION['userid'];
 }
 
+$mutated = false;
 if(isset($_POST['insert'])) {
     $n = new Termin;
     $n->fill_from_array($_POST);
     $n->save();
+    setFlash('success', 'Termin gespeichert.');
+    $mutated = true;
 }
 if(isset($_POST['delete'])) {
     $n = new Termin;
     $n->fill_from_array($_POST);
     $n->delete();
+    setFlash('success', 'Termin gelöscht.');
+    $mutated = true;
 }
 if(isset($_POST['insertAushilfe'])) {
-        $aushilfe = new Aushilfe;
-        $aushilfe->fill_from_array($_POST);
-        $aushilfe->save();
+    $aushilfe = new Aushilfe;
+    $aushilfe->fill_from_array($_POST);
+    $aushilfe->save();
+    setFlash('success', 'Aushilfe gespeichert.');
+    $mutated = true;
 }
 if(isset($_POST['deleteAushilfe'])) {
-        $aushilfe = new Aushilfe;
-        $aushilfe->load_by_id((int)$_POST['Index']);
-        if($aushilfe->Index && requirePermission('perm_editAppmnts')) {
-            $aushilfe->delete();
-        }
+    $aushilfe = new Aushilfe;
+    $aushilfe->load_by_id((int)$_POST['Index']);
+    if($aushilfe->Index && requirePermission('perm_editAppmnts')) {
+        $aushilfe->delete();
+        setFlash('success', 'Aushilfe gelöscht.');
+        $mutated = true;
+    }
 }
+if($mutated) {
+    redirectAfterPost(resolvePostReturnUrl('termine-archiv.php'));
+}
+
+include "common/header.php";
 ?>
 <script src="<?php echo assetUrl('js/getStatus.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/melde.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/meldeshift.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/changeInstrument.js'); ?>"></script>
 
+<?php echo renderFlashHtml(); ?>
 <?php
 if(isset($_POST['proxy'])) {
 ?>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -176,6 +176,7 @@ $sections[] = array(
     'visible' => isAdmin() && requirePermission('perm_editAppmnts'),
     'body' => '
 <p>Unter Admin → <b>Termin erstellen</b> legst du neue Termine an. Das Formular ist in Abschnitte gegliedert (Was, Wann, Wo, Optionen): auf dem Smartphone untereinander, auf dem Tablet zweispaltig, am PC als vier Spalten nebeneinander.</p>
+<p>Nach Speichern/Löschen von Terminen, Aushilfen oder Schichten erfolgt ein Redirect (kein erneutes Absenden beim Aktualisieren); Rücksprungziele können über Session-Token (<code>return_token</code>) geführt werden.</p>
 <p>Das Flag <b>Besetzung</b> steuert, ob Registeraufschlüsselung und Orchesterdarstellung greifen – für Proben und Auftritte. Veranstaltungen ohne Besetzung (z.&nbsp;B. Grillfest, Radtour) brauchen das nicht (nur Manpower).</p>
 <p>Mit dem Chip-Feld <b>sichtbar für</b> steuerst du den Kreis (Standard: <b>Alle User</b>). Ohne Chips = versteckt – nur User mit Recht <b>Versteckte Termine anzeigen</b>. Mit Chips nur der gewählte Kreis (Rollen, Gruppen, Register, Personen); Admins mit dem genannten Recht sehen weiterhin alles.</p>
 <p>Discord-Posts (bei konfiguriertem Webhook) erfolgen bei Sichtbarkeit <b>Alle User</b> automatisch, sonst nur mit der Checkbox <b>Auch auf Discord posten</b>.</p>

--- a/views/user/modal.php
+++ b/views/user/modal.php
@@ -52,6 +52,7 @@
 <?php if($showEditButton) { ?>
 <form class="w3-center w3-bar w3-mobile" action="new-musiker.php" method="POST">
   <input type="hidden" name="return_to" value="<?php echo htmlspecialchars($returnTo, ENT_QUOTES, 'UTF-8'); ?>">
+  <input type="hidden" name="return_token" value="<?php echo htmlspecialchars(isset($returnToken) ? $returnToken : '', ENT_QUOTES, 'UTF-8'); ?>">
   <button class="w3-button w3-center w3-mobile w3-block <?php echo $GLOBALS['optionsDB']['colorBtnEdit']; ?>" type="submit" name="id" value="<?php echo $user->Index; ?>">bearbeiten</button>
 </form>
 <?php } ?>


### PR DESCRIPTION
## Summary
- Session-`return_token` (one-shot) neben Whitelist-`return_to`
- PRG für Termine/Aushilfen, Schichten (`?Termin=`), Mail Speichern/Vorschau
- Hilfe aktualisiert

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-57

## Test plan
- [ ] Termin speichern/löschen → Redirect, Refresh ohne Resubmit
- [ ] Schicht speichern → bleibt auf `edit-shifts.php?Termin=…`
- [ ] Mail-Entwurf speichern/Vorschau → GET-Redirect
- [ ] Profil speichern springt zur Ausgangsliste zurück

Made with [Cursor](https://cursor.com)