### PR TITLE
MELD-125: Rechte-Chips und Profil-Nachbesserungen

### DIFF
--- a/js/profile-layout.js
+++ b/js/profile-layout.js
@@ -191,6 +191,181 @@
     render();
   }
 
+  function initPermissionChips() {
+    var wrap = document.getElementById('profile-perms-wrap');
+    if (!wrap) return;
+    var chipsEl = document.getElementById('profile-perm-chips');
+    var inputEl = document.getElementById('profile-perm-input');
+    var suggestEl = document.getElementById('profile-perm-suggest');
+    var hiddensEl = document.getElementById('profile-perm-hiddens');
+    if (!chipsEl || !inputEl || !suggestEl || !hiddensEl) return;
+
+    var catalog = parseJsonAttr(wrap, 'data-perm-catalog', { permissions: [] });
+    var permissions = Array.isArray(catalog.permissions) ? catalog.permissions : [];
+    var selected = parseJsonAttr(wrap, 'data-selected-perms', []);
+    if (!Array.isArray(selected)) selected = [];
+    selected = selected.map(String).filter(function (k) { return !!k; });
+    var lockedKey = String(wrap.getAttribute('data-locked-perm') || '');
+    var activeIndex = -1;
+
+    function metaFor(key) {
+      for (var i = 0; i < permissions.length; i++) {
+        if (String(permissions[i].key) === String(key)) return permissions[i];
+      }
+      return { key: key, label: key, group: '', groupId: 'sonst' };
+    }
+
+    function sortSelected() {
+      var order = {};
+      permissions.forEach(function (p, idx) {
+        order[String(p.key)] = idx;
+      });
+      selected.sort(function (a, b) {
+        var ia = order.hasOwnProperty(a) ? order[a] : 999;
+        var ib = order.hasOwnProperty(b) ? order[b] : 999;
+        return ia - ib;
+      });
+    }
+
+    function syncHiddens() {
+      hiddensEl.innerHTML = '';
+      selected.forEach(function (key) {
+        var input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = 'userPermissions[]';
+        input.value = String(key);
+        hiddensEl.appendChild(input);
+      });
+    }
+
+    function render() {
+      if (lockedKey && selected.indexOf(lockedKey) === -1) {
+        selected.push(lockedKey);
+      }
+      sortSelected();
+      chipsEl.innerHTML = '';
+      selected.forEach(function (key) {
+        var meta = metaFor(key);
+        var gid = String(meta.groupId || 'sonst').replace(/[^a-z0-9_-]/gi, '');
+        var chip = document.createElement('span');
+        chip.className = 'profile-perm-tile profile-perm-tile--' + gid;
+        chip.setAttribute('data-key', String(key));
+        var text = document.createElement('span');
+        text.textContent = meta.label || key;
+        chip.appendChild(text);
+        if (key !== lockedKey) {
+          var btn = document.createElement('button');
+          btn.type = 'button';
+          btn.className = 'mail-recipient-chip-remove';
+          btn.setAttribute('aria-label', 'Entfernen');
+          btn.innerHTML = '&times;';
+          btn.addEventListener('click', function () {
+            selected = selected.filter(function (x) { return x !== key; });
+            render();
+          });
+          chip.appendChild(btn);
+        }
+        chipsEl.appendChild(chip);
+      });
+      syncHiddens();
+    }
+
+    function filteredSuggestions() {
+      var q = normalize(inputEl.value);
+      var items = [];
+      permissions.forEach(function (p) {
+        var key = String(p.key);
+        if (selected.indexOf(key) !== -1) return;
+        if (q === '' || normalize(p.label).indexOf(q) !== -1 || normalize(p.group).indexOf(q) !== -1) {
+          items.push(p);
+        }
+      });
+      return items;
+    }
+
+    function hideSuggest() {
+      suggestEl.hidden = true;
+      suggestEl.innerHTML = '';
+      activeIndex = -1;
+    }
+
+    function showSuggest() {
+      var items = filteredSuggestions();
+      suggestEl.innerHTML = '';
+      if (!items.length) {
+        hideSuggest();
+        return;
+      }
+      items.forEach(function (p, idx) {
+        var row = document.createElement('button');
+        row.type = 'button';
+        row.className = 'mail-recipient-suggest-item' + (idx === activeIndex ? ' mail-recipient-suggest-item--active' : '');
+        row.setAttribute('data-index', String(idx));
+        var label = document.createElement('span');
+        label.textContent = p.label || '';
+        row.appendChild(label);
+        var meta = document.createElement('span');
+        meta.className = 'mail-recipient-suggest-meta';
+        meta.textContent = p.group || '';
+        row.appendChild(meta);
+        row.addEventListener('mousedown', function (e) {
+          e.preventDefault();
+          addPerm(String(p.key));
+        });
+        suggestEl.appendChild(row);
+      });
+      suggestEl.hidden = false;
+    }
+
+    function addPerm(key) {
+      key = String(key);
+      if (!key || selected.indexOf(key) !== -1) return;
+      selected.push(key);
+      inputEl.value = '';
+      hideSuggest();
+      render();
+      inputEl.focus();
+    }
+
+    inputEl.addEventListener('input', function () {
+      activeIndex = -1;
+      showSuggest();
+    });
+    inputEl.addEventListener('focus', showSuggest);
+    inputEl.addEventListener('blur', function () {
+      window.setTimeout(hideSuggest, 150);
+    });
+    inputEl.addEventListener('keydown', function (e) {
+      var items = filteredSuggestions();
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        if (!items.length) return;
+        activeIndex = (activeIndex + 1) % items.length;
+        showSuggest();
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        if (!items.length) return;
+        activeIndex = activeIndex <= 0 ? items.length - 1 : activeIndex - 1;
+        showSuggest();
+      } else if (e.key === 'Enter') {
+        if (activeIndex >= 0 && items[activeIndex]) {
+          e.preventDefault();
+          addPerm(String(items[activeIndex].key));
+        }
+      } else if (e.key === 'Backspace' && !inputEl.value && selected.length) {
+        var last = selected[selected.length - 1];
+        if (last !== lockedKey) {
+          selected.pop();
+          render();
+        }
+      } else if (e.key === 'Escape') {
+        hideSuggest();
+      }
+    });
+
+    render();
+  }
+
   function parseCatalog(wrap) {
     try {
       return JSON.parse(wrap.getAttribute('data-membership-catalog') || '{}');
@@ -297,6 +472,7 @@
   function init() {
     initQr();
     initGroupChips();
+    initPermissionChips();
     initMembershipPreview();
   }
 

--- a/libs/form-response.php
+++ b/libs/form-response.php
@@ -62,6 +62,11 @@ function handleUserFormPost($options = array()) {
                 MailGroup::syncUserExplicitMembership((int)$n->Index, $ids);
             }
 
+            if(isset($_POST['userPermissionsPosted']) && (int)$n->Index > 0) {
+                $sessionUserId = isset($_SESSION['userid']) ? (int)$_SESSION['userid'] : 0;
+                Permissions::applyPostedForUser((int)$n->Index, $_POST, $sessionUserId);
+            }
+
             if(isset($_POST['pw1']) && isset($_POST['pw2'])) {
                 if($_POST['pw1'] == $_POST['pw2'] && $_POST['pw1'] != '') {
                     if(!$n->passwd($_POST['pw1'])) {

--- a/libs/permissions.php
+++ b/libs/permissions.php
@@ -272,6 +272,74 @@ class Permissions
         );
     }
 
+    /**
+     * Logical groups: order + color id for chips (titles not shown in UI).
+     * @return array<int,array{id:string,title:string,keys:string[]}>
+     */
+    public static function permissionGroups() {
+        return array(
+            array(
+                'id' => 'nutzer',
+                'title' => 'Nutzer',
+                'keys' => array('perm_showUsers', 'perm_editUsers', 'perm_editPermissions'),
+            ),
+            array(
+                'id' => 'termine',
+                'title' => 'Termine',
+                'keys' => array(
+                    'perm_showHiddenAppmnts',
+                    'perm_editAppmnts',
+                    'perm_showResponse',
+                    'perm_editResponse',
+                ),
+            ),
+            array(
+                'id' => 'instrumente',
+                'title' => 'Instrumente',
+                'keys' => array('perm_showInstruments', 'perm_editInstruments'),
+            ),
+            array(
+                'id' => 'inventar',
+                'title' => 'Inventar',
+                'keys' => array('perm_showInventories', 'perm_editInventories'),
+            ),
+            array(
+                'id' => 'kommunikation',
+                'title' => 'Kommunikation',
+                'keys' => array('perm_sendEmail'),
+            ),
+            array(
+                'id' => 'system',
+                'title' => 'System',
+                'keys' => array('perm_showLog', 'perm_editConfig'),
+            ),
+        );
+    }
+
+    /**
+     * Flat catalog in group sort order for chip pickers / modal.
+     * @return array<int,array{key:string,label:string,group:string,groupId:string}>
+     */
+    public static function permissionCatalog() {
+        $labels = self::permissionLabels();
+        $out = array();
+        foreach(self::permissionGroups() as $group) {
+            $groupId = isset($group['id']) ? (string)$group['id'] : 'sonst';
+            $groupTitle = isset($group['title']) ? (string)$group['title'] : '';
+            $keys = isset($group['keys']) && is_array($group['keys']) ? $group['keys'] : array();
+            foreach($keys as $key) {
+                $meta = isset($labels[$key]) ? $labels[$key] : array('label' => $key);
+                $out[] = array(
+                    'key' => (string)$key,
+                    'label' => (string)$meta['label'],
+                    'group' => $groupTitle,
+                    'groupId' => $groupId,
+                );
+            }
+        }
+        return $out;
+    }
+
     public function hasAnyPermission() {
         foreach(self::permissionKeys() as $key) {
             if($this->$key) {
@@ -279,6 +347,49 @@ class Permissions
             }
         }
         return false;
+    }
+
+    /**
+     * Apply permission checkboxes from a user create/edit POST.
+     * @param array $posted typically $_POST
+     */
+    public static function applyPostedForUser($userId, array $posted, $sessionUserId = 0) {
+        $userId = (int)$userId;
+        if($userId < 1) {
+            return false;
+        }
+        $sessionUserId = (int)$sessionUserId;
+        $selected = array();
+        if(isset($posted['userPermissions']) && is_array($posted['userPermissions'])) {
+            foreach($posted['userPermissions'] as $key) {
+                $key = (string)$key;
+                if(in_array($key, self::permissionKeys(), true)) {
+                    $selected[$key] = true;
+                }
+            }
+        }
+        else {
+            foreach(self::permissionKeys() as $key) {
+                if(!empty($posted[$key])) {
+                    $selected[$key] = true;
+                }
+            }
+        }
+        $p = new Permissions;
+        $p->load_by_user($userId);
+        foreach(self::permissionKeys() as $key) {
+            $val = !empty($selected[$key]) ? 1 : 0;
+            if($sessionUserId === $userId && $key === 'perm_editPermissions' && $val === 0) {
+                $val = 1;
+            }
+            $p->$key = $val;
+        }
+        $p->save();
+        if($sessionUserId === $userId) {
+            $_SESSION['permissions'] = loadPermissions($userId);
+            $_SESSION['admin'] = isAdmin() ? 1 : 0;
+        }
+        return true;
     }
 
     public function printShort() {

--- a/libs/user.php
+++ b/libs/user.php
@@ -637,11 +637,10 @@ class User
     
     public function getModalHtml($forceEditButton = false) {
         $showUserDetails = requirePermission("perm_showUsers");
-        $permissionsHtml = '';
+        $permissions = null;
         if($showUserDetails) {
-            $p = new Permissions;
-            $p->load_by_user($this->Index);
-            $permissionsHtml = $p->printShort();
+            $permissions = new Permissions;
+            $permissions->load_by_user($this->Index);
         }
         $registerLeadName = null;
         if($this->RegisterLead) {
@@ -652,7 +651,7 @@ class User
         return render('user/modal', array(
             'user' => $this,
             'showUserDetails' => $showUserDetails,
-            'permissionsHtml' => $permissionsHtml,
+            'permissions' => $permissions,
             'registerLeadName' => $registerLeadName,
             'showEditButton' => ($forceEditButton || requirePermission("perm_editUsers")),
             'returnTo' => pageToReturnUrl(isset($_SESSION['page']) ? $_SESSION['page'] : 'musiker'),

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2002,6 +2002,87 @@ select.profile-control {
   gap: 0.4rem 0.85rem;
 }
 
+.profile-prefs--perms {
+  grid-template-columns: 1fr;
+}
+
+.profile-perm-tiles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.profile-perm-tile {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  max-width: 100%;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  border-radius: 0.25rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1.3;
+  background: #eef1f4;
+  color: #222;
+}
+
+.profile-perm-tile--nutzer {
+  background: #e3f2fd;
+  border-color: #64b5f6;
+}
+
+.profile-perm-tile--termine {
+  background: #e8f5e9;
+  border-color: #66bb6a;
+}
+
+.profile-perm-tile--instrumente {
+  background: #fff3e0;
+  border-color: #ffb74d;
+}
+
+.profile-perm-tile--inventar {
+  background: #f3e5f5;
+  border-color: #ba68c8;
+}
+
+.profile-perm-tile--kommunikation {
+  background: #e0f7fa;
+  border-color: #4dd0e1;
+}
+
+.profile-perm-tile--system {
+  background: #eceff1;
+  border-color: #90a4ae;
+}
+
+.profile-perm-picker #profile-perm-chips {
+  margin-bottom: 0.25rem;
+  min-height: 1.6rem;
+}
+
+.profile-perm-group + .profile-perm-group {
+  margin-top: 0.75rem;
+  padding-top: 0.65rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.profile-perm-group-title {
+  margin: 0 0 0.4rem;
+  font-size: 0.8rem;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+@media (min-width: 520px) {
+  .profile-prefs--perms {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
 .profile-pref {
   display: flex;
   align-items: center;

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -187,10 +187,10 @@ $sections[] = array(
 '.(!empty($optionsDB['showMembers']) ? '<li><b>Mitgliederliste</b> – nur Vereinsmitglieder</li>' : '').'
 '.(!empty($optionsDB['showNonMembers']) ? '<li><b>Nicht-Mitgliederliste</b></li>' : '').'
 ' : '').'
-'.(requirePermission('perm_editUsers') ? '<li><b>Musiker anlegen</b> – Person anlegen inkl. Benachrichtigungen, Mitglied-Status, Instrument und Gruppen-Chips; <b>Automatisch</b> zeigt die abgeleitete Zugehörigkeit</li>' : '').'
+'.(requirePermission('perm_editUsers') ? '<li><b>Musiker anlegen</b> – Person anlegen inkl. Benachrichtigungen, Mitglied-Status, Instrument, Gruppen-Chips und Rechte; <b>Automatisch</b> zeigt die abgeleitete Zugehörigkeit</li>' : '').'
 '.(requirePermission('perm_editUsers') && !empty($optionsDB['urlNotenarchiv']) ? '<li><b>Stimme / Fallbacks</b> – primäre Stimme und Fallback-Instrumente für das Notenarchiv (Stimmsatz); im Profil verlinkt oder <code>user-voice.php</code></li>' : '').'
 '.(requirePermission('perm_editInstruments') ? '<li><b>Instrument-Typen / Register</b> – Typen und Register anlegen, sortieren und einfärben</li>' : '').'
-'.(requirePermission('perm_editPermissions') ? '<li><b>Berechtigungen</b> – Matrix der Rechte pro User (Autosave)</li>' : '').'
+'.(requirePermission('perm_editPermissions') ? '<li><b>Berechtigungen</b> – Matrix aller User (Autosave); Rechte auch beim Anlegen/Bearbeiten unter Musiker</li>' : '').'
 </ul>
 '
 );

--- a/views/profile/fields_meta.php
+++ b/views/profile/fields_meta.php
@@ -19,6 +19,7 @@ if(!$showMetaDetails) {
   <span class="profile-label">Letzter Login</span>
   <div class="profile-value"><?php echo germanDate($n->LastLogin, 1); ?></div>
 </div>
+<?php if(isAdmin()) { ?>
 <div class="profile-field">
   <span class="profile-label">Anwesenheit</span>
   <div class="profile-value"><?php echo germanDate($n->getLastVisit(), 1); ?></div>
@@ -27,3 +28,4 @@ if(!$showMetaDetails) {
   <span class="profile-label">Meldequote</span>
   <div class="profile-value"><?php echo (float)$n->getMeldeQuote() * 100; ?> %</div>
 </div>
+<?php } ?>

--- a/views/profile/fields_permissions.php
+++ b/views/profile/fields_permissions.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Rechte-Chip-Picker (wie Gruppen) — Admin anlegen/bearbeiten.
+ * Expects: $adminUserEdit; optional $n, $fill, $inputBg
+ */
+if(!isset($adminUserEdit)) {
+    $adminUserEdit = !empty($canEditUsers) && isset($edit) && (int)$edit === 3;
+}
+if(empty($adminUserEdit)) {
+    return;
+}
+if(!isset($inputBg)) {
+    $inputBg = $GLOBALS['optionsDB']['colorInputBackground'];
+}
+$catalog = Permissions::permissionCatalog();
+$permObj = new Permissions;
+if(!empty($fill) && isset($n) && (int)$n->Index > 0) {
+    $permObj->load_by_user((int)$n->Index);
+}
+$sessionUserId = isset($_SESSION['userid']) ? (int)$_SESSION['userid'] : 0;
+$targetUserId = (!empty($fill) && isset($n)) ? (int)$n->Index : 0;
+$lockEditPerms = ($targetUserId > 0 && $sessionUserId === $targetUserId);
+
+$selected = array();
+foreach($catalog as $item) {
+    $key = $item['key'];
+    if(((int)$permObj->$key) === 1 || ($lockEditPerms && $key === 'perm_editPermissions')) {
+        $selected[] = $key;
+    }
+}
+
+$catalogJson = json_encode(
+    array('permissions' => $catalog),
+    JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE
+);
+$selectedJson = json_encode(
+    array_values($selected),
+    JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE
+);
+?>
+<div class="profile-pref-group" id="profile-perms-wrap"
+     data-perm-catalog="<?php echo htmlspecialchars((string)$catalogJson, ENT_QUOTES, 'UTF-8'); ?>"
+     data-selected-perms="<?php echo htmlspecialchars((string)$selectedJson, ENT_QUOTES, 'UTF-8'); ?>"
+     data-locked-perm="<?php echo $lockEditPerms ? 'perm_editPermissions' : ''; ?>">
+  <h3 class="profile-col-title">Rechte</h3>
+  <input type="hidden" name="userPermissionsPosted" value="1">
+  <div class="profile-group-picker profile-perm-picker w3-border <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>">
+    <div id="profile-perm-chips" class="mail-recipient-chips profile-perm-tiles" aria-live="polite"></div>
+    <input type="text" id="profile-perm-input" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" placeholder="Recht tippen…" autocomplete="off" aria-label="Recht hinzufügen">
+    <div id="profile-perm-suggest" class="mail-recipient-suggest" hidden></div>
+    <div id="profile-perm-hiddens" hidden></div>
+  </div>
+</div>

--- a/views/profile/fields_prefs.php
+++ b/views/profile/fields_prefs.php
@@ -48,20 +48,6 @@ $idSuffix = isset($idSuffix) ? (string)$idSuffix : '';
       </label>
     </div>
   </div>
+<?php include __DIR__.'/fields_permissions.php'; ?>
 </div>
 <p class="profile-help-link"><a href="help.php#help-profil">Hilfe zu Benachrichtigungen</a></p>
-<?php
-if($fill && (int)$n->Index > 0 && !empty($adminUserEdit)) {
-    $p = new Permissions;
-    $p->load_by_user((int)$n->Index);
-    $permissionsHtml = $p->printShort();
-    if($permissionsHtml !== '') {
-?>
-<div class="profile-field">
-  <span class="profile-label">Rechte</span>
-  <div class="profile-value profile-value--perms"><?php echo $permissionsHtml; ?></div>
-</div>
-<?php
-    }
-}
-?>

--- a/views/user/modal.php
+++ b/views/user/modal.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * User detail modal (profile-shell layout).
- * Expects: $user, $showUserDetails, $permissionsHtml, $registerLeadName,
+ * Expects: $user, $showUserDetails, $permissions, $registerLeadName,
  *          $showEditButton, $returnTo, $returnToken
  */
 $name = trim((string)$user->Vorname.' '.(string)$user->Nachname);
@@ -93,6 +93,7 @@ $btnEdit = $GLOBALS['optionsDB']['colorBtnEdit'];
         <span class="profile-label">Letzter Login</span>
         <div class="profile-value"><?php echo germanDate($user->LastLogin, 1); ?></div>
       </div>
+<?php if(isAdmin()) { ?>
       <div class="profile-field">
         <span class="profile-label">Anwesenheit</span>
         <div class="profile-value"><?php echo germanDate($user->getLastVisit(), 1); ?></div>
@@ -101,6 +102,7 @@ $btnEdit = $GLOBALS['optionsDB']['colorBtnEdit'];
         <span class="profile-label">Meldequote</span>
         <div class="profile-value"><?php echo (float)$user->getMeldeQuote()*100; ?> %</div>
       </div>
+<?php } ?>
     </section>
 
     <section class="profile-col" aria-labelledby="user-modal-notify">
@@ -139,12 +141,35 @@ $btnEdit = $GLOBALS['optionsDB']['colorBtnEdit'];
           </div>
         </div>
       </div>
-<?php if($showUserDetails && $permissionsHtml !== '') { ?>
-      <div class="profile-field">
-        <span class="profile-label">Rechte</span>
-        <div class="profile-value profile-value--perms"><?php echo $permissionsHtml; ?></div>
+<?php
+if($showUserDetails && !empty($permissions)) {
+    $activePerms = array();
+    foreach(Permissions::permissionCatalog() as $item) {
+        $key = $item['key'];
+        if((int)$permissions->$key !== 1) {
+            continue;
+        }
+        $activePerms[] = $item;
+    }
+    if(count($activePerms)) {
+?>
+      <div class="profile-pref-group">
+        <h3 class="profile-col-title">Rechte</h3>
+        <div class="profile-perm-tiles" aria-label="Aktive Rechte">
+<?php
+        foreach($activePerms as $item) {
+            $gid = preg_replace('/[^a-z0-9_-]/i', '', (string)$item['groupId']);
+            echo '<span class="profile-perm-tile profile-perm-tile--'.$gid.'">'
+                .htmlspecialchars($item['label'], ENT_QUOTES, 'UTF-8')
+                .'</span>';
+        }
+?>
+        </div>
       </div>
-<?php } ?>
+<?php
+    }
+}
+?>
     </section>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Rechte beim User-Anlegen/Bearbeiten als Chip-Input (wie Gruppen), Volltext + Gruppenfarben
- User-Modal: nur aktive Rechte als Kacheln unter Überschrift „Rechte“
- Anwesenheit/Meldequote nur für Admins

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-125

## Test plan
- [ ] Musiker anlegen: Rechte tippen/hinzufügen/entfernen, speichern
- [ ] Musiker bearbeiten: bestehende Rechte als Chips, speichern
- [ ] User-Modal: nur aktive Rechte, Spaltenüberschrift-Stil
- [ ] Non-Admin: keine Anwesenheit/Meldequote im Profil/Modal


Made with [Cursor](https://cursor.com)