### PR TITLE
MELD-126: Monats-Kalenderansicht

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -1,0 +1,46 @@
+<?php
+require_once __DIR__.'/libs/sessionBootstrap.php';
+meldeConfigureSession();
+$_SESSION['page'] = 'calendar';
+$_SESSION['adminpage'] = false;
+
+include_once 'common/include.php';
+mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($GLOBALS['conn']));
+requireLoggedInOrRedirect();
+
+$userId = (int)$_SESSION['userid'];
+$ym = calendarParseYearMonth(isset($_GET['ym']) ? $_GET['ym'] : null);
+$bounds = calendarMonthBounds($ym);
+$events = calendarLoadEventsForUser($userId, $bounds['gridStart'], $bounds['gridEnd']);
+$byDay = calendarEventsByDay($events, $bounds['gridStart'], $bounds['gridEnd']);
+
+include 'common/header.php';
+?>
+<script src="<?php echo assetUrl('js/melde.js'); ?>"></script>
+<script src="<?php echo assetUrl('js/meldeFT.js'); ?>"></script>
+<script src="<?php echo assetUrl('js/meldeshift.js'); ?>"></script>
+<script src="<?php echo assetUrl('js/getStatus.js'); ?>"></script>
+<script src="<?php echo assetUrl('js/changeInstrument.js'); ?>"></script>
+
+<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
+  <h2>Kalender</h2>
+</div>
+
+<div class="w3-container w3-padding-16 w3-center meld-cal-nav">
+  <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriger Monat" aria-label="Vorheriger Monat"><i class="fas fa-chevron-left"></i></a>
+  <span class="w3-padding meld-cal-label"><b><?php echo htmlspecialchars($bounds['label'], ENT_QUOTES, 'UTF-8'); ?></b></span>
+  <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächster Monat" aria-label="Nächster Monat"><i class="fas fa-chevron-right"></i></a>
+  <a class="w3-button w3-border w3-margin-left" href="calendar.php" title="Aktueller Monat">Heute</a>
+</div>
+
+<div class="w3-container w3-padding-small meld-cal-legend">
+  <span class="w3-tag w3-tiny <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnYes'], ENT_QUOTES, 'UTF-8'); ?>">Ja</span>
+  <span class="w3-tag w3-tiny <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnNo'], ENT_QUOTES, 'UTF-8'); ?>">Nein</span>
+  <span class="w3-tag w3-tiny <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnMaybe'], ENT_QUOTES, 'UTF-8'); ?>">Vielleicht</span>
+  <span class="w3-tag w3-tiny <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnEdit'], ENT_QUOTES, 'UTF-8'); ?>">Ohne Meldung</span>
+</div>
+
+<?php
+include __DIR__.'/views/calendar/month.php';
+include 'common/footer.php';
+?>

--- a/calendar.php
+++ b/calendar.php
@@ -27,12 +27,61 @@ include 'common/header.php';
   <h2>Kalender</h2>
 </div>
 
-<div class="w3-container w3-padding-16 w3-center meld-cal-nav">
-  <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriger Monat" aria-label="Vorheriger Monat"><i class="fas fa-chevron-left"></i></a>
-  <span class="w3-padding meld-cal-label"><b><?php echo htmlspecialchars($bounds['label'], ENT_QUOTES, 'UTF-8'); ?></b></span>
-  <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächster Monat" aria-label="Nächster Monat"><i class="fas fa-chevron-right"></i></a>
-  <a class="w3-button w3-border w3-margin-left" href="calendar.php" title="Aktueller Monat">Heute</a>
+<?php
+$calYear = (int)$bounds['year'];
+$calMonth = (int)$bounds['month'];
+$monthNames = calendarMonthNames();
+$yearFrom = max(1970, min($calYear, (int)date('Y')) - 10);
+$yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
+?>
+<style>
+.meld-cal-nav { display: flex; flex-wrap: wrap; justify-content: center; align-items: flex-start; gap: 1rem 1.5rem; }
+.meld-cal-spinner { display: inline-flex; flex-direction: column; align-items: stretch; min-width: 9rem; }
+.meld-cal-spinner select {
+  text-align: center; text-align-last: center; font-weight: bold;
+  padding: 8px 6px; margin: 0; border-radius: 0;
+}
+.meld-cal-spinner .w3-button { margin: 0; padding: 6px 8px; }
+.meld-cal-nav-today { align-self: center; }
+</style>
+
+<div class="w3-container w3-padding-16 meld-cal-nav">
+  <div class="meld-cal-spinner" role="group" aria-label="Monat">
+    <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächster Monat" aria-label="Monat erhöhen"><i class="fas fa-chevron-up"></i></a>
+    <select id="calMonthSelect" class="w3-select w3-border" aria-label="Monat wählen">
+<?php foreach($monthNames as $num => $name) { ?>
+      <option value="<?php echo (int)$num; ?>"<?php echo $num === $calMonth ? ' selected' : ''; ?>><?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8'); ?></option>
+<?php } ?>
+    </select>
+    <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriger Monat" aria-label="Monat verringern"><i class="fas fa-chevron-down"></i></a>
+  </div>
+  <div class="meld-cal-spinner" role="group" aria-label="Jahr">
+    <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächstes Jahr" aria-label="Jahr erhöhen"><i class="fas fa-chevron-up"></i></a>
+    <select id="calYearSelect" class="w3-select w3-border" aria-label="Jahr wählen">
+<?php for($y = $yearFrom; $y <= $yearTo; $y++) { ?>
+      <option value="<?php echo $y; ?>"<?php echo $y === $calYear ? ' selected' : ''; ?>><?php echo $y; ?></option>
+<?php } ?>
+    </select>
+    <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriges Jahr" aria-label="Jahr verringern"><i class="fas fa-chevron-down"></i></a>
+  </div>
+  <a class="w3-button w3-border meld-cal-nav-today" href="calendar.php" title="Aktueller Monat">Heute</a>
 </div>
+<script>
+(function() {
+    var monthSel = document.getElementById('calMonthSelect');
+    var yearSel = document.getElementById('calYearSelect');
+    function goYm() {
+        if(!monthSel || !yearSel) return;
+        var m = parseInt(monthSel.value, 10);
+        var y = parseInt(yearSel.value, 10);
+        if(isNaN(m) || isNaN(y)) return;
+        var mm = (m < 10 ? '0' : '') + m;
+        window.location.href = 'calendar.php?ym=' + encodeURIComponent(y + '-' + mm);
+    }
+    if(monthSel) monthSel.addEventListener('change', goYm);
+    if(yearSel) yearSel.addEventListener('change', goYm);
+})();
+</script>
 
 <?php
 include __DIR__.'/views/calendar/month.php';

--- a/calendar.php
+++ b/calendar.php
@@ -33,13 +33,6 @@ include 'common/header.php';
   <a class="w3-button w3-border w3-margin-left" href="calendar.php" title="Aktueller Monat">Heute</a>
 </div>
 
-<div class="w3-container w3-padding-small meld-cal-legend">
-  <span class="w3-tag w3-tiny <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnYes'], ENT_QUOTES, 'UTF-8'); ?>">Ja</span>
-  <span class="w3-tag w3-tiny <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnNo'], ENT_QUOTES, 'UTF-8'); ?>">Nein</span>
-  <span class="w3-tag w3-tiny <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnMaybe'], ENT_QUOTES, 'UTF-8'); ?>">Vielleicht</span>
-  <span class="w3-tag w3-tiny <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnEdit'], ENT_QUOTES, 'UTF-8'); ?>">Ohne Meldung</span>
-</div>
-
 <?php
 include __DIR__.'/views/calendar/month.php';
 include 'common/footer.php';

--- a/calendar.php
+++ b/calendar.php
@@ -36,33 +36,36 @@ $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
 ?>
 <style>
 .meld-cal-nav { display: flex; flex-wrap: wrap; justify-content: center; align-items: flex-start; gap: 1rem 1.5rem; }
-.meld-cal-spinner { display: inline-flex; flex-direction: column; align-items: stretch; min-width: 9rem; }
+.meld-cal-spinner { display: inline-flex; flex-direction: column; align-items: center; min-width: 9rem; }
 .meld-cal-spinner select {
   text-align: center; text-align-last: center; font-weight: bold;
-  padding: 8px 6px; margin: 0; border-radius: 0;
+  padding: 8px 6px; margin: 0; border-radius: 0; width: 100%;
 }
-.meld-cal-spinner .w3-button { margin: 0; padding: 6px 8px; }
+.meld-cal-spinner .meld-cal-step {
+  margin: 0; padding: 4px 10px; width: auto; min-width: 2.25rem;
+  line-height: 1;
+}
 .meld-cal-nav-today { align-self: center; }
 </style>
 
 <div class="w3-container w3-padding-16 meld-cal-nav">
   <div class="meld-cal-spinner" role="group" aria-label="Monat">
-    <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächster Monat" aria-label="Monat erhöhen"><i class="fas fa-chevron-up"></i></a>
+    <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriger Monat" aria-label="Früherer Monat"><i class="fas fa-chevron-up"></i></a>
     <select id="calMonthSelect" class="w3-select w3-border" aria-label="Monat wählen">
 <?php foreach($monthNames as $num => $name) { ?>
       <option value="<?php echo (int)$num; ?>"<?php echo $num === $calMonth ? ' selected' : ''; ?>><?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8'); ?></option>
 <?php } ?>
     </select>
-    <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriger Monat" aria-label="Monat verringern"><i class="fas fa-chevron-down"></i></a>
+    <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächster Monat" aria-label="Späterer Monat"><i class="fas fa-chevron-down"></i></a>
   </div>
   <div class="meld-cal-spinner" role="group" aria-label="Jahr">
-    <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächstes Jahr" aria-label="Jahr erhöhen"><i class="fas fa-chevron-up"></i></a>
+    <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriges Jahr" aria-label="Früheres Jahr"><i class="fas fa-chevron-up"></i></a>
     <select id="calYearSelect" class="w3-select w3-border" aria-label="Jahr wählen">
 <?php for($y = $yearFrom; $y <= $yearTo; $y++) { ?>
       <option value="<?php echo $y; ?>"<?php echo $y === $calYear ? ' selected' : ''; ?>><?php echo $y; ?></option>
 <?php } ?>
     </select>
-    <a class="w3-button w3-border" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriges Jahr" aria-label="Jahr verringern"><i class="fas fa-chevron-down"></i></a>
+    <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächstes Jahr" aria-label="Späteres Jahr"><i class="fas fa-chevron-down"></i></a>
   </div>
   <a class="w3-button w3-border meld-cal-nav-today" href="calendar.php" title="Aktueller Monat">Heute</a>
 </div>

--- a/calendar.php
+++ b/calendar.php
@@ -21,6 +21,7 @@ include 'common/header.php';
 <script src="<?php echo assetUrl('js/meldeshift.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/getStatus.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/changeInstrument.js'); ?>"></script>
+<script src="<?php echo assetUrl('js/calendarMelde.js'); ?>"></script>
 
 <div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
   <h2>Kalender</h2>

--- a/common/include.php
+++ b/common/include.php
@@ -48,6 +48,7 @@ include "libs/AppmntFreeTextResponse.php";
 include "libs/listChunk.php";
 include "libs/evaluateStats.php";
 include "libs/backup.php";
+include "libs/calendarView.php";
 include "libs/ssoTicket.php";
 include "libs/userVoice.php";
 ?>

--- a/common/nav.php
+++ b/common/nav.php
@@ -40,6 +40,7 @@ if(requirePermission('perm_editConfig')) {
 <div class="w3-bar <?php echo $optionsDB['colorNav']; ?>">
   <button onclick="showAll()" class="w3-bar-item w3-button w3-mobile w3-hide-large w3-hide-medium material-icons">menu</button>
   <a title="Termine" alt="Termine" href="<?php echo $GLOBALS['optionsDB']['WebSiteURL']; ?>" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php getPage('home');?>"><i class="far fa-calendar-alt"></i></a>
+  <a title="Kalender" alt="Kalender" href="calendar.php" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php getPage('calendar');?>"><i class="fas fa-calendar"></i></a>
   <?php
   $mailUnread = 0;
   if(isset($_SESSION['userid'])) {

--- a/getModal.php
+++ b/getModal.php
@@ -31,6 +31,22 @@ case 'termin':
     echo $t->getDetailModalHtml();
     break;
 
+case 'calendarMelde':
+    $t = new Termin;
+    $t->load_by_id($id);
+    if(!(int)$t->Index) {
+        http_response_code(404);
+        echo '<div class="w3-container w3-padding"><p>Termin nicht gefunden.</p></div>';
+        exit;
+    }
+    if(!$t->isVisibleToUser((int)$_SESSION['userid'])) {
+        http_response_code(403);
+        echo '<div class="w3-container w3-padding"><p>Keine Berechtigung.</p></div>';
+        exit;
+    }
+    echo $t->getCalendarMeldeModalHtml();
+    break;
+
 case 'terminResponse':
     // All logged-in users may view register responses (MELD-68); edit stays gated in modal HTML
     $t = new Termin;

--- a/js/calendarMelde.js
+++ b/js/calendarMelde.js
@@ -1,0 +1,57 @@
+/**
+ * Calendar melde modal helpers (MELD-126).
+ * Refresh intermediate modal + chip colors after melde().
+ */
+function invalidateCalendarMeldeModalCache(terminId) {
+    if(typeof modalCache === 'undefined') return;
+    var prefix = 'calendarMelde:' + terminId;
+    Object.keys(modalCache).forEach(function(k) {
+        if(k === prefix || k.indexOf(prefix + ':') === 0) {
+            delete modalCache[k];
+        }
+    });
+}
+
+function refreshOpenCalendarMeldeModal(terminId) {
+    var host = document.getElementById('ajaxModalHost');
+    if(!host || host.style.display === 'none') return;
+    var root = document.querySelector('.calendar-melde-modal[data-termin-id="' + terminId + '"]');
+    if(!root) return;
+    invalidateCalendarMeldeModalCache(terminId);
+    if(typeof openModal === 'function') {
+        openModal('calendarMelde', terminId);
+    }
+}
+
+function calendarChipColorClass(wert) {
+    var wrap = document.querySelector('.meld-cal-wrap');
+    if(!wrap) return '';
+    var w = parseInt(wert, 10);
+    if(w === 1) return wrap.getAttribute('data-color-yes') || '';
+    if(w === 2) return wrap.getAttribute('data-color-no') || '';
+    if(w === 3) return wrap.getAttribute('data-color-maybe') || '';
+    return wrap.getAttribute('data-color-none') || '';
+}
+
+function updateCalendarChipsForTermin(terminId, wert) {
+    var chips = document.querySelectorAll('.meld-cal-chip[data-termin-id="' + terminId + '"]');
+    if(!chips.length) return;
+    var wrap = document.querySelector('.meld-cal-wrap');
+    var palette = [];
+    if(wrap) {
+        palette = [
+            wrap.getAttribute('data-color-yes') || '',
+            wrap.getAttribute('data-color-no') || '',
+            wrap.getAttribute('data-color-maybe') || '',
+            wrap.getAttribute('data-color-none') || ''
+        ];
+    }
+    var next = calendarChipColorClass(wert);
+    chips.forEach(function(chip) {
+        palette.forEach(function(cls) {
+            if(cls) chip.classList.remove(cls);
+        });
+        if(next) chip.classList.add(next);
+        chip.setAttribute('data-melde-wert', (wert === null || wert === undefined || wert === '') ? '' : String(wert));
+    });
+}

--- a/js/calendarMelde.js
+++ b/js/calendarMelde.js
@@ -55,3 +55,34 @@ function updateCalendarChipsForTermin(terminId, wert) {
         chip.setAttribute('data-melde-wert', (wert === null || wert === undefined || wert === '') ? '' : String(wert));
     });
 }
+
+function calendarFormatDeDate(iso) {
+    var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso || '');
+    if(!m) return iso || '';
+    return m[3] + '.' + m[2] + '.' + m[1];
+}
+
+function calendarOfferNewTermin(dateIso) {
+    if(!dateIso) return;
+    var label = calendarFormatDeDate(dateIso);
+    if(!window.confirm('Neuen Termin am ' + label + ' anlegen?')) {
+        return;
+    }
+    window.location.href = 'new-termin.php?Datum=' + encodeURIComponent(dateIso);
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    var wrap = document.querySelector('.meld-cal-wrap');
+    if(!wrap || wrap.getAttribute('data-can-create') !== '1') return;
+    wrap.addEventListener('click', function(e) {
+        if(e.target.closest('.meld-cal-chip, .meld-cal-more, button, a, select, input')) {
+            return;
+        }
+        var cell = e.target.closest('.meld-cal-cell');
+        if(!cell || !wrap.contains(cell)) return;
+        var dateIso = cell.getAttribute('data-date');
+        if(dateIso) {
+            calendarOfferNewTermin(dateIso);
+        }
+    });
+});

--- a/js/melde.js
+++ b/js/melde.js
@@ -30,6 +30,15 @@ function melde(user, termin, wert, Children, Guests) {
             else if(typeof invalidateTerminResponseModalCache === 'function') {
                 invalidateTerminResponseModalCache(termin);
             }
+            if(typeof refreshOpenCalendarMeldeModal === 'function') {
+                refreshOpenCalendarMeldeModal(termin);
+            }
+            else if(typeof invalidateCalendarMeldeModalCache === 'function') {
+                invalidateCalendarMeldeModalCache(termin);
+            }
+            if(typeof updateCalendarChipsForTermin === 'function') {
+                updateCalendarChipsForTermin(termin, wert);
+            }
             // Weitere Einträge desselben Termins (z. B. Zähler) nachziehen
             if(typeof scheduleRefreshMainPageTerminEntries === 'function') {
                 scheduleRefreshMainPageTerminEntries(termin);

--- a/libs/calendarView.php
+++ b/libs/calendarView.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * In-app month calendar data helpers (MELD-126).
+ * Pure data API — no HTML. Reusable for later print/sync tickets.
+ */
+
+/**
+ * Parse YYYY-MM; invalid → current month.
+ *
+ * @param string|null $ym
+ * @return string YYYY-MM
+ */
+function calendarParseYearMonth($ym) {
+    $ym = trim((string)$ym);
+    if(preg_match('/^(\d{4})-(\d{2})$/', $ym, $m)) {
+        $y = (int)$m[1];
+        $mo = (int)$m[2];
+        if($y >= 1970 && $y <= 2100 && $mo >= 1 && $mo <= 12) {
+            return sprintf('%04d-%02d', $y, $mo);
+        }
+    }
+    return date('Y-m');
+}
+
+/**
+ * First Monday on/before the 1st of the month through last Sunday on/after the last day.
+ *
+ * @param string $ym YYYY-MM
+ * @return array{ym:string,monthStart:string,monthEnd:string,gridStart:string,gridEnd:string,prevYm:string,nextYm:string,label:string}
+ */
+function calendarMonthBounds($ym) {
+    $ym = calendarParseYearMonth($ym);
+    $monthStart = DateTimeImmutable::createFromFormat('Y-m-d', $ym.'-01');
+    if($monthStart === false) {
+        $ym = date('Y-m');
+        $monthStart = DateTimeImmutable::createFromFormat('Y-m-d', $ym.'-01');
+    }
+    $monthEnd = $monthStart->modify('last day of this month');
+
+    // Monday = 1 … Sunday = 7 (ISO)
+    $dow = (int)$monthStart->format('N');
+    $gridStart = $monthStart->modify('-'.($dow - 1).' days');
+    $dowEnd = (int)$monthEnd->format('N');
+    $gridEnd = $monthEnd->modify('+'.(7 - $dowEnd).' days');
+
+    $prev = $monthStart->modify('-1 month');
+    $next = $monthStart->modify('+1 month');
+
+    $monthsDe = array(
+        1 => 'Januar', 2 => 'Februar', 3 => 'März', 4 => 'April',
+        5 => 'Mai', 6 => 'Juni', 7 => 'Juli', 8 => 'August',
+        9 => 'September', 10 => 'Oktober', 11 => 'November', 12 => 'Dezember',
+    );
+    $mi = (int)$monthStart->format('n');
+    $label = $monthsDe[$mi].' '.$monthStart->format('Y');
+
+    return array(
+        'ym' => $ym,
+        'monthStart' => $monthStart->format('Y-m-d'),
+        'monthEnd' => $monthEnd->format('Y-m-d'),
+        'gridStart' => $gridStart->format('Y-m-d'),
+        'gridEnd' => $gridEnd->format('Y-m-d'),
+        'prevYm' => $prev->format('Y-m'),
+        'nextYm' => $next->format('Y-m'),
+        'label' => $label,
+    );
+}
+
+/**
+ * CSS class for own melde status (optionsDB colorBtn*).
+ *
+ * @param int|null $wert 1=ja, 2=nein, 3=vielleicht, null/0=ohne
+ * @return string
+ */
+function calendarColorClassForWert($wert) {
+    $opts = isset($GLOBALS['optionsDB']) ? $GLOBALS['optionsDB'] : array();
+    $w = ($wert === null || $wert === '') ? 0 : (int)$wert;
+    if($w === 1) {
+        return isset($opts['colorBtnYes']) ? (string)$opts['colorBtnYes'] : 'w3-green';
+    }
+    if($w === 2) {
+        return isset($opts['colorBtnNo']) ? (string)$opts['colorBtnNo'] : 'w3-red';
+    }
+    if($w === 3) {
+        return isset($opts['colorBtnMaybe']) ? (string)$opts['colorBtnMaybe'] : 'w3-blue';
+    }
+    return isset($opts['colorBtnEdit']) ? (string)$opts['colorBtnEdit'] : 'w3-teal';
+}
+
+/**
+ * Load visible appointments overlapping [fromDate, toDate] for a user.
+ *
+ * @param int $userId
+ * @param string $fromDate Y-m-d
+ * @param string $toDate Y-m-d
+ * @return list<array{id:int,name:string,date:string,endDate:string,startTime:string,endTime:string,wert:int|null,colorClass:string}>
+ */
+function calendarLoadEventsForUser($userId, $fromDate, $toDate) {
+    $userId = (int)$userId;
+    $fromDate = (string)$fromDate;
+    $toDate = (string)$toDate;
+    if($userId <= 0 || $fromDate === '' || $toDate === '') {
+        return array();
+    }
+
+    $conn = $GLOBALS['conn'];
+    $prefix = $GLOBALS['dbprefix'];
+    $fromEsc = mysqli_real_escape_string($conn, $fromDate);
+    $toEsc = mysqli_real_escape_string($conn, $toDate);
+
+    // Overlap: start <= to AND (end OR start) >= from
+    // CAST/NULLIF avoids "Incorrect DATE value: ''" when EndDatum is empty string
+    $sql = sprintf(
+        'SELECT `t`.*, `m`.`Wert` AS `meldeWert` FROM `%sTermine` `t`
+        LEFT JOIN `%sMeldungen` `m` ON `m`.`Termin` = `t`.`Index` AND `m`.`User` = %d
+        WHERE %s
+          AND `t`.`Datum` <= \'%s\'
+          AND COALESCE(NULLIF(CAST(`t`.`EndDatum` AS CHAR), \'\'), `t`.`Datum`) >= \'%s\'
+        ORDER BY `t`.`Datum`, `t`.`Uhrzeit`, `t`.`Name`;',
+        $prefix,
+        $prefix,
+        $userId,
+        Termin::sqlIsListed('`t`.'),
+        $toEsc,
+        $fromEsc
+    );
+    $dbr = mysqli_query($conn, $sql);
+    sqlerror();
+    if(!$dbr) {
+        return array();
+    }
+
+    $out = array();
+    while($row = mysqli_fetch_assoc($dbr)) {
+        $t = new Termin();
+        $t->fill_from_array($row);
+        if(!$t->isVisibleToUser($userId)) {
+            continue;
+        }
+        $wert = null;
+        if(isset($row['meldeWert']) && $row['meldeWert'] !== null && $row['meldeWert'] !== '') {
+            $wert = (int)$row['meldeWert'];
+        }
+        $endDate = trim((string)$t->EndDatum);
+        if($endDate === '') {
+            $endDate = (string)$t->Datum;
+        }
+        $startTime = trim((string)$t->Uhrzeit);
+        $endTime = trim((string)$t->Uhrzeit2);
+        $out[] = array(
+            'id' => (int)$t->Index,
+            'name' => (string)$t->Name,
+            'date' => (string)$t->Datum,
+            'endDate' => $endDate,
+            'startTime' => $startTime,
+            'endTime' => $endTime,
+            'wert' => $wert,
+            'colorClass' => calendarColorClassForWert($wert),
+        );
+    }
+    return $out;
+}
+
+/**
+ * Expand events onto each day they span within [from, to].
+ *
+ * @param list<array{id:int,name:string,date:string,endDate:string,startTime:string,endTime:string,wert:int|null,colorClass:string}> $events
+ * @param string $fromDate
+ * @param string $toDate
+ * @return array<string, list<array>> keyed by Y-m-d
+ */
+function calendarEventsByDay($events, $fromDate, $toDate) {
+    $map = array();
+    $from = DateTimeImmutable::createFromFormat('Y-m-d', $fromDate);
+    $to = DateTimeImmutable::createFromFormat('Y-m-d', $toDate);
+    if($from === false || $to === false) {
+        return $map;
+    }
+
+    foreach($events as $ev) {
+        $start = DateTimeImmutable::createFromFormat('Y-m-d', $ev['date']);
+        $end = DateTimeImmutable::createFromFormat('Y-m-d', $ev['endDate']);
+        if($start === false) {
+            continue;
+        }
+        if($end === false || $end < $start) {
+            $end = $start;
+        }
+        if($end < $from || $start > $to) {
+            continue;
+        }
+        $day = ($start < $from) ? $from : $start;
+        $last = ($end > $to) ? $to : $end;
+        while($day <= $last) {
+            $key = $day->format('Y-m-d');
+            if(!isset($map[$key])) {
+                $map[$key] = array();
+            }
+            $map[$key][] = $ev;
+            $day = $day->modify('+1 day');
+        }
+    }
+    return $map;
+}
+
+/**
+ * Short time label for chips (HH:MM or empty).
+ *
+ * @param string $time
+ * @return string
+ */
+function calendarFormatTimeShort($time) {
+    $time = trim((string)$time);
+    if($time === '') {
+        return '';
+    }
+    if(preg_match('/^(\d{1,2}):(\d{2})/', $time, $m)) {
+        return sprintf('%02d:%02d', (int)$m[1], (int)$m[2]);
+    }
+    return $time;
+}

--- a/libs/calendarView.php
+++ b/libs/calendarView.php
@@ -23,10 +23,23 @@ function calendarParseYearMonth($ym) {
 }
 
 /**
+ * German month names (1–12).
+ *
+ * @return array<int,string>
+ */
+function calendarMonthNames() {
+    return array(
+        1 => 'Januar', 2 => 'Februar', 3 => 'März', 4 => 'April',
+        5 => 'Mai', 6 => 'Juni', 7 => 'Juli', 8 => 'August',
+        9 => 'September', 10 => 'Oktober', 11 => 'November', 12 => 'Dezember',
+    );
+}
+
+/**
  * First Monday on/before the 1st of the month through last Sunday on/after the last day.
  *
  * @param string $ym YYYY-MM
- * @return array{ym:string,monthStart:string,monthEnd:string,gridStart:string,gridEnd:string,prevYm:string,nextYm:string,label:string}
+ * @return array{ym:string,year:int,month:int,monthStart:string,monthEnd:string,gridStart:string,gridEnd:string,prevYm:string,nextYm:string,prevYearYm:string,nextYearYm:string,label:string}
  */
 function calendarMonthBounds($ym) {
     $ym = calendarParseYearMonth($ym);
@@ -45,23 +58,26 @@ function calendarMonthBounds($ym) {
 
     $prev = $monthStart->modify('-1 month');
     $next = $monthStart->modify('+1 month');
+    $prevYear = $monthStart->modify('-1 year');
+    $nextYear = $monthStart->modify('+1 year');
 
-    $monthsDe = array(
-        1 => 'Januar', 2 => 'Februar', 3 => 'März', 4 => 'April',
-        5 => 'Mai', 6 => 'Juni', 7 => 'Juli', 8 => 'August',
-        9 => 'September', 10 => 'Oktober', 11 => 'November', 12 => 'Dezember',
-    );
+    $monthsDe = calendarMonthNames();
     $mi = (int)$monthStart->format('n');
-    $label = $monthsDe[$mi].' '.$monthStart->format('Y');
+    $yi = (int)$monthStart->format('Y');
+    $label = $monthsDe[$mi].' '.$yi;
 
     return array(
         'ym' => $ym,
+        'year' => $yi,
+        'month' => $mi,
         'monthStart' => $monthStart->format('Y-m-d'),
         'monthEnd' => $monthEnd->format('Y-m-d'),
         'gridStart' => $gridStart->format('Y-m-d'),
         'gridEnd' => $gridEnd->format('Y-m-d'),
         'prevYm' => $prev->format('Y-m'),
         'nextYm' => $next->format('Y-m'),
+        'prevYearYm' => $prevYear->format('Y-m'),
+        'nextYearYm' => $nextYear->format('Y-m'),
         'label' => $label,
     );
 }

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -1770,6 +1770,57 @@ class Termin
         return $str;
     }
 
+    /**
+     * Compact melde prompt for calendar clicks (MELD-126).
+     * Ja/Nein/Vielleicht like the list; „Weitere Optionen“ opens the detail modal.
+     */
+    public function getCalendarMeldeModalHtml() {
+        $user = (int)$this->getUser();
+        $name = htmlspecialchars((string)$this->Name, ENT_QUOTES, 'UTF-8');
+        $timeInfo = htmlspecialchars($this->makeTimeInfo(), ENT_QUOTES, 'UTF-8');
+        $ort = htmlspecialchars((string)$this->Ort1, ENT_QUOTES, 'UTF-8');
+
+        $str = '<div class="calendar-melde-modal" data-termin-id="'.(int)$this->Index.'">';
+        $str .= '<header class="w3-container '.$GLOBALS['optionsDB']['colorTitleBar'].'">';
+        $str .= '<span onclick="closeModal()" class="w3-button w3-display-topright">&times;</span>';
+        $str .= '<h2>'.$name.'</h2>';
+        $str .= '</header>';
+        $str .= '<div class="w3-container w3-padding">';
+        $str .= '<p class="w3-margin-bottom"><b>'.$timeInfo.'</b>';
+        if($ort !== '') {
+            $str .= '<br>'.$ort;
+        }
+        $str .= '</p>';
+
+        if($this->Shifts) {
+            $str .= '<p class="w3-padding w3-border">Dieser Termin hat Schichten. Bitte unter <b>Weitere Optionen</b> melden.</p>';
+        }
+        else {
+            $str .= '<p class="w3-margin-bottom">Deine Rückmeldung:</p>';
+            $str .= '<div class="w3-row w3-margin-bottom" id="calendarMeldeBtns'.(int)$this->Index.'">';
+            if($this->Capacity) {
+                if($this->Capacity > $this->getMeldungenVal(1) || $this->Wert == 1 || requirePermission('perm_editResponse')) {
+                    $str .= $this->makeButtons(2, 0, $this->Wert);
+                }
+                else {
+                    $str .= '<div class="w3-padding">Alle Plätze belegt</div>';
+                }
+            }
+            else {
+                $str .= $this->makeButtons(3, 0, $this->Wert);
+            }
+            $str .= '</div>';
+        }
+
+        $str .= '<div class="w3-margin-top w3-margin-bottom">';
+        $str .= '<button type="button" class="w3-button w3-border '.$GLOBALS['optionsDB']['colorBtnEdit'].'" '
+            .'onclick="openModal(\'termin\', '.(int)$this->Index.')">'
+            .'<i class="fas fa-info-circle"></i> Weitere Optionen</button>';
+        $str .= '</div>';
+        $str .= '</div></div>';
+        return $str;
+    }
+
     public function getDetailModalHtml() {
         $str="";
         $str=$str."<header class=\"w3-container ".$GLOBALS['optionsDB']['colorTitleBar']."\">\n";

--- a/new-termin.php
+++ b/new-termin.php
@@ -9,6 +9,7 @@ if(!requirePermission("perm_editAppmnts")) {
 }
 
 $fill = false;
+$prefillDatum = '';
 if(isset($_POST['id'])) {
     $n = new Termin;
     $n->load_by_id($_POST['id']);
@@ -23,6 +24,15 @@ if(isset($_POST['copy'])) {
         $fill = true;
     }
     $n->Index=NULL;
+}
+if(!$fill && isset($_GET['Datum'])) {
+    $d = trim((string)$_GET['Datum']);
+    if(preg_match('/^\d{4}-\d{2}-\d{2}$/', $d)) {
+        $parts = explode('-', $d);
+        if(checkdate((int)$parts[1], (int)$parts[2], (int)$parts[0])) {
+            $prefillDatum = $d;
+        }
+    }
 }
 $inputBg = $GLOBALS['optionsDB']['colorInputBackground'];
 ?>
@@ -47,7 +57,14 @@ $inputBg = $GLOBALS['optionsDB']['colorInputBackground'];
     <div class="w3-row">
       <div class="w3-col s12 m6 l6 termin-form-field">
         <label>Datum <span class="w3-small w3-text-gray">(mehrtägig <input id="endcheck" type="checkbox" <?php if($fill && $n->EndDatum) echo "checked"; ?> onclick="endToggle();"></input>)</span></label>
-        <input class="w3-input w3-border <?php echo $inputBg; ?> w3-margin-bottom w3-mobile" name="Datum" type="date" <?php if($fill) echo "value=\"".$n->Datum."\""; ?>>
+        <input class="w3-input w3-border <?php echo $inputBg; ?> w3-margin-bottom w3-mobile" name="Datum" type="date"<?php
+          if($fill) {
+              echo ' value="'.htmlspecialchars((string)$n->Datum, ENT_QUOTES, 'UTF-8').'"';
+          }
+          elseif($prefillDatum !== '') {
+              echo ' value="'.htmlspecialchars($prefillDatum, ENT_QUOTES, 'UTF-8').'"';
+          }
+        ?>>
       </div>
       <div class="w3-col s12 m6 l6 termin-form-field">
         <label id="endlabel" <?php if($fill && $n->EndDatum) echo "style=\"display: block;\""; else echo "style=\"display: none;\""; ?>>Enddatum</label>

--- a/views/calendar/month.php
+++ b/views/calendar/month.php
@@ -19,6 +19,8 @@ $gridEnd = DateTimeImmutable::createFromFormat('Y-m-d', $bounds['gridEnd']);
   background: #fff; overflow: hidden;
 }
 .meld-cal-cell--out { opacity: 0.45; background: #f5f5f5; }
+.meld-cal-cell--weekend { background: #f0f3f7; }
+.meld-cal-cell--out.meld-cal-cell--weekend { background: #e8ecf1; }
 .meld-cal-cell--today { outline: 2px solid #345A95; outline-offset: -2px; }
 .meld-cal-daynum { font-size: 0.8em; font-weight: bold; margin-bottom: 2px; }
 .meld-cal-chip {
@@ -50,9 +52,13 @@ while($cursor && $gridEnd && $cursor <= $gridEnd) {
     $key = $cursor->format('Y-m-d');
     $inMonth = ($key >= $monthStart && $key <= $monthEnd);
     $isToday = ($key === $today);
+    $dow = (int)$cursor->format('N'); // 6=Sa, 7=So
     $classes = 'meld-cal-cell';
     if(!$inMonth) {
         $classes .= ' meld-cal-cell--out';
+    }
+    if($dow >= 6) {
+        $classes .= ' meld-cal-cell--weekend';
     }
     if($isToday) {
         $classes .= ' meld-cal-cell--today';

--- a/views/calendar/month.php
+++ b/views/calendar/month.php
@@ -31,6 +31,8 @@ $gridEnd = DateTimeImmutable::createFromFormat('Y-m-d', $bounds['gridEnd']);
 }
 .meld-cal-more { font-size: 0.7em; color: #555; padding: 0 2px; }
 .meld-cal-events { max-height: 6.5rem; overflow-y: auto; }
+.meld-cal-cell--create { cursor: pointer; }
+.meld-cal-cell--create:hover { filter-color: #345A95; }
 @media (max-width: 600px) {
   .meld-cal-cell { min-height: 4.2rem; padding: 2px; }
   .meld-cal-chip { font-size: 0.6em; padding: 1px 2px; }
@@ -42,12 +44,14 @@ $gridEnd = DateTimeImmutable::createFromFormat('Y-m-d', $bounds['gridEnd']);
      data-color-yes="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnYes'], ENT_QUOTES, 'UTF-8'); ?>"
      data-color-no="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnNo'], ENT_QUOTES, 'UTF-8'); ?>"
      data-color-maybe="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnMaybe'], ENT_QUOTES, 'UTF-8'); ?>"
-     data-color-none="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnEdit'], ENT_QUOTES, 'UTF-8'); ?>">
+     data-color-none="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnEdit'], ENT_QUOTES, 'UTF-8'); ?>"
+     data-can-create="<?php echo (isAdmin() && requirePermission('perm_editAppmnts')) ? '1' : '0'; ?>">
   <div class="meld-cal-grid" role="grid" aria-label="Monatskalender">
 <?php foreach($weekdays as $wd) { ?>
     <div class="meld-cal-head" role="columnheader"><?php echo htmlspecialchars($wd, ENT_QUOTES, 'UTF-8'); ?></div>
 <?php } ?>
 <?php
+$canCreate = isAdmin() && requirePermission('perm_editAppmnts');
 while($cursor && $gridEnd && $cursor <= $gridEnd) {
     $key = $cursor->format('Y-m-d');
     $inMonth = ($key >= $monthStart && $key <= $monthEnd);
@@ -63,12 +67,19 @@ while($cursor && $gridEnd && $cursor <= $gridEnd) {
     if($isToday) {
         $classes .= ' meld-cal-cell--today';
     }
+    if($canCreate) {
+        $classes .= ' meld-cal-cell--create';
+    }
     $dayEvents = isset($byDay[$key]) ? $byDay[$key] : array();
     $total = count($dayEvents);
     $shown = array_slice($dayEvents, 0, $maxChips);
     $extra = $total - count($shown);
 ?>
-    <div class="<?php echo $classes; ?>" role="gridcell" data-date="<?php echo htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>">
+    <div class="<?php echo $classes; ?>" role="gridcell" data-date="<?php echo htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>"<?php
+      if($canCreate) {
+          echo ' title="Klick: neuen Termin anlegen"';
+      }
+    ?>>
       <div class="meld-cal-daynum"><?php echo (int)$cursor->format('j'); ?></div>
       <div class="meld-cal-events">
 <?php

--- a/views/calendar/month.php
+++ b/views/calendar/month.php
@@ -36,7 +36,11 @@ $gridEnd = DateTimeImmutable::createFromFormat('Y-m-d', $bounds['gridEnd']);
 }
 </style>
 
-<div class="w3-container w3-padding-small meld-cal-wrap">
+<div class="w3-container w3-padding-small meld-cal-wrap"
+     data-color-yes="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnYes'], ENT_QUOTES, 'UTF-8'); ?>"
+     data-color-no="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnNo'], ENT_QUOTES, 'UTF-8'); ?>"
+     data-color-maybe="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnMaybe'], ENT_QUOTES, 'UTF-8'); ?>"
+     data-color-none="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnEdit'], ENT_QUOTES, 'UTF-8'); ?>">
   <div class="meld-cal-grid" role="grid" aria-label="Monatskalender">
 <?php foreach($weekdays as $wd) { ?>
     <div class="meld-cal-head" role="columnheader"><?php echo htmlspecialchars($wd, ENT_QUOTES, 'UTF-8'); ?></div>
@@ -70,8 +74,10 @@ while($cursor && $gridEnd && $cursor <= $gridEnd) {
 ?>
         <button type="button"
           class="meld-cal-chip <?php echo $color; ?>"
+          data-termin-id="<?php echo (int)$ev['id']; ?>"
+          data-melde-wert="<?php echo $ev['wert'] === null ? '' : (int)$ev['wert']; ?>"
           title="<?php echo htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?>"
-          onclick="openModal('termin', <?php echo (int)$ev['id']; ?>)">
+          onclick="openModal('calendarMelde', <?php echo (int)$ev['id']; ?>)">
           <?php echo htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?>
         </button>
 <?php

--- a/views/calendar/month.php
+++ b/views/calendar/month.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Month grid partial. Expects: $bounds, $byDay
+ */
+$weekdays = array('Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So');
+$today = date('Y-m-d');
+$monthStart = $bounds['monthStart'];
+$monthEnd = $bounds['monthEnd'];
+$maxChips = 3;
+
+$cursor = DateTimeImmutable::createFromFormat('Y-m-d', $bounds['gridStart']);
+$gridEnd = DateTimeImmutable::createFromFormat('Y-m-d', $bounds['gridEnd']);
+?>
+<style>
+.meld-cal-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 2px; }
+.meld-cal-head { font-weight: bold; text-align: center; padding: 6px 2px; font-size: 0.85em; }
+.meld-cal-cell {
+  min-height: 5.5rem; border: 1px solid #ccc; padding: 4px; vertical-align: top;
+  background: #fff; overflow: hidden;
+}
+.meld-cal-cell--out { opacity: 0.45; background: #f5f5f5; }
+.meld-cal-cell--today { outline: 2px solid #345A95; outline-offset: -2px; }
+.meld-cal-daynum { font-size: 0.8em; font-weight: bold; margin-bottom: 2px; }
+.meld-cal-chip {
+  display: block; width: 100%; box-sizing: border-box; margin: 0 0 2px 0;
+  padding: 2px 4px; font-size: 0.7em; line-height: 1.2; text-align: left;
+  border: 1px solid rgba(0,0,0,0.25); cursor: pointer; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap; border-radius: 2px;
+}
+.meld-cal-more { font-size: 0.7em; color: #555; padding: 0 2px; }
+.meld-cal-events { max-height: 6.5rem; overflow-y: auto; }
+@media (max-width: 600px) {
+  .meld-cal-cell { min-height: 4.2rem; padding: 2px; }
+  .meld-cal-chip { font-size: 0.6em; padding: 1px 2px; }
+  .meld-cal-head { font-size: 0.75em; }
+}
+</style>
+
+<div class="w3-container w3-padding-small meld-cal-wrap">
+  <div class="meld-cal-grid" role="grid" aria-label="Monatskalender">
+<?php foreach($weekdays as $wd) { ?>
+    <div class="meld-cal-head" role="columnheader"><?php echo htmlspecialchars($wd, ENT_QUOTES, 'UTF-8'); ?></div>
+<?php } ?>
+<?php
+while($cursor && $gridEnd && $cursor <= $gridEnd) {
+    $key = $cursor->format('Y-m-d');
+    $inMonth = ($key >= $monthStart && $key <= $monthEnd);
+    $isToday = ($key === $today);
+    $classes = 'meld-cal-cell';
+    if(!$inMonth) {
+        $classes .= ' meld-cal-cell--out';
+    }
+    if($isToday) {
+        $classes .= ' meld-cal-cell--today';
+    }
+    $dayEvents = isset($byDay[$key]) ? $byDay[$key] : array();
+    $total = count($dayEvents);
+    $shown = array_slice($dayEvents, 0, $maxChips);
+    $extra = $total - count($shown);
+?>
+    <div class="<?php echo $classes; ?>" role="gridcell" data-date="<?php echo htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>">
+      <div class="meld-cal-daynum"><?php echo (int)$cursor->format('j'); ?></div>
+      <div class="meld-cal-events">
+<?php
+    foreach($shown as $ev) {
+        $timeLabel = calendarFormatTimeShort($ev['startTime']);
+        $label = ($timeLabel !== '' ? $timeLabel.' ' : '').$ev['name'];
+        $title = $ev['name'].($timeLabel !== '' ? ' ('.$timeLabel.')' : '');
+        $color = htmlspecialchars($ev['colorClass'], ENT_QUOTES, 'UTF-8');
+?>
+        <button type="button"
+          class="meld-cal-chip <?php echo $color; ?>"
+          title="<?php echo htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?>"
+          onclick="openModal('termin', <?php echo (int)$ev['id']; ?>)">
+          <?php echo htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?>
+        </button>
+<?php
+    }
+    if($extra > 0) {
+        $moreTitle = array();
+        foreach(array_slice($dayEvents, $maxChips) as $ev) {
+            $moreTitle[] = $ev['name'];
+        }
+?>
+        <div class="meld-cal-more" title="<?php echo htmlspecialchars(implode(', ', $moreTitle), ENT_QUOTES, 'UTF-8'); ?>">+<?php echo (int)$extra; ?></div>
+<?php } ?>
+      </div>
+    </div>
+<?php
+    $cursor = $cursor->modify('+1 day');
+}
+?>
+  </div>
+</div>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -41,6 +41,7 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 <li><i class="far fa-calendar-alt"></i> <b>Termine</b> – bevorstehende Termine und schnelles Melden</li>
+<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Details)</li>
 <li><i class="fas fa-envelope"></i> <b>Meine Nachrichten</b> – empfangene Mails aus der Meldeliste (Badge bei ungelesenen)</li>
 <li><i class="fas fa-users"></i> <b>Mein Register</b> – Rückmeldungen deines Registers</li>
 '.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir zugeordnetes bzw. ausgeliehenes Inventar</li>' : '').'
@@ -61,6 +62,7 @@ $sections[] = array(
 <p>Unter <b>Termine</b> (Startseite) kannst du dich zu Terminen eintragen:</p>
 <ul>
 <li>Über die Suchzeile findest du Termine nach Titel, Ort, Datum oder Beschreibung (auch im Termin-Archiv).</li>
+<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; die Chip-Farbe entspricht deiner Meldung (ja / nein / vielleicht / ohne).</li>
 </ul>
 '.$meldeButtons.'
 <p>Tippe auf den gewünschten Status. Die Farbe am Termin zeigt deinen aktuellen Stand. Eine erneute Auswahl ändert die Meldung.</p>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -41,7 +41,7 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 <li><i class="far fa-calendar-alt"></i> <b>Termine</b> – bevorstehende Termine und schnelles Melden</li>
-<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Details)</li>
+<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details)</li>
 <li><i class="fas fa-envelope"></i> <b>Meine Nachrichten</b> – empfangene Mails aus der Meldeliste (Badge bei ungelesenen)</li>
 <li><i class="fas fa-users"></i> <b>Mein Register</b> – Rückmeldungen deines Registers</li>
 '.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir zugeordnetes bzw. ausgeliehenes Inventar</li>' : '').'
@@ -62,7 +62,7 @@ $sections[] = array(
 <p>Unter <b>Termine</b> (Startseite) kannst du dich zu Terminen eintragen:</p>
 <ul>
 <li>Über die Suchzeile findest du Termine nach Titel, Ort, Datum oder Beschreibung (auch im Termin-Archiv).</li>
-<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; die Chip-Farbe entspricht deiner Meldung (ja / nein / vielleicht / ohne).</li>
+<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details.</li>
 </ul>
 '.$meldeButtons.'
 <p>Tippe auf den gewünschten Status. Die Farbe am Termin zeigt deinen aktuellen Stand. Eine erneute Auswahl ändert die Meldung.</p>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -178,6 +178,7 @@ $sections[] = array(
     'visible' => isAdmin() && requirePermission('perm_editAppmnts'),
     'body' => '
 <p>Unter Admin → <b>Termin erstellen</b> legst du neue Termine an. Das Formular ist in Abschnitte gegliedert (Was, Wann, Wo, Optionen): auf dem Smartphone untereinander, auf dem Tablet zweispaltig, am PC als vier Spalten nebeneinander.</p>
+<p>Im <b>Kalender</b> kannst du auf eine freie Tagesfläche klicken: Nach Bestätigung öffnet sich das Anlege-Formular mit vorausgefülltem Datum.</p>
 <p>Nach Speichern/Löschen von Terminen, Aushilfen oder Schichten erfolgt ein Redirect (kein erneutes Absenden beim Aktualisieren); Rücksprungziele können über Session-Token (<code>return_token</code>) geführt werden.</p>
 <p>Das Flag <b>Besetzung</b> steuert, ob Registeraufschlüsselung und Orchesterdarstellung greifen – für Proben und Auftritte. Veranstaltungen ohne Besetzung (z.&nbsp;B. Grillfest, Radtour) brauchen das nicht (nur Manpower).</p>
 <p>Mit dem Chip-Feld <b>sichtbar für</b> steuerst du den Kreis (Standard: <b>Alle User</b>). Ohne Chips = versteckt – nur User mit Recht <b>Versteckte Termine anzeigen</b>. Mit Chips nur der gewählte Kreis (Rollen, Gruppen, Register, Personen); Admins mit dem genannten Recht sehen weiterhin alles.</p>


### PR DESCRIPTION
## Summary
- Monats-Kalender ohne externe Libs (`calendar.php`, `libs/calendarView.php`)
- Zwischen-Modal mit Meldeabfrage; Chips nach eigenem Melde-Status; Wochenenden schattiert
- Monat/Jahr-Navigation; Admin/`perm_editAppmnts`: leerer Tag → neuer Termin mit Datum
- Nav + Hilfe-Guide aktualisiert

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-126

## Test plan
- [ ] Kalender in Nav öffnen, Monat/Jahr wechseln
- [ ] Termin-Chip öffnet Zwischen-Modal; Melden aktualisiert Chip
- [ ] „Weitere Optionen“ öffnet volles Termin-Modal
- [ ] Wochenenden leicht schattiert
- [ ] Als Admin: leeren Tag klicken → Bestätigung → new-termin mit Datum


Made with [Cursor](https://cursor.com)