### PR TITLE
MELD-135: Email an Termin-Gruppe

### DIFF
--- a/js/mailRecipients.js
+++ b/js/mailRecipients.js
@@ -1,5 +1,5 @@
 /**
- * MELD-60/61: chip picker — roles + registers + users + named mailGroups.
+ * MELD-60/61/135: chip picker — roles + registers + users + mailGroups + termine.
  */
 (function(global) {
   'use strict';
@@ -13,17 +13,18 @@
   var GROUP_IDS = ['musicians', 'members', 'nonmembers', 'users'];
 
   function parseCatalog(el) {
-    if(!el) return {groups: [], registers: [], users: [], mailGroups: []};
+    if(!el) return {groups: [], registers: [], users: [], mailGroups: [], termine: []};
     try {
       var c = JSON.parse(el.textContent || '{}');
       return {
         groups: Array.isArray(c.groups) ? c.groups : [],
         registers: Array.isArray(c.registers) ? c.registers : [],
         users: Array.isArray(c.users) ? c.users : [],
-        mailGroups: Array.isArray(c.mailGroups) ? c.mailGroups : []
+        mailGroups: Array.isArray(c.mailGroups) ? c.mailGroups : [],
+        termine: Array.isArray(c.termine) ? c.termine : []
       };
     } catch(e) {
-      return {groups: [], registers: [], users: [], mailGroups: []};
+      return {groups: [], registers: [], users: [], mailGroups: [], termine: []};
     }
   }
 
@@ -45,7 +46,15 @@
   }
 
   function emptySpec() {
-    return {groups: [], registers: [], users: [], mailGroups: []};
+    return {groups: [], registers: [], users: [], mailGroups: [], termine: []};
+  }
+
+  function isSpecEmpty(spec) {
+    return !(spec.groups && spec.groups.length)
+      && !(spec.registers && spec.registers.length)
+      && !(spec.users && spec.users.length)
+      && !(spec.mailGroups && spec.mailGroups.length)
+      && !(spec.termine && spec.termine.length);
   }
 
   function parseSpec(el, opts) {
@@ -66,7 +75,8 @@
       var registers = normalizeIdList(s.registers);
       var users = normalizeIdList(s.users);
       var mailGroups = normalizeIdList(s.mailGroups);
-      if(!groups.length && !registers.length && !users.length && !mailGroups.length) {
+      var termine = normalizeIdList(s.termine);
+      if(!groups.length && !registers.length && !users.length && !mailGroups.length && !termine.length) {
         if(!allowEmpty && defaultGroups.length) {
           groups = normalizeGroups(defaultGroups);
         }
@@ -75,7 +85,8 @@
         groups: groups,
         registers: registers,
         users: users,
-        mailGroups: mailGroups
+        mailGroups: mailGroups,
+        termine: termine
       };
     } catch(e) {
       return fallback;
@@ -125,7 +136,8 @@
         groups: this.spec.groups.slice(),
         registers: this.spec.registers.slice(),
         users: this.spec.users.slice(),
-        mailGroups: this.spec.mailGroups.slice()
+        mailGroups: (this.spec.mailGroups || []).slice(),
+        termine: (this.spec.termine || []).slice()
       });
     },
 
@@ -193,12 +205,7 @@
             self.countEl.textContent = n === 1 ? '1 Mitglied' : (n + ' Mitglieder');
           }
           else if(label === 'sichtbar für') {
-            var emptySpec = self.allowEmpty
-              && !(self.spec.groups && self.spec.groups.length)
-              && !(self.spec.registers && self.spec.registers.length)
-              && !(self.spec.users && self.spec.users.length)
-              && !(self.spec.mailGroups && self.spec.mailGroups.length);
-            self.countEl.textContent = emptySpec
+            self.countEl.textContent = (self.allowEmpty && isSpecEmpty(self.spec))
               ? '—'
               : (n === 1 ? 'sichtbar für 1 Person' : ('sichtbar für ' + n + ' Personen'));
           }
@@ -253,6 +260,14 @@
       return 'Gruppe #' + id;
     },
 
+    labelForTermin: function(id) {
+      var list = this.catalog.termine || [];
+      for(var i = 0; i < list.length; i++) {
+        if(Number(list[i].id) === Number(id)) return list[i].label;
+      }
+      return 'Teilnehmer: Termin #' + id;
+    },
+
     render: function() {
       if(!this.chipsEl) return;
       this.chipsEl.innerHTML = '';
@@ -268,6 +283,9 @@
       });
       this.spec.users.forEach(function(id) {
         self.chipsEl.appendChild(self.makeChip('user', id, self.labelForUser(id)));
+      });
+      (this.spec.termine || []).forEach(function(id) {
+        self.chipsEl.appendChild(self.makeChip('termin', id, self.labelForTermin(id)));
       });
     },
 
@@ -305,6 +323,10 @@
         id = Number(id);
         this.spec.mailGroups = (this.spec.mailGroups || []).filter(function(x) { return x !== id; });
       }
+      else if(type === 'termin') {
+        id = Number(id);
+        this.spec.termine = (this.spec.termine || []).filter(function(x) { return x !== id; });
+      }
       else {
         id = Number(id);
         this.spec.users = this.spec.users.filter(function(x) { return x !== id; });
@@ -330,6 +352,10 @@
       else if(type === 'mailGroup') {
         if(!this.spec.mailGroups) this.spec.mailGroups = [];
         if(this.spec.mailGroups.indexOf(id) === -1) this.spec.mailGroups.push(id);
+      }
+      else if(type === 'termin') {
+        if(!this.spec.termine) this.spec.termine = [];
+        if(this.spec.termine.indexOf(id) === -1) this.spec.termine.push(id);
       }
       else if(this.spec.users.indexOf(id) === -1) {
         this.spec.users.push(id);
@@ -381,6 +407,13 @@
           return;
         }
         items.push({type: 'user', id: u.id, label: u.label, meta: u.meta || 'Person'});
+      });
+
+      (this.catalog.termine || []).forEach(function(t) {
+        if((self.spec.termine || []).indexOf(Number(t.id)) !== -1) return;
+        if(q === '' || normalize(t.label).indexOf(q) !== -1) {
+          items.push({type: 'termin', id: t.id, label: t.label, meta: t.meta || 'Termin'});
+        }
       });
 
       this.showSuggest(items.slice(0, 14));
@@ -477,7 +510,10 @@
         this.hideSuggest();
       }
       else if(e.key === 'Backspace' && this.inputEl && this.inputEl.value === '') {
-        if(this.spec.users.length) {
+        if(this.spec.termine && this.spec.termine.length) {
+          this.removeChip('termin', this.spec.termine[this.spec.termine.length - 1]);
+        }
+        else if(this.spec.users.length) {
           this.removeChip('user', this.spec.users[this.spec.users.length - 1]);
         }
         else if(this.spec.registers.length) {

--- a/libs/DatabaseManager.php
+++ b/libs/DatabaseManager.php
@@ -793,6 +793,7 @@ class DatabaseManager
                             'registers' => $spec['registers'],
                             'users' => $spec['users'],
                             'mailGroups' => $spec['mailGroups'],
+                            'termine' => isset($spec['termine']) ? $spec['termine'] : array(),
                         ));
                         $update = sprintf(
                             'UPDATE `%sMailJob` SET `RecipientSpec` = \'%s\' WHERE `Index` = %d;',

--- a/libs/appToken.php
+++ b/libs/appToken.php
@@ -309,7 +309,7 @@ function pollNotifyEvents($userId, $since) {
         $sql = sprintf(
             "SELECT `Index` FROM `%sTermine`
              WHERE (%s)
-             ORDER BY `Datum` ASC
+             ORDER BY `Created` DESC, `Updated` DESC, `Datum` ASC
              LIMIT 200;",
             $GLOBALS['dbprefix'],
             implode(' OR ', $sqlParts)

--- a/libs/audienceSpec.php
+++ b/libs/audienceSpec.php
@@ -1,13 +1,14 @@
 <?php
 /**
- * Shared audience / recipient chip specs (MELD-61).
+ * Shared audience / recipient chip specs (MELD-61 / MELD-135).
  *
  * Shape:
  * {
  *   "groups": ["musicians"|"members"|"nonmembers"|"users", ...],
  *   "registers": [id, ...],
  *   "users": [id, ...],
- *   "mailGroups": [id, ...]   // named MailGroup rows; not nested inside MemberSpec
+ *   "mailGroups": [id, ...],  // named MailGroup rows; not nested inside MemberSpec
+ *   "termine": [id, ...]      // Termin-Teilnehmer (ja+vielleicht); Mail-Verteiler only
  * }
  */
 class AudienceSpec
@@ -52,11 +53,12 @@ class AudienceSpec
             && $norm['groups'][0] === 'users'
             && empty($norm['registers'])
             && empty($norm['users'])
-            && empty($norm['mailGroups']);
+            && empty($norm['mailGroups'])
+            && empty($norm['termine']);
     }
 
     /**
-     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[]}
+     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[],termine:int[]}
      */
     public static function emptySpec() {
         return array(
@@ -64,13 +66,14 @@ class AudienceSpec
             'registers' => array(),
             'users' => array(),
             'mailGroups' => array(),
+            'termine' => array(),
         );
     }
 
     /**
      * Default termin visibility: chip „Alle User“.
      *
-     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[]}
+     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[],termine:int[]}
      */
     public static function defaultVisibilitySpec() {
         return array(
@@ -78,16 +81,76 @@ class AudienceSpec
             'registers' => array(),
             'users' => array(),
             'mailGroups' => array(),
+            'termine' => array(),
         );
     }
 
     /**
+     * Chip label for termin participants (ja + vielleicht).
+     *
+     * @param int $terminId
+     * @return string
+     */
+    public static function terminParticipantLabel($terminId) {
+        $terminId = (int)$terminId;
+        $t = new Termin();
+        $t->load_by_id($terminId);
+        if(!(int)$t->Index) {
+            return 'Teilnehmer: Termin #'.$terminId;
+        }
+        $name = trim((string)$t->Name);
+        if($name === '') {
+            $name = 'Termin #'.$terminId;
+        }
+        $date = germanDate($t->Datum, 0);
+        if($date === null || $date === '') {
+            return 'Teilnehmer: '.$name;
+        }
+        return 'Teilnehmer: '.$name.', '.$date;
+    }
+
+    /**
+     * User ids with melde ja (1) or vielleicht (3) for a termin.
+     *
+     * @param int $terminId
+     * @param bool $requireMail
+     * @return int[]
+     */
+    public static function userIdsForTerminParticipants($terminId, $requireMail = false) {
+        $terminId = (int)$terminId;
+        if($terminId <= 0) {
+            return array();
+        }
+        $where = array('u.`Deleted` != 1');
+        if($requireMail) {
+            $where[] = 'u.`getMail` = 1';
+            $where[] = '(u.`Email` != \'\' OR u.`Email2` != \'\')';
+        }
+        $sql = sprintf(
+            'SELECT u.`Index` FROM `%sMeldungen` m INNER JOIN `%sUser` u ON u.`Index` = m.`User` WHERE m.`Termin` = %d AND m.`Wert` != 2 AND %s;',
+            $GLOBALS['dbprefix'],
+            $GLOBALS['dbprefix'],
+            $terminId,
+            implode(' AND ', $where)
+        );
+        $ids = array();
+        $dbr = mysqli_query($GLOBALS['conn'], $sql);
+        if($dbr) {
+            while($row = mysqli_fetch_array($dbr)) {
+                $ids[] = (int)$row['Index'];
+            }
+        }
+        return $ids;
+    }
+
+    /**
      * @param mixed $input array or JSON string
-     * @param array $opts allowMailGroups (bool), defaultGroups (string[]|null), legacyRegister, legacyMemberOnly
-     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[]}
+     * @param array $opts allowMailGroups (bool), allowTermine (bool), defaultGroups (string[]|null), legacyRegister, legacyMemberOnly
+     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[],termine:int[]}
      */
     public static function normalize($input, $opts = array()) {
         $allowMailGroups = !array_key_exists('allowMailGroups', $opts) || !empty($opts['allowMailGroups']);
+        $allowTermine = !empty($opts['allowTermine']);
         $defaultGroups = array_key_exists('defaultGroups', $opts) ? $opts['defaultGroups'] : null;
         $legacyRegister = isset($opts['legacyRegister']) ? (int)$opts['legacyRegister'] : 0;
         $legacyMemberOnly = !empty($opts['legacyMemberOnly']) ? 1 : 0;
@@ -148,6 +211,12 @@ class AudienceSpec
                     if($id > 0) $out['mailGroups'][] = $id;
                 }
             }
+            if($allowTermine && isset($decoded['termine']) && is_array($decoded['termine'])) {
+                foreach($decoded['termine'] as $id) {
+                    $id = (int)$id;
+                    if($id > 0) $out['termine'][] = $id;
+                }
+            }
         }
         elseif($decoded === null && ($legacyRegister > 0 || $legacyMemberOnly)) {
             $out['groups'] = array($legacyMemberOnly ? 'members' : 'musicians');
@@ -160,6 +229,7 @@ class AudienceSpec
         $out['registers'] = array_values(array_unique($out['registers']));
         $out['users'] = array_values(array_unique($out['users']));
         $out['mailGroups'] = array_values(array_unique($out['mailGroups']));
+        $out['termine'] = array_values(array_unique($out['termine']));
 
         if(self::isEmpty($out) && is_array($defaultGroups) && count($defaultGroups) > 0) {
             foreach($defaultGroups as $g) {
@@ -180,17 +250,22 @@ class AudienceSpec
      */
     public static function isEmpty($spec) {
         if(!is_array($spec)) return true;
-        return empty($spec['groups']) && empty($spec['registers']) && empty($spec['users']) && empty($spec['mailGroups']);
+        return empty($spec['groups']) && empty($spec['registers']) && empty($spec['users']) && empty($spec['mailGroups']) && empty($spec['termine']);
     }
 
     /**
      * Expand named mailGroups into groups/registers/users (union). Nested mailGroups ignored.
+     * Termin-IDs remain on the spec for resolveUserIds.
      *
      * @param array $spec
-     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[]}
+     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[],termine:int[]}
      */
     public static function expand($spec) {
-        $spec = self::normalize($spec, array('allowMailGroups' => true, 'defaultGroups' => null));
+        $spec = self::normalize($spec, array(
+            'allowMailGroups' => true,
+            'allowTermine' => true,
+            'defaultGroups' => null,
+        ));
         if(empty($spec['mailGroups'])) {
             return $spec;
         }
@@ -304,6 +379,14 @@ class AudienceSpec
             }
         }
 
+        if(!empty($flat['termine'])) {
+            foreach($flat['termine'] as $tid) {
+                foreach(self::userIdsForTerminParticipants((int)$tid, $requireMail) as $uid) {
+                    $byId[(int)$uid] = true;
+                }
+            }
+        }
+
         return array_map('intval', array_keys($byId));
     }
 
@@ -384,8 +467,10 @@ class AudienceSpec
      */
     public static function formatLabel($spec, $opts = array()) {
         $allowMailGroups = !array_key_exists('allowMailGroups', $opts) || !empty($opts['allowMailGroups']);
+        $allowTermine = !empty($opts['allowTermine']);
         $norm = self::normalize($spec, array(
             'allowMailGroups' => $allowMailGroups,
+            'allowTermine' => $allowTermine,
             'defaultGroups' => null,
         ));
         if(self::isEmpty($norm)) {
@@ -419,6 +504,11 @@ class AudienceSpec
                 $bits[] = $u->getName();
             }
         }
+        if($allowTermine) {
+            foreach($norm['termine'] as $tid) {
+                $bits[] = self::terminParticipantLabel((int)$tid);
+            }
+        }
         return count($bits) ? implode(', ', $bits) : '—';
     }
 
@@ -426,13 +516,15 @@ class AudienceSpec
      * Chip items for read-only display (same types/labels as mailRecipients.js).
      *
      * @param mixed $spec
-     * @param array $opts allowMailGroups (bool)
+     * @param array $opts allowMailGroups (bool), allowTermine (bool)
      * @return array<int,array{type:string,label:string}>
      */
     public static function chipsForSpec($spec, $opts = array()) {
         $allowMailGroups = !array_key_exists('allowMailGroups', $opts) || !empty($opts['allowMailGroups']);
+        $allowTermine = !empty($opts['allowTermine']);
         $norm = self::normalize($spec, array(
             'allowMailGroups' => $allowMailGroups,
+            'allowTermine' => $allowTermine,
             'defaultGroups' => null,
         ));
         $chips = array();
@@ -464,6 +556,14 @@ class AudienceSpec
             $u->load_by_id((int)$uid);
             if((int)$u->Index) {
                 $chips[] = array('type' => 'user', 'label' => $u->getName());
+            }
+        }
+        if($allowTermine) {
+            foreach($norm['termine'] as $tid) {
+                $chips[] = array(
+                    'type' => 'termin',
+                    'label' => self::terminParticipantLabel((int)$tid),
+                );
             }
         }
         return $chips;
@@ -503,13 +603,17 @@ class AudienceSpec
      */
     public static function canonicalJson($spec, $opts = array()) {
         $allowMailGroups = !array_key_exists('allowMailGroups', $opts) || !empty($opts['allowMailGroups']);
+        $allowTermine = !empty($opts['allowTermine']);
         $norm = self::normalize($spec, array(
             'allowMailGroups' => $allowMailGroups,
+            'allowTermine' => $allowTermine,
             'defaultGroups' => null,
         ));
         if(!$allowMailGroups) {
-            unset($norm['mailGroups']);
             $norm['mailGroups'] = array();
+        }
+        if(!$allowTermine) {
+            $norm['termine'] = array();
         }
         if(self::isEmpty($norm)) {
             return '';
@@ -519,24 +623,27 @@ class AudienceSpec
             'registers' => $norm['registers'],
             'users' => $norm['users'],
             'mailGroups' => $norm['mailGroups'],
+            'termine' => $norm['termine'],
         ));
     }
 
     /**
      * Catalog for chip autocomplete.
      *
-     * @param array $opts forMail (bool), includeMailGroups (bool)
+     * @param array $opts forMail (bool), includeMailGroups (bool), includeTermine (bool)
      * @return array
      */
     public static function buildCatalog($opts = array()) {
         $forMail = !empty($opts['forMail']);
         $includeMailGroups = !array_key_exists('includeMailGroups', $opts) || !empty($opts['includeMailGroups']);
+        $includeTermine = !empty($opts['includeTermine']);
 
         $catalog = array(
             'groups' => array(),
             'registers' => array(),
             'users' => array(),
             'mailGroups' => array(),
+            'termine' => array(),
         );
         foreach(self::groupLabels() as $id => $label) {
             $catalog['groups'][] = array('id' => $id, 'label' => $label, 'meta' => 'Rolle');
@@ -592,6 +699,26 @@ class AudienceSpec
                     'label' => (string)$g->Name,
                     'meta' => 'Gruppe',
                 );
+            }
+        }
+
+        if($includeTermine) {
+            $today = date('Y-m-d');
+            $sqlTerm = sprintf(
+                'SELECT `Index`, `Name`, `Datum` FROM `%sTermine` WHERE `Datum` >= "%s" ORDER BY `Datum`, `Name` LIMIT 200;',
+                $GLOBALS['dbprefix'],
+                mysqli_real_escape_string($GLOBALS['conn'], $today)
+            );
+            $dbrTerm = mysqli_query($GLOBALS['conn'], $sqlTerm);
+            if($dbrTerm) {
+                while($row = mysqli_fetch_array($dbrTerm)) {
+                    $tid = (int)$row['Index'];
+                    $catalog['termine'][] = array(
+                        'id' => $tid,
+                        'label' => self::terminParticipantLabel($tid),
+                        'meta' => 'Termin',
+                    );
+                }
             }
         }
 

--- a/libs/mailJob.php
+++ b/libs/mailJob.php
@@ -124,6 +124,7 @@ class MailJob
 
     /**
      * Create a new draft with fixed ID and dedicated attachment directory.
+     * Optional $termin preselects a Teilnehmer-chip (RecipientSpec), not MailJob.Termin.
      */
     public static function createDraft($createdBy = 0, $termin = 0) {
         self::ensureSchema();
@@ -132,11 +133,22 @@ class MailJob
         $job->Subject = '';
         $job->BodyText = '';
         $job->Source = 'mail';
-        $job->Termin = (int)$termin;
+        $job->Termin = 0;
         $job->Status = 'draft';
         $job->Gruss = 1;
-        $job->PostDiscord = ((int)$termin === 0 && Discord::isConfigured()) ? 1 : 0;
-        if((int)$termin === 0) {
+        $termin = (int)$termin;
+        if($termin > 0) {
+            $job->PostDiscord = 0;
+            $job->setRecipientSpecArray(array(
+                'groups' => array(),
+                'registers' => array(),
+                'users' => array(),
+                'mailGroups' => array(),
+                'termine' => array($termin),
+            ));
+        }
+        else {
+            $job->PostDiscord = Discord::isConfigured() ? 1 : 0;
             $job->setRecipientSpecArray(self::defaultRecipientSpecArray());
         }
         if(!$job->save()) {
@@ -239,6 +251,7 @@ class MailJob
     public static function parseRecipientSpec($json, $legacyRegister = 0, $legacyMemberOnly = 0) {
         return AudienceSpec::normalize($json, array(
             'allowMailGroups' => true,
+            'allowTermine' => true,
             'defaultGroups' => null,
             'legacyRegister' => $legacyRegister,
             'legacyMemberOnly' => $legacyMemberOnly,
@@ -251,6 +264,7 @@ class MailJob
     public function setRecipientSpecArray($spec) {
         $norm = AudienceSpec::normalize($spec, array(
             'allowMailGroups' => true,
+            'allowTermine' => true,
             'defaultGroups' => null,
         ));
         $payload = array(
@@ -258,6 +272,7 @@ class MailJob
             'registers' => $norm['registers'],
             'users' => $norm['users'],
             'mailGroups' => $norm['mailGroups'],
+            'termine' => $norm['termine'],
         );
         $this->RecipientSpec = json_encode($payload);
     }
@@ -268,6 +283,7 @@ class MailJob
             'registers' => array(),
             'users' => array(),
             'mailGroups' => array(),
+            'termine' => array(),
         );
     }
 

--- a/libs/usermail.php
+++ b/libs/usermail.php
@@ -252,7 +252,7 @@ class Usermail {
         if($count > 0) {
             $specLabel = AudienceSpec::formatLabel(
                 $job->getRecipientSpecArray(),
-                array('allowMailGroups' => true)
+                array('allowMailGroups' => true, 'allowTermine' => true)
             );
             $logentry->email(sprintf(
                 "In Warteschlange gestellt | Email-ID: <b>%d</b>, Betreff: <b>%s</b>, Empfänger: <b>%d</b>, Quelle: <b>%s</b>, Auswahl: <b>%s</b>",
@@ -751,6 +751,7 @@ class Usermail {
         $spec = is_array($this->recipientSpec)
             ? AudienceSpec::normalize($this->recipientSpec, array(
                 'allowMailGroups' => true,
+                'allowTermine' => true,
                 'defaultGroups' => array('musicians'),
                 'legacyRegister' => (int)$this->register,
                 'legacyMemberOnly' => $this->memberonly ? 1 : 0,

--- a/mail.php
+++ b/mail.php
@@ -100,22 +100,16 @@ if($job && $job->Status === 'draft' && (isset($_POST['save']) || isset($_POST['p
     $rawBody = isset($_POST['Text']) ? (string)$_POST['Text'] : '';
     $job->BodyText = function_exists('sanitizeMailHtml') ? sanitizeMailHtml($rawBody) : $rawBody;
     $job->Gruss = isset($_POST['gruss']) ? (int)$_POST['gruss'] : 1;
-    $job->Termin = isset($_POST['termin']) ? (int)$_POST['termin'] : (int)$job->Termin;
-    if($job->Termin) {
-        $job->RecipientSpec = null;
-        $job->PostDiscord = ($discordAvailable && isset($_POST['postDiscord'])) ? 1 : 0;
-    }
-    else {
-        $specIn = MailJob::defaultRecipientSpecArray();
-        if(isset($_POST['recipientSpec'])) {
-            $decoded = json_decode((string)$_POST['recipientSpec'], true);
-            if(is_array($decoded)) {
-                $specIn = $decoded;
-            }
+    $job->Termin = 0;
+    $specIn = MailJob::defaultRecipientSpecArray();
+    if(isset($_POST['recipientSpec'])) {
+        $decoded = json_decode((string)$_POST['recipientSpec'], true);
+        if(is_array($decoded)) {
+            $specIn = $decoded;
         }
-        $job->setRecipientSpecArray($specIn);
-        $job->PostDiscord = ($discordAvailable && isset($_POST['postDiscord'])) ? 1 : 0;
     }
+    $job->setRecipientSpecArray($specIn);
+    $job->PostDiscord = ($discordAvailable && isset($_POST['postDiscord'])) ? 1 : 0;
     $job->ensureAttachmentDir();
     $job->save();
 
@@ -163,19 +157,31 @@ if(isset($_GET['deleted'])) {
 }
 
 $recipientSpec = $job ? $job->getRecipientSpecArray() : MailJob::defaultRecipientSpecArray();
+// Legacy: Entwurf mit MailJob.Termin → Termin-Chip in RecipientSpec
+if($job && $job->Status === 'draft' && (int)$job->Termin > 0) {
+    $legacyTermin = (int)$job->Termin;
+    $job->Termin = 0;
+    $job->setRecipientSpecArray(array(
+        'groups' => array(),
+        'registers' => array(),
+        'users' => array(),
+        'mailGroups' => array(),
+        'termine' => array($legacyTermin),
+    ));
+    $job->save();
+    $recipientSpec = $job->getRecipientSpecArray();
+}
 // Neue / leere Entwürfe: Alle Musiker vorauswählen und im Job speichern
-// (mailGroups zählen mit — sonst würden reine Gruppen-Chips überschrieben)
+// (mailGroups/termine zählen mit — sonst würden reine Gruppen-/Termin-Chips überschrieben)
 if(
     $job
     && $job->Status === 'draft'
-    && !(int)$job->Termin
     && AudienceSpec::isEmpty($recipientSpec)
 ) {
     $recipientSpec = MailJob::defaultRecipientSpecArray();
     $job->setRecipientSpecArray($recipientSpec);
     $job->save();
 }
-$termin = $job ? (int)$job->Termin : $terminParam;
 $gruss = $job ? (int)$job->Gruss : 1;
 $betreff = $job ? (string)$job->Subject : '';
 $textRaw = $job ? (string)$job->BodyText : '';
@@ -188,7 +194,25 @@ MailGroup::ensureSchema();
 $mailRecipientCatalog = AudienceSpec::buildCatalog(array(
     'forMail' => true,
     'includeMailGroups' => true,
+    'includeTermine' => true,
 ));
+// Ensure already selected termine appear (also past events)
+if(!empty($recipientSpec['termine']) && is_array($recipientSpec['termine'])) {
+    $known = array();
+    foreach($mailRecipientCatalog['termine'] as $row) {
+        $known[(int)$row['id']] = true;
+    }
+    foreach($recipientSpec['termine'] as $tid) {
+        $tid = (int)$tid;
+        if($tid <= 0 || isset($known[$tid])) continue;
+        $mailRecipientCatalog['termine'][] = array(
+            'id' => $tid,
+            'label' => AudienceSpec::terminParticipantLabel($tid),
+            'meta' => 'Termin',
+        );
+        $known[$tid] = true;
+    }
+}
 
 $allJobs = MailJob::listJobs(null, 300);
 
@@ -360,39 +384,9 @@ foreach($allJobs as $rowJob) {
   <form name="mailform" class="w3-container w3-margin" action="mail.php?id=<?php echo (int)$job->Index; ?>" method="POST" enctype="multipart/form-data">
     <input type="hidden" name="id" value="<?php echo (int)$job->Index; ?>" />
     <label>Empfänger</label>
-    <?php
-         if($termin) {
-             $t=new Termin;
-             $t->load_by_id($termin);
-    ?>
-             <div class="w3-mobile w3-margin-bottom w3-padding">Alle Teilnehmer von <?php echo htmlspecialchars($t->Name." (".$t->getGermanDate().")", ENT_QUOTES, 'UTF-8'); ?>
-               <span id="mailRecipientCount" class="mail-recipient-count" data-termin="<?php echo (int)$termin; ?>" aria-live="polite"></span>
-             </div>
-    <input type="hidden" name="termin" value="<?php echo (int)$termin; ?>" />
-    <script>
-    (function() {
-      var el = document.getElementById('mailRecipientCount');
-      if(!el) return;
-      var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
-      xhr.onreadystatechange = function() {
-        if(xhr.readyState !== 4 || xhr.status !== 200) return;
-        try {
-          var data = JSON.parse(xhr.responseText);
-          var n = data && typeof data.count === 'number' ? data.count : 0;
-          el.textContent = n === 1 ? '1 Empfänger' : (n + ' Empfänger');
-        } catch(e) {}
-      };
-      xhr.open('GET', 'mailRecipientCount.php?termin=' + encodeURIComponent(el.getAttribute('data-termin') || '0'), true);
-      xhr.send();
-    })();
-    </script>
-    <?php
-         }
-         else {
-    ?>
     <div class="w3-mobile w3-margin-bottom w3-padding w3-border <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?>">
       <div id="mailRecipientChips" class="mail-recipient-chips" aria-live="polite"></div>
-      <input type="text" id="mailRecipientInput" class="w3-input w3-border <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?>" placeholder="Gruppe, Rolle, Register oder Person tippen…" autocomplete="off" />
+      <input type="text" id="mailRecipientInput" class="w3-input w3-border <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?>" placeholder="Gruppe, Rolle, Register, Termin oder Person tippen…" autocomplete="off" />
       <div id="mailRecipientSuggest" class="mail-recipient-suggest" hidden></div>
       <input type="hidden" name="recipientSpec" id="mailRecipientSpec" value="<?php echo htmlspecialchars(json_encode($recipientSpec), ENT_QUOTES, 'UTF-8'); ?>" />
       <p class="w3-small w3-margin-top mail-recipient-count-line">
@@ -426,8 +420,6 @@ foreach($allJobs as $rowJob) {
   window.syncDiscordDefault = function() {
     var cb = document.getElementById('postDiscord');
     if(!cb) return;
-    var isTermin = <?php echo $termin ? 'true' : 'false'; ?>;
-    if(isTermin) { cb.checked = false; return; }
     var specEl = document.getElementById('mailRecipientSpec');
     try {
       var spec = JSON.parse(specEl ? specEl.value : '{}');
@@ -435,7 +427,9 @@ foreach($allJobs as $rowJob) {
         && spec.groups.length === 1
         && spec.groups[0] === 'musicians'
         && (!spec.registers || !spec.registers.length)
-        && (!spec.users || !spec.users.length);
+        && (!spec.users || !spec.users.length)
+        && (!spec.mailGroups || !spec.mailGroups.length)
+        && (!spec.termine || !spec.termine.length);
       cb.checked = !!isDefaultAll;
     } catch(e) {
       cb.checked = false;
@@ -444,15 +438,7 @@ foreach($allJobs as $rowJob) {
   window.syncDiscordDefault();
 })();
 </script>
-<?php } ?>
-<?php if($discordAvailable && $termin) { ?>
-<script>
-window.syncDiscordDefault = function() {
-  var cb = document.getElementById('postDiscord');
-  if(cb) cb.checked = false;
-};
-</script>
-<?php } elseif(!$termin && !$discordAvailable) { ?>
+<?php if(!$discordAvailable) { ?>
 <script>
 window.syncDiscordDefault = function() {};
 </script>
@@ -694,6 +680,7 @@ function delFile(hash) {
     else {
         $verteilerHtml = AudienceSpec::renderChipsHtml($recipientSpecView, array(
             'allowMailGroups' => true,
+            'allowTermine' => true,
             'ariaLabel' => 'Verteiler',
             'emptyHtml' => '<span class="w3-text-gray">—</span>',
         ));

--- a/mailRecipientCount.php
+++ b/mailRecipientCount.php
@@ -48,6 +48,7 @@ elseif($requireMail) {
 else {
     $norm = AudienceSpec::normalize($spec, array(
         'allowMailGroups' => true,
+        'allowTermine' => false,
         'defaultGroups' => null,
     ));
     $count = count(AudienceSpec::resolveUserIds($norm, false));

--- a/mailSaveRecipients.php
+++ b/mailSaveRecipients.php
@@ -29,10 +29,6 @@ if(!$job->Index || $job->Status !== 'draft') {
     echo json_encode(array('ok' => false, 'error' => 'not_draft'));
     exit;
 }
-if((int)$job->Termin > 0) {
-    echo json_encode(array('ok' => true, 'skipped' => 'termin'));
-    exit;
-}
 
 $specRaw = isset($_POST['recipientSpec']) ? (string)$_POST['recipientSpec'] : '';
 $decoded = json_decode($specRaw, true);

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1169,6 +1169,11 @@
   border-color: #66bb6a;
 }
 
+.mail-recipient-chip--termin {
+  background: #f3e5f5;
+  border-color: #ab47bc;
+}
+
 .mail-recipient-chip--user {
   background: #f7f3e3;
   border-color: #c9b87a;

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -211,7 +211,7 @@ $sections[] = array(
     'body' => '
 <p>Unter Admin → <b>Email versenden</b> erstellst du Nachrichten an Verteiler oder einzelne Empfänger.</p>
 <p>Unter Admin → <b>Gruppen</b> legst du wiederverwendbare Gruppen an (Rollen, Register, Personen). Diese Gruppen kannst du beim Mailversand und bei der Termin-Sichtbarkeit als Chip auswählen.</p>
-<p>Mails werden in einer Warteschlange verarbeitet; den Versandstatus siehst du in der Admin-Ansicht. Bei versendeten Mails siehst du den gewählten <b>Verteiler</b> (Rollen, Gruppen, Register bzw. Termin-Teilnehmer) sowie die Liste der einzelnen Empfänger. Empfänger finden die Nachricht unter <b>Meine Nachrichten</b>.</p>
+<p>Beim Mailversand kannst du Chips für Rollen, Gruppen, Register, Personen und <b>Teilnehmer</b> (ja/vielleicht) zukünftiger Termine wählen. Über <b>Email an Teilnehmer</b> am Termin wird der passende Teilnehmer-Chip vorausgewählt. Mails werden in einer Warteschlange verarbeitet; den Versandstatus siehst du in der Admin-Ansicht. Bei versendeten Mails siehst du den gewählten <b>Verteiler</b> sowie die Liste der einzelnen Empfänger. Empfänger finden die Nachricht unter <b>Meine Nachrichten</b>.</p>
 <p>Falls Discord angebunden ist, kann der Versand optional auch dort veröffentlicht werden (nur bei konfiguriertem Webhook).</p>
 '
 );


### PR DESCRIPTION
## Summary
- RecipientSpec-Schlüssel `termine[]` für Teilnehmer (ja + vielleicht)
- Chip-Autocomplete für zukünftige Termine; „Email an Teilnehmer“ setzt den Chip voraus
- Poll-Termine nach `Created` sortieren (neueste zuerst)
- Hilfe in guide.php ergänzt

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-135

## Test plan
- [ ] Admin → Email: Termin-Chip suchen/wählen, Empfängerzahl prüfen
- [ ] Am Termin „Email an Teilnehmer“ → Chip vorausgewählt, erweiterbar
- [ ] Versand/Entwurf: Verteiler zeigt Termin-Chip
- [ ] Ohne Termin-Chip: bisherige Rollen/Gruppen/Register unverändert

Made with [Cursor](https://cursor.com)