### PR TITLE
MELD-127: On-Demand-Kalenderabo

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -88,5 +88,16 @@ $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
 
 <?php
 include __DIR__.'/views/calendar/month.php';
+
+$calUser = new User();
+$calUser->load_by_id($userId);
+if((int)$calUser->Index > 0 && $calUser->activeLink) {
+    $n = $calUser;
+    $calendarSubscribeUid = 'page-cal';
+    echo '<div class="w3-container w3-padding-16" style="max-width:40rem;margin:0 auto;">';
+    include __DIR__.'/views/calendar/subscribe.php';
+    echo '</div>';
+}
+
 include 'common/footer.php';
 ?>

--- a/calendars/README
+++ b/calendars/README
@@ -1,2 +1,3 @@
-This folder contains user specific ics calendars.
-Users can subscribe to the custom link.
+This folder may still contain legacy static ICS files from older builds.
+Personal calendar subscriptions use on-demand ical.php (MELD-127) — do not rely on
+rebuilding MVDcal_*.ics per user.

--- a/common/include.php
+++ b/common/include.php
@@ -49,6 +49,7 @@ include "libs/listChunk.php";
 include "libs/evaluateStats.php";
 include "libs/backup.php";
 include "libs/calendarView.php";
+include "libs/icalFeed.php";
 include "libs/ssoTicket.php";
 include "libs/userVoice.php";
 ?>

--- a/config/ConfigDefaults.php
+++ b/config/ConfigDefaults.php
@@ -300,6 +300,12 @@ function getConfigDefaults() {
             'Description' => 'Termine im Kalender anzeigen, die wieviele Tage alt sind',
         ),
         array(
+            'Parameter' => 'calendarFutureDays',
+            'Value' => '365',
+            'Type' => 'uint',
+            'Description' => 'Persönliches Kalenderabo (ICS): wie viele Tage in die Zukunft (MELD-127)',
+        ),
+        array(
             'Parameter' => 'alwaysMaybeNewAppmnts',
             'Value' => '',
             'Type' => 'string',

--- a/ical.php
+++ b/ical.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * On-demand personal ICS subscription (MELD-127).
+ * Auth: secret token in ?t= (User.activeLink). No session required.
+ */
+require_once __DIR__.'/common/include.php';
+mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($GLOBALS['conn']));
+
+$token = '';
+if(isset($_GET['t'])) {
+    $token = trim((string)$_GET['t']);
+}
+elseif(isset($_GET['alink'])) {
+    $token = trim((string)$_GET['alink']);
+}
+
+if($token === '' || !preg_match('/^[a-zA-Z0-9]+$/', $token)) {
+    http_response_code(404);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo "Not found\n";
+    exit;
+}
+
+$row = findUserByActiveLink($token);
+if(!$row) {
+    http_response_code(404);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo "Not found\n";
+    exit;
+}
+
+$userId = (int)$row['Index'];
+$loaded = icalFeedLoadForUser($userId);
+$etag = icalFeedEtag($userId, $loaded['events'], $loaded['from'], $loaded['to']);
+
+$inm = isset($_SERVER['HTTP_IF_NONE_MATCH']) ? trim((string)$_SERVER['HTTP_IF_NONE_MATCH']) : '';
+if($inm !== '' && $inm === $etag) {
+    http_response_code(304);
+    header('ETag: '.$etag);
+    header('Cache-Control: private, max-age=300');
+    exit;
+}
+
+$body = icalFeedBuild($loaded['events']);
+
+header('Content-Type: text/calendar; charset=utf-8');
+header('ETag: '.$etag);
+header('Cache-Control: private, max-age=300');
+header('X-Content-Type-Options: nosniff');
+echo $body;

--- a/libs/calendarView.php
+++ b/libs/calendarView.php
@@ -109,7 +109,7 @@ function calendarColorClassForWert($wert) {
  * @param int $userId
  * @param string $fromDate Y-m-d
  * @param string $toDate Y-m-d
- * @return list<array{id:int,name:string,date:string,endDate:string,startTime:string,endTime:string,wert:int|null,colorClass:string}>
+ * @return list<array{id:int,name:string,date:string,endDate:string,startTime:string,endTime:string,wert:int|null,colorClass:string,description:string,location:string}>
  */
 function calendarLoadEventsForUser($userId, $fromDate, $toDate) {
     $userId = (int)$userId;
@@ -172,6 +172,8 @@ function calendarLoadEventsForUser($userId, $fromDate, $toDate) {
             'endTime' => $endTime,
             'wert' => $wert,
             'colorClass' => calendarColorClassForWert($wert),
+            'description' => (string)$t->Beschreibung,
+            'location' => method_exists($t, 'getOrt') ? (string)$t->getOrt() : '',
         );
     }
     return $out;

--- a/libs/icalFeed.php
+++ b/libs/icalFeed.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * On-demand personal ICS feed (MELD-127, Konzertmeister-style).
+ * No static per-user files — build on request.
+ */
+
+/**
+ * Date window for subscription feeds.
+ *
+ * @return array{from:string,to:string}
+ */
+function icalFeedDateWindow() {
+    $past = 0;
+    if(isset($GLOBALS['optionsDB']['calendarPastDays'])) {
+        $past = max(0, (int)$GLOBALS['optionsDB']['calendarPastDays']);
+    }
+    $future = 365;
+    if(isset($GLOBALS['optionsDB']['calendarFutureDays'])) {
+        $future = max(1, (int)$GLOBALS['optionsDB']['calendarFutureDays']);
+    }
+    $today = new DateTimeImmutable('today');
+    return array(
+        'from' => $today->modify('-'.$past.' days')->format('Y-m-d'),
+        'to' => $today->modify('+'.$future.' days')->format('Y-m-d'),
+    );
+}
+
+/**
+ * Drop "Nein" (wert=2); keep ja / vielleicht / ohne.
+ *
+ * @param list<array{id:int,name:string,date:string,endDate:string,startTime:string,endTime:string,wert:int|null,description?:string,location?:string}> $events
+ * @return list<array>
+ */
+function icalFeedFilterEvents(array $events) {
+    $out = array();
+    foreach($events as $ev) {
+        $wert = isset($ev['wert']) ? $ev['wert'] : null;
+        if($wert !== null && $wert !== '' && (int)$wert === 2) {
+            continue;
+        }
+        $out[] = $ev;
+    }
+    return $out;
+}
+
+/**
+ * Host part for UID (no scheme/path).
+ *
+ * @param string|null $websiteUrl
+ * @return string
+ */
+function icalFeedUidHost($websiteUrl = null) {
+    if($websiteUrl === null && isset($GLOBALS['optionsDB']['WebSiteURL'])) {
+        $websiteUrl = (string)$GLOBALS['optionsDB']['WebSiteURL'];
+    }
+    $host = parse_url((string)$websiteUrl, PHP_URL_HOST);
+    if(is_string($host) && $host !== '') {
+        return $host;
+    }
+    return 'meldeliste.local';
+}
+
+/**
+ * Stable VEVENT UID.
+ *
+ * @param int $terminId
+ * @param string|null $host
+ * @return string
+ */
+function icalFeedUid($terminId, $host = null) {
+    if($host === null || $host === '') {
+        $host = icalFeedUidHost();
+    }
+    return 'meld-'.(int)$terminId.'@'.$host;
+}
+
+/**
+ * Escape text for ICS CONTENTLINE.
+ *
+ * @param string $text
+ * @return string
+ */
+function icalFeedEscapeText($text) {
+    $text = str_replace(array("\\", ";", ",", "\r\n", "\n", "\r"), array("\\\\", "\\;", "\\,", "\\n", "\\n", "\\n"), (string)$text);
+    return $text;
+}
+
+/**
+ * Fold long ICS lines (max 75 octets, CRLF + space).
+ *
+ * @param string $line
+ * @return string
+ */
+function icalFeedFoldLine($line) {
+    $line = (string)$line;
+    if(strlen($line) <= 75) {
+        return $line;
+    }
+    $out = '';
+    $chunk = substr($line, 0, 75);
+    $rest = substr($line, 75);
+    $out .= $chunk;
+    while($rest !== '' && $rest !== false) {
+        $out .= "\r\n ".substr($rest, 0, 74);
+        $rest = substr($rest, 74);
+    }
+    return $out;
+}
+
+/**
+ * Melde status label for DESCRIPTION.
+ *
+ * @param int|null $wert
+ * @return string
+ */
+function icalFeedMeldeLabel($wert) {
+    if($wert === null || $wert === '') {
+        return 'ohne Rückmeldung';
+    }
+    $w = (int)$wert;
+    if($w === 1) {
+        return 'zugesagt';
+    }
+    if($w === 3) {
+        return 'vielleicht';
+    }
+    if($w === 2) {
+        return 'abgesagt';
+    }
+    return 'ohne Rückmeldung';
+}
+
+/**
+ * Local DTSTART/DTEND as YmdThis (Europe/Berlin wall clock), matching legacy UserCalendar.
+ *
+ * @param array{date:string,endDate:string,startTime:string,endTime:string} $ev
+ * @return array{begin:string,end:string}
+ */
+function icalFeedEventTimes(array $ev) {
+    $date = (string)$ev['date'];
+    $endDate = trim((string)$ev['endDate']);
+    if($endDate === '') {
+        $endDate = $date;
+    }
+    $startTime = trim((string)$ev['startTime']);
+    $endTime = trim((string)$ev['endTime']);
+
+    $multiDay = ($endDate !== $date);
+
+    if($multiDay) {
+        $end = date('Ymd\THis', strtotime($endDate.' 23:59:00'));
+        if($endTime !== '') {
+            $end = date('Ymd\THis', strtotime($endDate.' '.$endTime));
+        }
+        if($startTime === '') {
+            $begin = date('Ymd\THis', strtotime($date.' 00:00:00'));
+            $end = date('Ymd\THis', strtotime($endDate.' 23:59:00'));
+        }
+        else {
+            $begin = date('Ymd\THis', strtotime($date.' '.$startTime));
+        }
+    }
+    else {
+        if($startTime === '') {
+            $begin = date('Ymd\THis', strtotime($date.' 00:00:00'));
+            $end = date('Ymd\THis', strtotime($date.' 23:59:00'));
+        }
+        else {
+            $begin = date('Ymd\THis', strtotime($date.' '.$startTime));
+            if($endTime !== '') {
+                $end = date('Ymd\THis', strtotime($date.' '.$endTime));
+            }
+            else {
+                $end = date('Ymd\THis', strtotime('+120 minutes', strtotime($date.' '.$startTime)));
+            }
+        }
+    }
+
+    return array('begin' => $begin, 'end' => $end);
+}
+
+/**
+ * Build full VCALENDAR body (CRLF).
+ *
+ * @param list<array{id:int,name:string,date:string,endDate:string,startTime:string,endTime:string,wert:int|null,description?:string,location?:string}> $events
+ * @param string|null $websiteUrl
+ * @return string
+ */
+function icalFeedBuild(array $events, $websiteUrl = null) {
+    if($websiteUrl === null && isset($GLOBALS['optionsDB']['WebSiteURL'])) {
+        $websiteUrl = (string)$GLOBALS['optionsDB']['WebSiteURL'];
+    }
+    $websiteUrl = rtrim((string)$websiteUrl, '/');
+    $host = icalFeedUidHost($websiteUrl);
+    $dtstamp = gmdate('Ymd\THis\Z');
+
+    $lines = array(
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//Meldeliste//Kalenderabo//DE',
+        'CALSCALE:GREGORIAN',
+        'METHOD:PUBLISH',
+        'X-WR-CALNAME:Meldeliste',
+    );
+
+    foreach($events as $ev) {
+        $id = (int)$ev['id'];
+        $times = icalFeedEventTimes($ev);
+        $wert = isset($ev['wert']) ? $ev['wert'] : null;
+        $status = ($wert === null || $wert === '' || (int)$wert === 3) ? 'TENTATIVE' : 'CONFIRMED';
+
+        $descParts = array();
+        $descParts[] = 'Rückmeldung: '.icalFeedMeldeLabel($wert);
+        $besch = isset($ev['description']) ? trim((string)$ev['description']) : '';
+        if($besch !== '') {
+            $descParts[] = $besch;
+        }
+        if($websiteUrl !== '') {
+            $descParts[] = $websiteUrl.'/';
+        }
+        $description = implode("\n\n", $descParts);
+        $location = isset($ev['location']) ? trim((string)$ev['location']) : '';
+
+        $vevent = array(
+            'BEGIN:VEVENT',
+            'UID:'.icalFeedUid($id, $host),
+            'DTSTAMP:'.$dtstamp,
+            'SUMMARY:'.icalFeedEscapeText((string)$ev['name']),
+            'DESCRIPTION:'.icalFeedEscapeText($description),
+            'STATUS:'.$status,
+            'DTSTART;TZID=Europe/Berlin:'.$times['begin'],
+            'DTEND;TZID=Europe/Berlin:'.$times['end'],
+        );
+        if($location !== '') {
+            $vevent[] = 'LOCATION:'.icalFeedEscapeText($location);
+        }
+        $vevent[] = 'END:VEVENT';
+
+        foreach($vevent as $line) {
+            $lines[] = icalFeedFoldLine($line);
+        }
+    }
+
+    $lines[] = 'END:VCALENDAR';
+    return implode("\r\n", $lines)."\r\n";
+}
+
+/**
+ * Weak ETag for conditional GET.
+ *
+ * @param int $userId
+ * @param list<array{id:int,wert:int|null}> $events
+ * @param string $from
+ * @param string $to
+ * @return string quoted ETag
+ */
+function icalFeedEtag($userId, array $events, $from, $to) {
+    $parts = array((int)$userId, (string)$from, (string)$to);
+    foreach($events as $ev) {
+        $w = isset($ev['wert']) && $ev['wert'] !== null && $ev['wert'] !== '' ? (int)$ev['wert'] : 0;
+        $parts[] = (int)$ev['id'].':'.$w.':'.(string)$ev['date'].':'.(string)$ev['endDate'].':'.(string)$ev['startTime'].':'.(string)$ev['endTime'];
+    }
+    return '"'.hash('sha256', implode('|', $parts)).'"';
+}
+
+/**
+ * Load filtered feed events for a user (visibility + Nein dropped).
+ *
+ * @param int $userId
+ * @return array{from:string,to:string,events:list<array>}
+ */
+function icalFeedLoadForUser($userId) {
+    $window = icalFeedDateWindow();
+    $events = calendarLoadEventsForUser((int)$userId, $window['from'], $window['to']);
+    $events = icalFeedFilterEvents($events);
+    return array(
+        'from' => $window['from'],
+        'to' => $window['to'],
+        'events' => $events,
+    );
+}

--- a/libs/user.php
+++ b/libs/user.php
@@ -338,7 +338,13 @@ class User
         return $GLOBALS['optionsDB']['WebSiteURL']."/login.php?alink=".$this->activeLink;
     }
     public function getCalendarLink() {
-        return $GLOBALS['optionsDB']['WebSiteURL']."/calendars/MVDcal_".$this->activeLink.".ics";
+        return $GLOBALS['optionsDB']['WebSiteURL']."/ical.php?t=".$this->activeLink;
+    }
+
+    /** webcal:// variant of getCalendarLink() for calendar apps (MELD-127). */
+    public function getCalendarWebcalLink() {
+        $https = $this->getCalendarLink();
+        return (string)preg_replace('#^https?://#i', 'webcal://', $https);
     }
     protected function insert() {
         $sql = sprintf('INSERT INTO `%sUser` (`Nachname`, `Vorname`, `RefID`, `login`, `Passhash`, `activeLink`, `Mitglied`, `Instrument`, `Email`, `Email2`, `Birthday`, `getMail`, `Admin`, `RegisterLead`) VALUES ("%s", "%s", %s, "%s", "%s", "%s", %d, "%d", "%s", "%s", %s, "%d", "%d", "%d");',

--- a/new-musiker.php
+++ b/new-musiker.php
@@ -217,9 +217,6 @@ if($showAppLoginLink) {
     <p class="w3-small">Mit der Meldeliste-App scannen oder Link öffnen. Den Link kannst du auch manuell in der App einfügen.</p>
     <div id="app-login-qr" class="w3-margin-bottom" style="display:inline-block;" data-alink-url="<?php echo htmlspecialchars($appLoginUrl, ENT_QUOTES, 'UTF-8'); ?>"></div>
     <div class="w3-small w3-break"><a href="<?php echo htmlspecialchars($appLoginUrl, ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($appLoginUrl, ENT_QUOTES, 'UTF-8'); ?></a></div>
-<?php if($canEditUsers) { ?>
-    <div class="w3-small w3-margin-top w3-break"><a href="<?php echo htmlspecialchars($n->getCalendarLink(), ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($n->getCalendarLink(), ENT_QUOTES, 'UTF-8'); ?></a></div>
-<?php } ?>
   </div>
   <div class="w3-col s3 l4">&nbsp;</div>
 </div>
@@ -233,7 +230,26 @@ if($showAppLoginLink) {
   new QRCode(el, { text: url, width: 192, height: 192, correctLevel: QRCode.CorrectLevel.M });
 })();
 </script>
-<?php } ?>
+<?php
+    // Personal calendar subscription for self-profile (and when admin views that user)
+    $showCalendarSubscribe = $fill && (int)$n->Index > 0
+        && ($isSelfProfileEdit || (int)$n->Index === $userid || $canEditUsers)
+        && $n->activeLink;
+    if($showCalendarSubscribe) {
+?>
+<div class="w3-row">
+  <div class="w3-col s3 l4">&nbsp;</div>
+  <div class="w3-col s6 l4">
+<?php
+        $calendarSubscribeUid = 'profile-cal';
+        include __DIR__.'/views/calendar/subscribe.php';
+?>
+  </div>
+  <div class="w3-col s3 l4">&nbsp;</div>
+</div>
+<?php
+    }
+} ?>
 <?php if($fill && $canEditUsers) { ?>
     <div id="delmodal" class="w3-modal">
     <div class="w3-modal-content w3-card">

--- a/views/calendar/subscribe.php
+++ b/views/calendar/subscribe.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Personal calendar subscription block (MELD-127).
+ * Expects $n = User with activeLink, or $calendarHttps / $calendarWebcal strings.
+ */
+if(!isset($calendarHttps) || !isset($calendarWebcal)) {
+    if(!isset($n) || !is_object($n) || !(int)$n->Index) {
+        return;
+    }
+    if($n->activeLink === null || $n->activeLink === '') {
+        return;
+    }
+    $calendarHttps = $n->getCalendarLink();
+    $calendarWebcal = $n->getCalendarWebcalLink();
+}
+$calendarHttps = (string)$calendarHttps;
+$calendarWebcal = (string)$calendarWebcal;
+if($calendarHttps === '') {
+    return;
+}
+$uid = isset($calendarSubscribeUid) ? (string)$calendarSubscribeUid : 'cal-sub';
+?>
+<div class="w3-panel w3-border w3-padding w3-margin-top <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorInputBackground'], ENT_QUOTES, 'UTF-8'); ?>">
+  <h3><i class="fas fa-calendar-plus" aria-hidden="true"></i> Kalender abonnieren</h3>
+  <p class="w3-small">
+    Trage den Link in Google Kalender, Apple Kalender oder Outlook als <b>Kalender-URL / Abonnement</b> ein.
+    Neue und geänderte Termine erscheinen automatisch — das Aktualisierungsintervall steuert dein Kalender (oft erst nach einigen Stunden).
+    Zu- und Absagen weiterhin hier in der Meldeliste.
+  </p>
+  <p class="w3-small w3-break">
+    <label for="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-https"><b>HTTPS</b></label><br>
+    <input id="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-https" class="w3-input w3-border" type="text" readonly value="<?php echo htmlspecialchars($calendarHttps, ENT_QUOTES, 'UTF-8'); ?>">
+  </p>
+  <p class="w3-small w3-break">
+    <label for="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-webcal"><b>webcal</b> (manche Apps)</label><br>
+    <input id="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-webcal" class="w3-input w3-border" type="text" readonly value="<?php echo htmlspecialchars($calendarWebcal, ENT_QUOTES, 'UTF-8'); ?>">
+  </p>
+  <p class="w3-margin-top">
+    <button type="button" class="w3-button w3-border <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnSubmit'], ENT_QUOTES, 'UTF-8'); ?>" data-copy-target="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-https">HTTPS kopieren</button>
+    <button type="button" class="w3-button w3-border" data-copy-target="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-webcal">webcal kopieren</button>
+  </p>
+  <p class="w3-small"><a href="help.php#help-kalender-abo">Hilfe: Kalender abonnieren</a></p>
+</div>
+<script>
+(function () {
+  document.querySelectorAll('[data-copy-target]').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      var id = btn.getAttribute('data-copy-target');
+      var el = id ? document.getElementById(id) : null;
+      if(!el) return;
+      var text = el.value || '';
+      if(navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(function () {
+          btn.textContent = 'Kopiert';
+          setTimeout(function () {
+            btn.textContent = id.indexOf('webcal') >= 0 ? 'webcal kopieren' : 'HTTPS kopieren';
+          }, 1500);
+        });
+        return;
+      }
+      el.select();
+      try { document.execCommand('copy'); } catch (e) {}
+    });
+  });
+})();
+</script>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -41,7 +41,7 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 <li><i class="far fa-calendar-alt"></i> <b>Termine</b> – bevorstehende Termine und schnelles Melden</li>
-<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details)</li>
+<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details); unten Link zum Abonnieren in Google/Apple/Outlook</li>
 <li><i class="fas fa-envelope"></i> <b>Meine Nachrichten</b> – empfangene Mails aus der Meldeliste (Badge bei ungelesenen)</li>
 <li><i class="fas fa-users"></i> <b>Mein Register</b> – Rückmeldungen deines Registers</li>
 '.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir zugeordnetes bzw. ausgeliehenes Inventar</li>' : '').'
@@ -115,6 +115,23 @@ $sections[] = array(
 <p>Unter <b>Gruppenzugehörigkeit</b> siehst du, welchen Rollen (z.&nbsp;B. Alle Musiker), welchem Register und welchen benannten Gruppen du zugeordnet bist – relevant für Mail und Termin-Sichtbarkeit.</p>
 <p>Falls du ein Einmal-Passwort erhalten hast, wirst du nach dem Login zum Ändern des Passworts aufgefordert.</p>
 <p>Die Android-App speichert nach dem Login ein Gerätetoken und meldet dich beim nächsten Öffnen automatisch an. Abmelden in der App widerruft dieses Token.</p>
+<p>Unter <b>Kalender abonnieren</b> findest du deinen persönlichen ICS-Link für Google, Apple oder Outlook (siehe auch <a href="#help-kalender-abo">Kalender abonnieren</a>).</p>
+'
+);
+
+$sections[] = array(
+    'id' => 'kalender-abo',
+    'title' => 'Kalender abonnieren',
+    'body' => '
+<p>Du kannst deine sichtbaren Meldeliste-Termine in deinen privaten Kalender (Google, Apple, Outlook, …) <b>abonnieren</b>. Der Link steht unter <b>Mein Profil</b> und auf der Seite <b>Kalender</b>.</p>
+<p><b>Einweg:</b> Termine und dein Melde-Status (zugesagt / vielleicht / ohne) werden in den Kalender übernommen. Zu- und Absagen änderst du weiterhin in der Meldeliste — nicht in der Kalender-App.</p>
+<p><b>Aktualisierung:</b> Wie oft der Feed neu geladen wird, steuert dein Kalender-Anbieter (oft erst nach einigen Stunden). Darauf hat die Meldeliste keinen Einfluss.</p>
+<ul>
+<li><b>Google Kalender</b> (am PC): Weitere Kalender → <b>Über URL hinzufügen</b> → HTTPS-Link einfügen.</li>
+<li><b>Apple</b> (iOS): Einstellungen → Kalender → Accounts → Account hinzufügen → Andere → <b>Kalenderabonnement</b>; oder in der Kalender-App auf dem Mac: Ablage → Neues Kalenderabonnement.</li>
+<li><b>Outlook</b>: Kalender hinzufügen → Aus dem Internet / Abonnieren → HTTPS- oder webcal-Link.</li>
+</ul>
+<p>Abgesagte Termine (Nein) erscheinen nicht im Abo. Der Link ist persönlich — nicht weitergeben.</p>
 '
 );
 


### PR DESCRIPTION
## Summary
- Persönlicher ICS-Feed on demand (`ical.php?t=…`), keine Per-User-Datei-Rebuilds
- Sichtbarkeit wie Monatsansicht; Nein ausgeblendet; stabile UIDs + ETag
- Abonnieren-Block in Profil und Kalender; Hilfe Google/Apple/Outlook

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-127

## Test plan
- [ ] Profil / Kalender: HTTPS- und webcal-Link kopieren
- [ ] URL in Browser öffnen → `text/calendar` mit Terminen
- [ ] Ungültiges `t` → 404
- [ ] Nach Melde-Änderung (Ja) erscheint Status im Feed (ggf. Cache/ETag beachten)


Made with [Cursor](https://cursor.com)