### PR TITLE
MELD-9: Druckbarer Terminkalender

### DIFF
--- a/calendar-print.php
+++ b/calendar-print.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Printable appointment table for a month (MELD-9).
+ * Printable appointment table — all upcoming visible events (MELD-9).
  */
 require_once __DIR__.'/libs/sessionBootstrap.php';
 meldeConfigureSession();
@@ -14,11 +14,20 @@ requireLoggedInOrRedirect();
 $userId = (int)$_SESSION['userid'];
 $ym = calendarParseYearMonth(isset($_GET['ym']) ? $_GET['ym'] : null);
 $bounds = calendarMonthBounds($ym);
-$events = calendarLoadEventsForUser($userId, $bounds['monthStart'], $bounds['monthEnd']);
-$events = calendarEventsOverlappingRange($events, $bounds['monthStart'], $bounds['monthEnd']);
+
+$window = icalFeedDateWindow();
+$fromDate = date('Y-m-d');
+$toDate = $window['to'];
+if($toDate < $fromDate) {
+    $toDate = $fromDate;
+}
+
+$events = calendarLoadEventsForUser($userId, $fromDate, $toDate);
+$events = calendarEventsOverlappingRange($events, $fromDate, $toDate);
 
 $orgName = isset($GLOBALS['optionsDB']['orgName']) ? (string)$GLOBALS['optionsDB']['orgName'] : '';
 $printDate = germanDate(date('Y-m-d'), 1);
+$rangeLabel = 'ab '.germanDate($fromDate, 1).' bis '.germanDate($toDate, 1);
 $nEvents = count($events);
 $assetV = isset($GLOBALS['version']['Hash']) ? $GLOBALS['version']['Hash'] : '0';
 $cssMtime = @filemtime(__DIR__.'/styles/custom.css');
@@ -31,7 +40,7 @@ header('Content-Type: text/html; charset=utf-8');
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Terminkalender – <?php echo htmlspecialchars($bounds['label'], ENT_QUOTES, 'UTF-8'); ?></title>
+  <title>Terminkalender – kommende Termine</title>
   <link rel="stylesheet" href="<?php echo htmlspecialchars($cssUrl, ENT_QUOTES, 'UTF-8'); ?>">
 </head>
 <body class="meld-cal-print">

--- a/calendar-print.php
+++ b/calendar-print.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Printable appointment table for a month (MELD-9).
+ */
+require_once __DIR__.'/libs/sessionBootstrap.php';
+meldeConfigureSession();
+$_SESSION['page'] = 'calendar';
+$_SESSION['adminpage'] = false;
+
+include_once 'common/include.php';
+mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($GLOBALS['conn']));
+requireLoggedInOrRedirect();
+
+$userId = (int)$_SESSION['userid'];
+$ym = calendarParseYearMonth(isset($_GET['ym']) ? $_GET['ym'] : null);
+$bounds = calendarMonthBounds($ym);
+$events = calendarLoadEventsForUser($userId, $bounds['monthStart'], $bounds['monthEnd']);
+$events = calendarEventsOverlappingRange($events, $bounds['monthStart'], $bounds['monthEnd']);
+
+$orgName = isset($GLOBALS['optionsDB']['orgName']) ? (string)$GLOBALS['optionsDB']['orgName'] : '';
+$printDate = germanDate(date('Y-m-d'), 1);
+$nEvents = count($events);
+$assetV = isset($GLOBALS['version']['Hash']) ? $GLOBALS['version']['Hash'] : '0';
+$cssMtime = @filemtime(__DIR__.'/styles/custom.css');
+$cssUrl = 'styles/custom.css?'.$assetV.'-'.$cssMtime;
+$backYm = htmlspecialchars($bounds['ym'], ENT_QUOTES, 'UTF-8');
+
+header('Content-Type: text/html; charset=utf-8');
+?><!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Terminkalender – <?php echo htmlspecialchars($bounds['label'], ENT_QUOTES, 'UTF-8'); ?></title>
+  <link rel="stylesheet" href="<?php echo htmlspecialchars($cssUrl, ENT_QUOTES, 'UTF-8'); ?>">
+</head>
+<body class="meld-cal-print">
+  <div class="meld-cal-print-toolbar no-print">
+    <a class="meld-cal-print-btn" href="calendar.php?ym=<?php echo $backYm; ?>">Zur&uuml;ck zum Kalender</a>
+    <button type="button" class="meld-cal-print-btn" onclick="window.print()">Drucken / als PDF speichern</button>
+  </div>
+
+<?php include __DIR__.'/views/calendar/print.php'; ?>
+</body>
+</html>

--- a/calendar.php
+++ b/calendar.php
@@ -39,54 +39,85 @@ $yearFrom = max(1970, min($calYear, (int)date('Y')) - 10);
 $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
 ?>
 <style>
+.meld-cal-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 1rem 1.25rem 0.35rem;
+  max-width: 72rem;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
 .meld-cal-nav {
-  display: flex; flex-wrap: wrap; justify-content: center; align-items: flex-start;
-  gap: 1rem 1.5rem; position: relative;
-}
-.meld-cal-nav-actions {
-  display: inline-flex; align-items: center; gap: 0.35rem;
-  align-self: center;
-}
-@media (min-width: 901px) {
-  .meld-cal-nav-actions {
-    position: absolute; left: 0; top: 50%; transform: translateY(-50%);
-  }
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 1rem 1.5rem;
+  padding: 0.75rem 1.25rem 1rem;
+  max-width: 72rem;
+  margin: 0 auto;
+  box-sizing: border-box;
 }
 .meld-cal-nav-icon,
 a.w3-button.meld-cal-nav-icon,
 button.w3-button.meld-cal-nav-icon {
-  margin: 0; padding: 0; line-height: 1;
-  width: 2.5rem; height: 2.5rem; min-width: 2.5rem;
-  display: inline-flex; align-items: center; justify-content: center;
-  border-radius: 50% !important; box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  line-height: 1;
+  width: 2.75rem;
+  height: 2.75rem;
+  min-width: 2.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50% !important;
+  box-sizing: border-box;
 }
-.meld-cal-spinner { display: inline-flex; flex-direction: column; align-items: center; min-width: 9rem; }
+.meld-cal-spinner {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 9rem;
+}
 .meld-cal-spinner select {
-  text-align: center; text-align-last: center; font-weight: bold;
-  padding: 8px 6px; margin: 0; border-radius: 0; width: 100%;
+  text-align: center;
+  text-align-last: center;
+  font-weight: bold;
+  padding: 8px 6px;
+  margin: 0;
+  border-radius: 0;
+  width: 100%;
 }
 .meld-cal-spinner .meld-cal-step {
-  margin: 0; padding: 4px 10px; width: auto; min-width: 2.25rem;
+  margin: 0;
+  padding: 4px 10px;
+  width: auto;
+  min-width: 2.25rem;
   line-height: 1;
 }
 .meld-cal-nav-today { align-self: center; }
-#calSubscribePanel[hidden] { display: none !important; }
+#calSubscribeModal .w3-modal-content {
+  max-width: 36rem;
+  margin: 4vh auto;
+}
 </style>
 
-<div class="w3-container w3-padding-16 meld-cal-nav">
-  <div class="meld-cal-nav-actions">
+<div class="meld-cal-toolbar" role="toolbar" aria-label="Kalender-Aktionen">
 <?php if($showCalendarSubscribe) { ?>
-    <button type="button" id="calSubscribeToggle" class="w3-button w3-border meld-cal-nav-icon"
-            title="Kalender abonnieren" aria-label="Kalender abonnieren" aria-expanded="false" aria-controls="calSubscribePanel">
-      <i class="fas fa-info-circle" aria-hidden="true"></i>
-    </button>
+  <button type="button" id="calSubscribeToggle" class="w3-button w3-border meld-cal-nav-icon"
+          title="Kalender abonnieren" aria-label="Kalender abonnieren" aria-haspopup="dialog" aria-controls="calSubscribeModal">
+    <i class="fas fa-info-circle" aria-hidden="true"></i>
+  </button>
 <?php } ?>
-    <a class="w3-button w3-border meld-cal-nav-icon"
-       href="calendar-print.php?ym=<?php echo htmlspecialchars($bounds['ym'], ENT_QUOTES, 'UTF-8'); ?>"
-       title="Terminkalender drucken" aria-label="Terminkalender drucken" target="_blank" rel="noopener">
-      <i class="fas fa-print" aria-hidden="true"></i>
-    </a>
-  </div>
+  <a class="w3-button w3-border meld-cal-nav-icon"
+     href="calendar-print.php?ym=<?php echo htmlspecialchars($bounds['ym'], ENT_QUOTES, 'UTF-8'); ?>"
+     title="Terminkalender drucken" aria-label="Terminkalender drucken" target="_blank" rel="noopener">
+    <i class="fas fa-print" aria-hidden="true"></i>
+  </a>
+</div>
+
+<div class="meld-cal-nav">
   <div class="meld-cal-spinner" role="group" aria-label="Monat">
     <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriger Monat" aria-label="Früherer Monat"><i class="fas fa-chevron-up"></i></a>
     <select id="calMonthSelect" class="w3-select w3-border" aria-label="Monat wählen">
@@ -130,24 +161,32 @@ include __DIR__.'/views/calendar/month.php';
 if($showCalendarSubscribe) {
     $n = $calUser;
     $calendarSubscribeUid = 'page-cal';
+    $calendarSubscribeInModal = true;
 ?>
-<div id="calSubscribePanel" class="w3-container w3-padding-16" style="max-width:40rem;margin:0 auto;" hidden>
+<div id="calSubscribeModal" class="w3-modal" role="dialog" aria-modal="true" aria-labelledby="calSubscribeModalTitle" style="display:none;"
+     onclick="if(event.target===this){ this.style.display='none'; }">
+  <div class="w3-modal-content w3-card">
+    <header class="w3-container <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorTitleBar'], ENT_QUOTES, 'UTF-8'); ?>">
+      <button type="button" class="w3-button w3-display-topright" id="calSubscribeClose" aria-label="Schließen">&times;</button>
+      <h2 id="calSubscribeModalTitle"><i class="fas fa-calendar-plus" aria-hidden="true"></i> Kalender abonnieren</h2>
+    </header>
+    <div class="w3-container w3-padding">
 <?php include __DIR__.'/views/calendar/subscribe.php'; ?>
+    </div>
+  </div>
 </div>
 <script>
 (function() {
     var toggle = document.getElementById('calSubscribeToggle');
-    var panel = document.getElementById('calSubscribePanel');
-    if(!toggle || !panel) return;
-    toggle.addEventListener('click', function () {
-        var open = panel.hasAttribute('hidden');
-        if(open) {
-            panel.removeAttribute('hidden');
-            toggle.setAttribute('aria-expanded', 'true');
-        } else {
-            panel.setAttribute('hidden', '');
-            toggle.setAttribute('aria-expanded', 'false');
-        }
+    var modal = document.getElementById('calSubscribeModal');
+    var closeBtn = document.getElementById('calSubscribeClose');
+    if(!toggle || !modal) return;
+    function openSub() { modal.style.display = 'block'; }
+    function closeSub() { modal.style.display = 'none'; }
+    toggle.addEventListener('click', openSub);
+    if(closeBtn) closeBtn.addEventListener('click', closeSub);
+    document.addEventListener('keydown', function (e) {
+        if(e.key === 'Escape' && modal.style.display === 'block') closeSub();
     });
 })();
 </script>

--- a/calendar.php
+++ b/calendar.php
@@ -52,8 +52,13 @@ $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
     position: absolute; left: 0; top: 50%; transform: translateY(-50%);
   }
 }
-.meld-cal-nav-icon {
-  margin: 0; padding: 8px 12px; line-height: 1; min-width: 2.5rem; text-align: center;
+.meld-cal-nav-icon,
+a.w3-button.meld-cal-nav-icon,
+button.w3-button.meld-cal-nav-icon {
+  margin: 0; padding: 0; line-height: 1;
+  width: 2.5rem; height: 2.5rem; min-width: 2.5rem;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 50% !important; box-sizing: border-box;
 }
 .meld-cal-spinner { display: inline-flex; flex-direction: column; align-items: center; min-width: 9rem; }
 .meld-cal-spinner select {
@@ -116,21 +121,6 @@ $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
     }
     if(monthSel) monthSel.addEventListener('change', goYm);
     if(yearSel) yearSel.addEventListener('change', goYm);
-
-    var toggle = document.getElementById('calSubscribeToggle');
-    var panel = document.getElementById('calSubscribePanel');
-    if(toggle && panel) {
-        toggle.addEventListener('click', function () {
-            var open = panel.hasAttribute('hidden');
-            if(open) {
-                panel.removeAttribute('hidden');
-                toggle.setAttribute('aria-expanded', 'true');
-            } else {
-                panel.setAttribute('hidden', '');
-                toggle.setAttribute('aria-expanded', 'false');
-            }
-        });
-    }
 })();
 </script>
 
@@ -144,6 +134,23 @@ if($showCalendarSubscribe) {
 <div id="calSubscribePanel" class="w3-container w3-padding-16" style="max-width:40rem;margin:0 auto;" hidden>
 <?php include __DIR__.'/views/calendar/subscribe.php'; ?>
 </div>
+<script>
+(function() {
+    var toggle = document.getElementById('calSubscribeToggle');
+    var panel = document.getElementById('calSubscribePanel');
+    if(!toggle || !panel) return;
+    toggle.addEventListener('click', function () {
+        var open = panel.hasAttribute('hidden');
+        if(open) {
+            panel.removeAttribute('hidden');
+            toggle.setAttribute('aria-expanded', 'true');
+        } else {
+            panel.setAttribute('hidden', '');
+            toggle.setAttribute('aria-expanded', 'false');
+        }
+    });
+})();
+</script>
 <?php
 }
 

--- a/calendar.php
+++ b/calendar.php
@@ -14,6 +14,10 @@ $bounds = calendarMonthBounds($ym);
 $events = calendarLoadEventsForUser($userId, $bounds['gridStart'], $bounds['gridEnd']);
 $byDay = calendarEventsByDay($events, $bounds['gridStart'], $bounds['gridEnd']);
 
+$calUser = new User();
+$calUser->load_by_id($userId);
+$showCalendarSubscribe = ((int)$calUser->Index > 0 && $calUser->activeLink);
+
 include 'common/header.php';
 ?>
 <script src="<?php echo assetUrl('js/melde.js'); ?>"></script>
@@ -35,7 +39,22 @@ $yearFrom = max(1970, min($calYear, (int)date('Y')) - 10);
 $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
 ?>
 <style>
-.meld-cal-nav { display: flex; flex-wrap: wrap; justify-content: center; align-items: flex-start; gap: 1rem 1.5rem; }
+.meld-cal-nav {
+  display: flex; flex-wrap: wrap; justify-content: center; align-items: flex-start;
+  gap: 1rem 1.5rem; position: relative;
+}
+.meld-cal-nav-actions {
+  display: inline-flex; align-items: center; gap: 0.35rem;
+  align-self: center;
+}
+@media (min-width: 901px) {
+  .meld-cal-nav-actions {
+    position: absolute; left: 0; top: 50%; transform: translateY(-50%);
+  }
+}
+.meld-cal-nav-icon {
+  margin: 0; padding: 8px 12px; line-height: 1; min-width: 2.5rem; text-align: center;
+}
 .meld-cal-spinner { display: inline-flex; flex-direction: column; align-items: center; min-width: 9rem; }
 .meld-cal-spinner select {
   text-align: center; text-align-last: center; font-weight: bold;
@@ -46,9 +65,23 @@ $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
   line-height: 1;
 }
 .meld-cal-nav-today { align-self: center; }
+#calSubscribePanel[hidden] { display: none !important; }
 </style>
 
 <div class="w3-container w3-padding-16 meld-cal-nav">
+  <div class="meld-cal-nav-actions">
+<?php if($showCalendarSubscribe) { ?>
+    <button type="button" id="calSubscribeToggle" class="w3-button w3-border meld-cal-nav-icon"
+            title="Kalender abonnieren" aria-label="Kalender abonnieren" aria-expanded="false" aria-controls="calSubscribePanel">
+      <i class="fas fa-info-circle" aria-hidden="true"></i>
+    </button>
+<?php } ?>
+    <a class="w3-button w3-border meld-cal-nav-icon"
+       href="calendar-print.php?ym=<?php echo htmlspecialchars($bounds['ym'], ENT_QUOTES, 'UTF-8'); ?>"
+       title="Terminkalender drucken" aria-label="Terminkalender drucken" target="_blank" rel="noopener">
+      <i class="fas fa-print" aria-hidden="true"></i>
+    </a>
+  </div>
   <div class="meld-cal-spinner" role="group" aria-label="Monat">
     <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriger Monat" aria-label="Früherer Monat"><i class="fas fa-chevron-up"></i></a>
     <select id="calMonthSelect" class="w3-select w3-border" aria-label="Monat wählen">
@@ -68,7 +101,6 @@ $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
     <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächstes Jahr" aria-label="Späteres Jahr"><i class="fas fa-chevron-down"></i></a>
   </div>
   <a class="w3-button w3-border meld-cal-nav-today" href="calendar.php" title="Aktueller Monat">Heute</a>
-  <a class="w3-button w3-border" href="calendar-print.php?ym=<?php echo htmlspecialchars($bounds['ym'], ENT_QUOTES, 'UTF-8'); ?>" title="Terminkalender drucken" target="_blank" rel="noopener"><i class="fas fa-print" aria-hidden="true"></i> Drucken</a>
 </div>
 <script>
 (function() {
@@ -84,20 +116,35 @@ $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
     }
     if(monthSel) monthSel.addEventListener('change', goYm);
     if(yearSel) yearSel.addEventListener('change', goYm);
+
+    var toggle = document.getElementById('calSubscribeToggle');
+    var panel = document.getElementById('calSubscribePanel');
+    if(toggle && panel) {
+        toggle.addEventListener('click', function () {
+            var open = panel.hasAttribute('hidden');
+            if(open) {
+                panel.removeAttribute('hidden');
+                toggle.setAttribute('aria-expanded', 'true');
+            } else {
+                panel.setAttribute('hidden', '');
+                toggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
 })();
 </script>
 
 <?php
 include __DIR__.'/views/calendar/month.php';
 
-$calUser = new User();
-$calUser->load_by_id($userId);
-if((int)$calUser->Index > 0 && $calUser->activeLink) {
+if($showCalendarSubscribe) {
     $n = $calUser;
     $calendarSubscribeUid = 'page-cal';
-    echo '<div class="w3-container w3-padding-16" style="max-width:40rem;margin:0 auto;">';
-    include __DIR__.'/views/calendar/subscribe.php';
-    echo '</div>';
+?>
+<div id="calSubscribePanel" class="w3-container w3-padding-16" style="max-width:40rem;margin:0 auto;" hidden>
+<?php include __DIR__.'/views/calendar/subscribe.php'; ?>
+</div>
+<?php
 }
 
 include 'common/footer.php';

--- a/calendar.php
+++ b/calendar.php
@@ -68,6 +68,7 @@ $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
     <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächstes Jahr" aria-label="Späteres Jahr"><i class="fas fa-chevron-down"></i></a>
   </div>
   <a class="w3-button w3-border meld-cal-nav-today" href="calendar.php" title="Aktueller Monat">Heute</a>
+  <a class="w3-button w3-border" href="calendar-print.php?ym=<?php echo htmlspecialchars($bounds['ym'], ENT_QUOTES, 'UTF-8'); ?>" title="Terminkalender drucken" target="_blank" rel="noopener"><i class="fas fa-print" aria-hidden="true"></i> Drucken</a>
 </div>
 <script>
 (function() {

--- a/calendar.php
+++ b/calendar.php
@@ -39,26 +39,37 @@ $yearFrom = max(1970, min($calYear, (int)date('Y')) - 10);
 $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
 ?>
 <style>
+.meld-cal-page {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0 16px 1rem;
+  box-sizing: border-box;
+  width: 100%;
+}
 .meld-cal-toolbar {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: flex-start;
-  gap: 0.65rem;
-  padding: 1rem 16px 0.5rem;
+  justify-content: space-between;
+  gap: 0.75rem 1.25rem;
+  padding: 0.75rem 0;
   margin: 0;
   width: 100%;
-  max-width: none;
   box-sizing: border-box;
+}
+.meld-cal-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
 }
 .meld-cal-nav {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
-  align-items: flex-start;
-  gap: 1rem 1.5rem;
-  padding: 0.75rem 1.25rem 1rem;
-  max-width: 72rem;
-  margin: 0 auto;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem 1rem;
+  margin: 0 0 0 auto;
+  padding: 0;
   box-sizing: border-box;
 }
 .meld-cal-nav-icon,
@@ -80,7 +91,7 @@ button.w3-button.meld-cal-nav-icon {
   display: inline-flex;
   flex-direction: column;
   align-items: center;
-  min-width: 9rem;
+  min-width: 8rem;
 }
 .meld-cal-spinner select {
   text-align: center;
@@ -99,46 +110,52 @@ button.w3-button.meld-cal-nav-icon {
   line-height: 1;
 }
 .meld-cal-nav-today { align-self: center; }
+.meld-cal-page .meld-cal-wrap {
+  padding-left: 0;
+  padding-right: 0;
+}
 #calSubscribeModal .w3-modal-content {
   max-width: 36rem;
   margin: 4vh auto;
 }
 </style>
 
-<div class="meld-cal-toolbar" role="toolbar" aria-label="Kalender-Aktionen">
+<div class="meld-cal-page">
+<div class="meld-cal-toolbar" role="toolbar" aria-label="Kalender-Navigation">
+  <div class="meld-cal-actions">
 <?php if($showCalendarSubscribe) { ?>
-  <button type="button" id="calSubscribeToggle" class="w3-button w3-border meld-cal-nav-icon"
-          title="Kalender abonnieren" aria-label="Kalender abonnieren" aria-haspopup="dialog" aria-controls="calSubscribeModal">
-    <i class="fas fa-info-circle" aria-hidden="true"></i>
-  </button>
+    <button type="button" id="calSubscribeToggle" class="w3-button w3-border meld-cal-nav-icon"
+            title="Kalender abonnieren" aria-label="Kalender abonnieren" aria-haspopup="dialog" aria-controls="calSubscribeModal">
+      <i class="fas fa-info-circle" aria-hidden="true"></i>
+    </button>
 <?php } ?>
-  <a class="w3-button w3-border meld-cal-nav-icon"
-     href="calendar-print.php?ym=<?php echo htmlspecialchars($bounds['ym'], ENT_QUOTES, 'UTF-8'); ?>"
-     title="Terminkalender drucken" aria-label="Terminkalender drucken" target="_blank" rel="noopener">
-    <i class="fas fa-print" aria-hidden="true"></i>
-  </a>
-</div>
-
-<div class="meld-cal-nav">
-  <div class="meld-cal-spinner" role="group" aria-label="Monat">
-    <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriger Monat" aria-label="Früherer Monat"><i class="fas fa-chevron-up"></i></a>
-    <select id="calMonthSelect" class="w3-select w3-border" aria-label="Monat wählen">
+    <a class="w3-button w3-border meld-cal-nav-icon"
+       href="calendar-print.php?ym=<?php echo htmlspecialchars($bounds['ym'], ENT_QUOTES, 'UTF-8'); ?>"
+       title="Terminkalender drucken" aria-label="Terminkalender drucken" target="_blank" rel="noopener">
+      <i class="fas fa-print" aria-hidden="true"></i>
+    </a>
+  </div>
+  <div class="meld-cal-nav">
+    <div class="meld-cal-spinner" role="group" aria-label="Monat">
+      <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriger Monat" aria-label="Früherer Monat"><i class="fas fa-chevron-up"></i></a>
+      <select id="calMonthSelect" class="w3-select w3-border" aria-label="Monat wählen">
 <?php foreach($monthNames as $num => $name) { ?>
-      <option value="<?php echo (int)$num; ?>"<?php echo $num === $calMonth ? ' selected' : ''; ?>><?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8'); ?></option>
+        <option value="<?php echo (int)$num; ?>"<?php echo $num === $calMonth ? ' selected' : ''; ?>><?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8'); ?></option>
 <?php } ?>
-    </select>
-    <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächster Monat" aria-label="Späterer Monat"><i class="fas fa-chevron-down"></i></a>
-  </div>
-  <div class="meld-cal-spinner" role="group" aria-label="Jahr">
-    <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriges Jahr" aria-label="Früheres Jahr"><i class="fas fa-chevron-up"></i></a>
-    <select id="calYearSelect" class="w3-select w3-border" aria-label="Jahr wählen">
+      </select>
+      <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächster Monat" aria-label="Späterer Monat"><i class="fas fa-chevron-down"></i></a>
+    </div>
+    <div class="meld-cal-spinner" role="group" aria-label="Jahr">
+      <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['prevYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Vorheriges Jahr" aria-label="Früheres Jahr"><i class="fas fa-chevron-up"></i></a>
+      <select id="calYearSelect" class="w3-select w3-border" aria-label="Jahr wählen">
 <?php for($y = $yearFrom; $y <= $yearTo; $y++) { ?>
-      <option value="<?php echo $y; ?>"<?php echo $y === $calYear ? ' selected' : ''; ?>><?php echo $y; ?></option>
+        <option value="<?php echo $y; ?>"<?php echo $y === $calYear ? ' selected' : ''; ?>><?php echo $y; ?></option>
 <?php } ?>
-    </select>
-    <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächstes Jahr" aria-label="Späteres Jahr"><i class="fas fa-chevron-down"></i></a>
+      </select>
+      <a class="w3-button w3-border meld-cal-step" href="calendar.php?ym=<?php echo htmlspecialchars($bounds['nextYearYm'], ENT_QUOTES, 'UTF-8'); ?>" title="Nächstes Jahr" aria-label="Späteres Jahr"><i class="fas fa-chevron-down"></i></a>
+    </div>
+    <a class="w3-button w3-border meld-cal-nav-today" href="calendar.php" title="Aktueller Monat">Heute</a>
   </div>
-  <a class="w3-button w3-border meld-cal-nav-today" href="calendar.php" title="Aktueller Monat">Heute</a>
 </div>
 <script>
 (function() {
@@ -159,7 +176,9 @@ button.w3-button.meld-cal-nav-icon {
 
 <?php
 include __DIR__.'/views/calendar/month.php';
-
+?>
+</div>
+<?php
 if($showCalendarSubscribe) {
     $n = $calUser;
     $calendarSubscribeUid = 'page-cal';

--- a/calendar.php
+++ b/calendar.php
@@ -42,10 +42,12 @@ $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
 .meld-cal-toolbar {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 0.65rem;
-  padding: 1rem 1.25rem 0.35rem;
-  max-width: 72rem;
-  margin: 0 auto;
+  padding: 1rem 16px 0.5rem;
+  margin: 0;
+  width: 100%;
+  max-width: none;
   box-sizing: border-box;
 }
 .meld-cal-nav {

--- a/common/include.php
+++ b/common/include.php
@@ -1,5 +1,8 @@
 <?php
 
+// Appointment wall-clock times and calendar "today" are Europe/Berlin (ICS TZID).
+date_default_timezone_set('Europe/Berlin');
+
 include "common/config.php";
 if(isset($GLOBALS['conn']) && $GLOBALS['conn']) {
     mysqli_set_charset($GLOBALS['conn'], 'utf8mb4');

--- a/libs/calendarView.php
+++ b/libs/calendarView.php
@@ -237,3 +237,91 @@ function calendarFormatTimeShort($time) {
     }
     return $time;
 }
+
+/**
+ * Melde status label for print / lists (MELD-9).
+ *
+ * @param int|null $wert
+ * @return string
+ */
+function calendarMeldeLabel($wert) {
+    if($wert === null || $wert === '') {
+        return 'offen';
+    }
+    $w = (int)$wert;
+    if($w === 1) {
+        return 'zugesagt';
+    }
+    if($w === 2) {
+        return 'abgesagt';
+    }
+    if($w === 3) {
+        return 'vielleicht';
+    }
+    return 'offen';
+}
+
+/**
+ * Keep events whose date range overlaps [fromDate, toDate] (inclusive Y-m-d).
+ *
+ * @param list<array{id:int,date:string,endDate:string}> $events
+ * @param string $fromDate
+ * @param string $toDate
+ * @return list<array>
+ */
+function calendarEventsOverlappingRange(array $events, $fromDate, $toDate) {
+    $from = DateTimeImmutable::createFromFormat('Y-m-d', (string)$fromDate);
+    $to = DateTimeImmutable::createFromFormat('Y-m-d', (string)$toDate);
+    if($from === false || $to === false) {
+        return array();
+    }
+    $out = array();
+    foreach($events as $ev) {
+        $start = DateTimeImmutable::createFromFormat('Y-m-d', (string)$ev['date']);
+        if($start === false) {
+            continue;
+        }
+        $end = DateTimeImmutable::createFromFormat('Y-m-d', (string)$ev['endDate']);
+        if($end === false || $end < $start) {
+            $end = $start;
+        }
+        if($end < $from || $start > $to) {
+            continue;
+        }
+        $out[] = $ev;
+    }
+    return $out;
+}
+
+/**
+ * Human date for print table (single day or span).
+ *
+ * @param array{date:string,endDate:string} $ev
+ * @return string
+ */
+function calendarPrintDateLabel(array $ev) {
+    $date = (string)$ev['date'];
+    $endDate = trim((string)$ev['endDate']);
+    if($endDate === '' || $endDate === $date) {
+        return (string)germanDate($date, 1);
+    }
+    return (string)germanDateSpan($date, $endDate);
+}
+
+/**
+ * Time range for print table (HH:MM or HH:MM–HH:MM).
+ *
+ * @param array{startTime:string,endTime:string} $ev
+ * @return string
+ */
+function calendarPrintTimeLabel(array $ev) {
+    $start = calendarFormatTimeShort(isset($ev['startTime']) ? $ev['startTime'] : '');
+    $end = calendarFormatTimeShort(isset($ev['endTime']) ? $ev['endTime'] : '');
+    if($start === '' && $end === '') {
+        return '';
+    }
+    if($start !== '' && $end !== '') {
+        return $start.'–'.$end;
+    }
+    return $start !== '' ? $start : $end;
+}

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1412,6 +1412,121 @@ body.insurance-print {
   }
 }
 
+/* Calendar print table (MELD-9) */
+body.meld-cal-print {
+  margin: 0;
+  padding: 1.25rem 1.5rem 2rem;
+  font-family: Georgia, "Times New Roman", Times, serif;
+  font-size: 11pt;
+  line-height: 1.35;
+  color: #1a1a1a;
+  background: #fff;
+}
+
+.meld-cal-print-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.25rem;
+}
+
+.meld-cal-print-btn {
+  display: inline-block;
+  font-family: system-ui, -apple-system, sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.3;
+  text-decoration: none;
+  color: #111;
+  background: #f5f5f5;
+  border: 1px solid #888;
+  border-radius: 2px;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+}
+
+.meld-cal-print-btn:hover {
+  background: #e8e8e8;
+}
+
+.meld-cal-print-header {
+  margin-bottom: 1.25rem;
+}
+
+.meld-cal-print-org {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.meld-cal-print-header h1 {
+  margin: 0 0 0.35rem;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.meld-cal-print-meta {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #333;
+}
+
+.meld-cal-print-empty {
+  margin: 1rem 0;
+  font-style: italic;
+}
+
+.meld-cal-print-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 10pt;
+}
+
+.meld-cal-print-table th,
+.meld-cal-print-table td {
+  border: 1px solid #666;
+  padding: 0.35rem 0.5rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.meld-cal-print-table thead th {
+  background: #efefef;
+  font-weight: 700;
+  border-bottom-width: 2px;
+}
+
+.meld-cal-print-table tbody tr:nth-child(even) {
+  background: #fafafa;
+}
+
+.meld-cal-print-time {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+@media print {
+  body.meld-cal-print {
+    padding: 0;
+    font-size: 10pt;
+  }
+
+  .no-print {
+    display: none !important;
+  }
+
+  .meld-cal-print-table {
+    font-size: 9pt;
+  }
+
+  .meld-cal-print-table thead {
+    display: table-header-group;
+  }
+
+  .meld-cal-print-table tr {
+    page-break-inside: avoid;
+  }
+}
+
 /* MELD-89: evaluate.php layout */
 .eval-layout {
   max-width: 100%;

--- a/views/calendar/print.php
+++ b/views/calendar/print.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Print table partial (MELD-9). Expects: $bounds, $events, $orgName, $printDate, $nEvents
+ * Print table partial (MELD-9). Expects: $events, $orgName, $printDate, $nEvents, $rangeLabel
  */
 ?>
   <header class="meld-cal-print-header">
@@ -9,7 +9,7 @@
 <?php } ?>
     <h1>Terminkalender</h1>
     <p class="meld-cal-print-meta">
-      <strong><?php echo htmlspecialchars($bounds['label'], ENT_QUOTES, 'UTF-8'); ?></strong>
+      <strong><?php echo htmlspecialchars((string)$rangeLabel, ENT_QUOTES, 'UTF-8'); ?></strong>
       &middot;
       gedruckt am <?php echo htmlspecialchars((string)$printDate, ENT_QUOTES, 'UTF-8'); ?>
       &middot;
@@ -18,7 +18,7 @@
   </header>
 
 <?php if($nEvents === 0) { ?>
-  <p class="meld-cal-print-empty">Keine Termine in diesem Monat.</p>
+  <p class="meld-cal-print-empty">Keine kommenden Termine.</p>
 <?php } else { ?>
   <table class="meld-cal-print-table">
     <thead>

--- a/views/calendar/print.php
+++ b/views/calendar/print.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Print table partial (MELD-9). Expects: $bounds, $events, $orgName, $printDate, $nEvents
+ */
+?>
+  <header class="meld-cal-print-header">
+<?php if($orgName !== '') { ?>
+    <p class="meld-cal-print-org"><?php echo htmlspecialchars($orgName, ENT_QUOTES, 'UTF-8'); ?></p>
+<?php } ?>
+    <h1>Terminkalender</h1>
+    <p class="meld-cal-print-meta">
+      <strong><?php echo htmlspecialchars($bounds['label'], ENT_QUOTES, 'UTF-8'); ?></strong>
+      &middot;
+      gedruckt am <?php echo htmlspecialchars((string)$printDate, ENT_QUOTES, 'UTF-8'); ?>
+      &middot;
+      <?php echo (int)$nEvents; ?> Termin<?php echo $nEvents === 1 ? '' : 'e'; ?>
+    </p>
+  </header>
+
+<?php if($nEvents === 0) { ?>
+  <p class="meld-cal-print-empty">Keine Termine in diesem Monat.</p>
+<?php } else { ?>
+  <table class="meld-cal-print-table">
+    <thead>
+      <tr>
+        <th>Datum</th>
+        <th>Zeit</th>
+        <th>Termin</th>
+        <th>Ort</th>
+        <th>R&uuml;ckmeldung</th>
+      </tr>
+    </thead>
+    <tbody>
+<?php foreach($events as $ev) {
+    $dateLabel = calendarPrintDateLabel($ev);
+    $timeLabel = calendarPrintTimeLabel($ev);
+    $name = isset($ev['name']) ? (string)$ev['name'] : '';
+    $location = isset($ev['location']) ? (string)$ev['location'] : '';
+    $melde = calendarMeldeLabel(isset($ev['wert']) ? $ev['wert'] : null);
+?>
+      <tr>
+        <td><?php echo htmlspecialchars($dateLabel, ENT_QUOTES, 'UTF-8'); ?></td>
+        <td class="meld-cal-print-time"><?php echo htmlspecialchars($timeLabel, ENT_QUOTES, 'UTF-8'); ?></td>
+        <td><?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8'); ?></td>
+        <td><?php echo htmlspecialchars($location, ENT_QUOTES, 'UTF-8'); ?></td>
+        <td><?php echo htmlspecialchars($melde, ENT_QUOTES, 'UTF-8'); ?></td>
+      </tr>
+<?php } ?>
+    </tbody>
+  </table>
+<?php } ?>

--- a/views/calendar/subscribe.php
+++ b/views/calendar/subscribe.php
@@ -2,6 +2,7 @@
 /**
  * Personal calendar subscription block (MELD-127).
  * Expects $n = User with activeLink, or $calendarHttps / $calendarWebcal strings.
+ * Set $calendarSubscribeInModal = true to omit outer panel (content for a modal).
  */
 if(!isset($calendarHttps) || !isset($calendarWebcal)) {
     if(!isset($n) || !is_object($n) || !(int)$n->Index) {
@@ -19,9 +20,12 @@ if($calendarHttps === '') {
     return;
 }
 $uid = isset($calendarSubscribeUid) ? (string)$calendarSubscribeUid : 'cal-sub';
+$inModal = !empty($calendarSubscribeInModal);
+if(!$inModal) {
 ?>
 <div class="w3-panel w3-border w3-padding w3-margin-top <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorInputBackground'], ENT_QUOTES, 'UTF-8'); ?>">
   <h3><i class="fas fa-calendar-plus" aria-hidden="true"></i> Kalender abonnieren</h3>
+<?php } ?>
   <p class="w3-small">
     Trage den Link in Google Kalender, Apple Kalender oder Outlook als <b>Kalender-URL / Abonnement</b> ein.
     Neue und geänderte Termine erscheinen automatisch — das Aktualisierungsintervall steuert dein Kalender (oft erst nach einigen Stunden).
@@ -40,10 +44,14 @@ $uid = isset($calendarSubscribeUid) ? (string)$calendarSubscribeUid : 'cal-sub';
     <button type="button" class="w3-button w3-border" data-copy-target="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-webcal">webcal kopieren</button>
   </p>
   <p class="w3-small"><a href="help.php#help-kalender-abo">Hilfe: Kalender abonnieren</a></p>
+<?php if(!$inModal) { ?>
 </div>
+<?php } ?>
 <script>
 (function () {
   document.querySelectorAll('[data-copy-target]').forEach(function (btn) {
+    if(btn.getAttribute('data-copy-bound') === '1') return;
+    btn.setAttribute('data-copy-bound', '1');
     btn.addEventListener('click', function () {
       var id = btn.getAttribute('data-copy-target');
       var el = id ? document.getElementById(id) : null;

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -62,7 +62,7 @@ $sections[] = array(
 <p>Unter <b>Termine</b> (Startseite) kannst du dich zu Terminen eintragen:</p>
 <ul>
 <li>Über die Suchzeile findest du Termine nach Titel, Ort, Datum oder Beschreibung (auch im Termin-Archiv).</li>
-<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details. Oben links: Info-Button für den Abo-Link, Drucken-Button für die Monatstabelle (PDF/Ausdruck).</li>
+<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details. Über dem Monat: Info öffnet das Abo-Fenster, Drucken die Monatstabelle.</li>
 </ul>
 '.$meldeButtons.'
 <p>Tippe auf den gewünschten Status. Die Farbe am Termin zeigt deinen aktuellen Stand. Eine erneute Auswahl ändert die Meldung.</p>
@@ -123,7 +123,7 @@ $sections[] = array(
     'id' => 'kalender-abo',
     'title' => 'Kalender abonnieren',
     'body' => '
-<p>Du kannst deine sichtbaren Meldeliste-Termine in deinen privaten Kalender (Google, Apple, Outlook, …) <b>abonnieren</b>. Der Link steht unter <b>Mein Profil</b> und auf der Seite <b>Kalender</b> hinter dem Info-Button (oben links).</p>
+<p>Du kannst deine sichtbaren Meldeliste-Termine in deinen privaten Kalender (Google, Apple, Outlook, …) <b>abonnieren</b>. Der Link steht unter <b>Mein Profil</b> und auf der Seite <b>Kalender</b> im Info-Dialog (runde Buttons über der Monatsauswahl).</p>
 <p><b>Einweg:</b> Termine und dein Melde-Status (zugesagt / vielleicht / ohne) werden in den Kalender übernommen. Zu- und Absagen änderst du weiterhin in der Meldeliste — nicht in der Kalender-App.</p>
 <p><b>Aktualisierung:</b> Wie oft der Feed neu geladen wird, steuert dein Kalender-Anbieter (oft erst nach einigen Stunden). Darauf hat die Meldeliste keinen Einfluss.</p>
 <ul>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -41,7 +41,7 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 <li><i class="far fa-calendar-alt"></i> <b>Termine</b> – bevorstehende Termine und schnelles Melden</li>
-<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details); Drucken als Tabelle; unten Link zum Abonnieren in Google/Apple/Outlook</li>
+<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details); Info-Button für Abo-Link, Drucken-Button für die Monatstabelle</li>
 <li><i class="fas fa-envelope"></i> <b>Meine Nachrichten</b> – empfangene Mails aus der Meldeliste (Badge bei ungelesenen)</li>
 <li><i class="fas fa-users"></i> <b>Mein Register</b> – Rückmeldungen deines Registers</li>
 '.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir zugeordnetes bzw. ausgeliehenes Inventar</li>' : '').'
@@ -62,7 +62,7 @@ $sections[] = array(
 <p>Unter <b>Termine</b> (Startseite) kannst du dich zu Terminen eintragen:</p>
 <ul>
 <li>Über die Suchzeile findest du Termine nach Titel, Ort, Datum oder Beschreibung (auch im Termin-Archiv).</li>
-<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details. Mit <b>Drucken</b> öffnest du eine Tabelle des Monats zum Ausdrucken oder Speichern als PDF.</li>
+<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details. Oben links: Info-Button für den Abo-Link, Drucken-Button für die Monatstabelle (PDF/Ausdruck).</li>
 </ul>
 '.$meldeButtons.'
 <p>Tippe auf den gewünschten Status. Die Farbe am Termin zeigt deinen aktuellen Stand. Eine erneute Auswahl ändert die Meldung.</p>
@@ -123,7 +123,7 @@ $sections[] = array(
     'id' => 'kalender-abo',
     'title' => 'Kalender abonnieren',
     'body' => '
-<p>Du kannst deine sichtbaren Meldeliste-Termine in deinen privaten Kalender (Google, Apple, Outlook, …) <b>abonnieren</b>. Der Link steht unter <b>Mein Profil</b> und auf der Seite <b>Kalender</b>.</p>
+<p>Du kannst deine sichtbaren Meldeliste-Termine in deinen privaten Kalender (Google, Apple, Outlook, …) <b>abonnieren</b>. Der Link steht unter <b>Mein Profil</b> und auf der Seite <b>Kalender</b> hinter dem Info-Button (oben links).</p>
 <p><b>Einweg:</b> Termine und dein Melde-Status (zugesagt / vielleicht / ohne) werden in den Kalender übernommen. Zu- und Absagen änderst du weiterhin in der Meldeliste — nicht in der Kalender-App.</p>
 <p><b>Aktualisierung:</b> Wie oft der Feed neu geladen wird, steuert dein Kalender-Anbieter (oft erst nach einigen Stunden). Darauf hat die Meldeliste keinen Einfluss.</p>
 <ul>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -41,7 +41,7 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 <li><i class="far fa-calendar-alt"></i> <b>Termine</b> – bevorstehende Termine und schnelles Melden</li>
-<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details); unten Link zum Abonnieren in Google/Apple/Outlook</li>
+<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details); Drucken als Tabelle; unten Link zum Abonnieren in Google/Apple/Outlook</li>
 <li><i class="fas fa-envelope"></i> <b>Meine Nachrichten</b> – empfangene Mails aus der Meldeliste (Badge bei ungelesenen)</li>
 <li><i class="fas fa-users"></i> <b>Mein Register</b> – Rückmeldungen deines Registers</li>
 '.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir zugeordnetes bzw. ausgeliehenes Inventar</li>' : '').'
@@ -62,7 +62,7 @@ $sections[] = array(
 <p>Unter <b>Termine</b> (Startseite) kannst du dich zu Terminen eintragen:</p>
 <ul>
 <li>Über die Suchzeile findest du Termine nach Titel, Ort, Datum oder Beschreibung (auch im Termin-Archiv).</li>
-<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details.</li>
+<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details. Mit <b>Drucken</b> öffnest du eine Tabelle des Monats zum Ausdrucken oder Speichern als PDF.</li>
 </ul>
 '.$meldeButtons.'
 <p>Tippe auf den gewünschten Status. Die Farbe am Termin zeigt deinen aktuellen Stand. Eine erneute Auswahl ändert die Meldung.</p>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -41,7 +41,7 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 <li><i class="far fa-calendar-alt"></i> <b>Termine</b> – bevorstehende Termine und schnelles Melden</li>
-<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details); Info-Button für Abo-Link, Drucken-Button für die Monatstabelle</li>
+<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details); Info-Button für Abo-Link, Drucken für alle kommenden Termine als Tabelle</li>
 <li><i class="fas fa-envelope"></i> <b>Meine Nachrichten</b> – empfangene Mails aus der Meldeliste (Badge bei ungelesenen)</li>
 <li><i class="fas fa-users"></i> <b>Mein Register</b> – Rückmeldungen deines Registers</li>
 '.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir zugeordnetes bzw. ausgeliehenes Inventar</li>' : '').'
@@ -62,7 +62,7 @@ $sections[] = array(
 <p>Unter <b>Termine</b> (Startseite) kannst du dich zu Terminen eintragen:</p>
 <ul>
 <li>Über die Suchzeile findest du Termine nach Titel, Ort, Datum oder Beschreibung (auch im Termin-Archiv).</li>
-<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details. Über dem Monat: Info öffnet das Abo-Fenster, Drucken die Monatstabelle.</li>
+<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details. Über dem Monat: Info öffnet das Abo-Fenster, Drucken listet alle kommenden Termine (nicht nur den aktuellen Monat).</li>
 </ul>
 '.$meldeButtons.'
 <p>Tippe auf den gewünschten Status. Die Farbe am Termin zeigt deinen aktuellen Stand. Eine erneute Auswahl ändert die Meldung.</p>


### PR DESCRIPTION
## Summary
- Druckansicht als Tabelle für alle kommenden Termine (`calendar-print.php`)
- Kalender-Toolbar: Info/Drucken links, Monatsauswahl rechts; Inhalt mit max. Breite
- Abo-Hinweis als Modal; App-Zeitzone `Europe/Berlin` für Kalender/ICS

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-9

## Test plan
- [ ] Kalender: Info öffnet Modal, Drucken öffnet Druckansicht
- [ ] Druck: Liste kommender Termine mit Datum/Zeit/Ort/Rückmeldung
- [ ] Monat/Jahr/Heute-Navigation rechts in der Toolbar
- [ ] „Heute“-Markierung und Tagesgrenzen in Lokalzeit (Europe/Berlin)

Made with [Cursor](https://cursor.com)