### PR TITLE
MELD-138: Admin-Überschriften in Rechte-Farben

### DIFF
--- a/backup.php
+++ b/backup.php
@@ -74,12 +74,8 @@ if($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['restore_confirm'])) {
 $manifest = buildBackupManifest();
 $ver = $manifest['version'];
 $schema = $manifest['schemaVersion'];
+adminListPageBegin('System', 'Backup & Restore', array('permKey' => 'perm_editConfig'));
 ?>
-<div id="header" class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-  <h2>Backup &amp; Restore</h2>
-</div>
-
-<div class="w3-container w3-margin-top">
 <?php if($flash) {
     $panel = ($flash['type'] === 'ok') ? $GLOBALS['optionsDB']['colorSuccess'] : $GLOBALS['optionsDB']['colorLogError'];
     echo '<div class="w3-panel '.$panel.'"><p>'.htmlspecialchars($flash['message'], ENT_QUOTES, 'UTF-8').'</p></div>';
@@ -118,8 +114,7 @@ $schema = $manifest['schemaVersion'];
       <button type="submit" class="w3-button w3-border w3-red">Backup einspielen</button>
     </form>
   </div>
-</div>
-
 <?php
+adminListPageEnd();
 include 'common/footer.php';
 ?>

--- a/config-menu.php
+++ b/config-menu.php
@@ -147,10 +147,8 @@ function resetColorScheme() {
 	xmlhttp.send(body);
 }
 </script>
-<div class="w3-container <?php echo htmlspecialchars(adminHeroClass(array('kicker' => 'globale Einstellungen', 'permKey' => 'perm_editConfig', 'withProfileHero' => false)), ENT_QUOTES, 'UTF-8'); ?>">
-    <h2>globale Einstellungen</h2>
-</div>
-<div class="w3-container w3-card w3-margin w3-padding <?php echo $GLOBALS['optionsDB']['colorWarning']; ?>">
+<?php adminListPageBegin('System', 'globale Einstellungen', array('permKey' => 'perm_editConfig')); ?>
+<div class="w3-container w3-card w3-margin-bottom w3-padding <?php echo $GLOBALS['optionsDB']['colorWarning']; ?>">
   <div class="w3-col l3 m3 s2 w3-center">
     <i class="fas fa-exclamation-triangle"></i>
 </div>
@@ -282,7 +280,7 @@ while($row = mysqli_fetch_array($dbr)) {
 ?>
 <button class="w3-btn w3-padding <?php echo $GLOBALS['optionsDB']['colorBtnSubmit']; ?> w3-border w3-margin w3-mobile" type="submit" name="save" value="speichern" >speichern</button>
     </form>
-      
 <?php
+adminListPageEnd();
 include "common/footer.php";
 ?>

--- a/config-menu.php
+++ b/config-menu.php
@@ -147,7 +147,7 @@ function resetColorScheme() {
 	xmlhttp.send(body);
 }
 </script>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
+<div class="w3-container <?php echo htmlspecialchars(adminHeroClass(array('kicker' => 'globale Einstellungen', 'permKey' => 'perm_editConfig', 'withProfileHero' => false)), ENT_QUOTES, 'UTF-8'); ?>">
     <h2>globale Einstellungen</h2>
 </div>
 <div class="w3-container w3-card w3-margin w3-padding <?php echo $GLOBALS['optionsDB']['colorWarning']; ?>">

--- a/edit-shifts.php
+++ b/edit-shifts.php
@@ -60,15 +60,16 @@ if(!$n->Index) {
 }
 
 include "common/header.php";
+$shiftHero = adminHeroClass(array('kicker' => 'Schichten bearbeiten', 'permKey' => 'perm_editAppmnts', 'withProfileHero' => false));
 ?>
-<div class="w3-container w3-margin-bottom <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
+<div class="w3-container w3-margin-bottom <?php echo htmlspecialchars($shiftHero, ENT_QUOTES, 'UTF-8'); ?>">
     <h2>Schichten bearbeiten</h2>
 <p><?php echo $n->Name." (".germanDate($n->Datum, 1).")"; ?></p>
 </div>
 <?php echo renderFlashHtml(); ?>
 
 <?php echo $n->printShiftEdit(); ?>
-<div class="w3-container w3-margin-bottom w3-margin-top <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
+<div class="w3-container w3-margin-bottom w3-margin-top <?php echo htmlspecialchars($shiftHero, ENT_QUOTES, 'UTF-8'); ?>">
 <p>neue Schicht anlegen</p>
 </div>
 <?php echo $n->shiftEditLine(0); ?>

--- a/edit-shifts.php
+++ b/edit-shifts.php
@@ -60,20 +60,20 @@ if(!$n->Index) {
 }
 
 include "common/header.php";
-$shiftHero = adminHeroClass(array('kicker' => 'Schichten bearbeiten', 'permKey' => 'perm_editAppmnts', 'withProfileHero' => false));
+$shiftSub = htmlspecialchars($n->Name.' ('.germanDate($n->Datum, 1).')', ENT_QUOTES, 'UTF-8');
+adminListPageBegin('Termine', 'Schichten bearbeiten', array('permKey' => 'perm_editAppmnts'));
 ?>
-<div class="w3-container w3-margin-bottom <?php echo htmlspecialchars($shiftHero, ENT_QUOTES, 'UTF-8'); ?>">
-    <h2>Schichten bearbeiten</h2>
-<p><?php echo $n->Name." (".germanDate($n->Datum, 1).")"; ?></p>
+<div class="admin-list-intro">
+  <p><?php echo $shiftSub; ?></p>
 </div>
 <?php echo renderFlashHtml(); ?>
 
 <?php echo $n->printShiftEdit(); ?>
-<div class="w3-container w3-margin-bottom w3-margin-top <?php echo htmlspecialchars($shiftHero, ENT_QUOTES, 'UTF-8'); ?>">
-<p>neue Schicht anlegen</p>
+<div class="admin-list-intro w3-margin-top">
+  <p>neue Schicht anlegen</p>
 </div>
 <?php echo $n->shiftEditLine(0); ?>
-
 <?php
+adminListPageEnd();
 include "common/footer.php";
 ?>

--- a/evaluate.php
+++ b/evaluate.php
@@ -33,10 +33,10 @@ $payload = array(
     'logLabels' => array('FATAL', 'ERROR', 'WARNING', 'DBDELETE', 'DBINSERT', 'DBUPDATE', 'EMAIL', 'INFO'),
 );
 
-$titleBar = $GLOBALS['optionsDB']['colorTitleBar'];
+$titleBar = adminHeroClass(array('kicker' => 'Datenauswertung', 'permKey' => 'perm_showLog', 'withProfileHero' => false));
 $btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
 ?>
-<div id="header" class="w3-container <?php echo $titleBar; ?>">
+<div id="header" class="w3-container <?php echo htmlspecialchars($titleBar, ENT_QUOTES, 'UTF-8'); ?>">
   <h2>Datenauswertung</h2>
 </div>
 

--- a/evaluate.php
+++ b/evaluate.php
@@ -33,14 +33,11 @@ $payload = array(
     'logLabels' => array('FATAL', 'ERROR', 'WARNING', 'DBDELETE', 'DBINSERT', 'DBUPDATE', 'EMAIL', 'INFO'),
 );
 
-$titleBar = adminHeroClass(array('kicker' => 'Datenauswertung', 'permKey' => 'perm_showLog', 'withProfileHero' => false));
+$tableHeadClass = adminHeroClass(array('kicker' => 'Datenauswertung', 'permKey' => 'perm_showLog', 'withProfileHero' => false));
 $btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
+adminListPageBegin('System', 'Datenauswertung', array('permKey' => 'perm_showLog'));
 ?>
-<div id="header" class="w3-container <?php echo htmlspecialchars($titleBar, ENT_QUOTES, 'UTF-8'); ?>">
-  <h2>Datenauswertung</h2>
-</div>
-
-<div class="w3-container w3-margin-top w3-margin-bottom">
+<div class="w3-container w3-margin-bottom">
   <form method="get" action="evaluate.php" class="eval-filter" id="eval-filter">
     <label for="eval-days"><b>Zeitraum</b></label>
     <input id="eval-days" name="days" type="number" min="1" max="3650" step="1" value="<?php echo (int)$days; ?>" class="w3-input w3-border" required>
@@ -86,12 +83,12 @@ $btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
         <table id="evalRanking" class="w3-table w3-striped w3-bordered w3-hoverable eval-data-table">
           <thead>
             <tr>
-              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="name" data-type="string">Name</th>
-              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="yes" data-type="number">Ja</th>
-              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="no" data-type="number">Nein</th>
-              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="maybe" data-type="number">Vielleicht</th>
-              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="termine" data-type="number">Termine</th>
-              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="quote" data-type="number">Quote</th>
+              <th class="eval-sort <?php echo $tableHeadClass; ?>" data-sort="name" data-type="string">Name</th>
+              <th class="eval-sort <?php echo $tableHeadClass; ?>" data-sort="yes" data-type="number">Ja</th>
+              <th class="eval-sort <?php echo $tableHeadClass; ?>" data-sort="no" data-type="number">Nein</th>
+              <th class="eval-sort <?php echo $tableHeadClass; ?>" data-sort="maybe" data-type="number">Vielleicht</th>
+              <th class="eval-sort <?php echo $tableHeadClass; ?>" data-sort="termine" data-type="number">Termine</th>
+              <th class="eval-sort <?php echo $tableHeadClass; ?>" data-sort="quote" data-type="number">Quote</th>
             </tr>
           </thead>
           <tbody></tbody>
@@ -106,10 +103,10 @@ $btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
         <table id="evalInactive" class="w3-table w3-striped w3-bordered w3-hoverable eval-data-table">
           <thead>
             <tr>
-              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="name" data-type="string">Name</th>
-              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="lastLogin" data-type="string">Letzter Login</th>
-              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="lastAttend" data-type="string">Letzte Teilnahme</th>
-              <th class="eval-sort <?php echo $titleBar; ?>" data-sort="quote" data-type="number">Meldequote</th>
+              <th class="eval-sort <?php echo $tableHeadClass; ?>" data-sort="name" data-type="string">Name</th>
+              <th class="eval-sort <?php echo $tableHeadClass; ?>" data-sort="lastLogin" data-type="string">Letzter Login</th>
+              <th class="eval-sort <?php echo $tableHeadClass; ?>" data-sort="lastAttend" data-type="string">Letzte Teilnahme</th>
+              <th class="eval-sort <?php echo $tableHeadClass; ?>" data-sort="quote" data-type="number">Meldequote</th>
             </tr>
           </thead>
           <tbody></tbody>
@@ -122,7 +119,7 @@ $btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
 <script type="application/json" id="evaluate-data"><?php echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS); ?></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.8/dist/chart.umd.min.js"></script>
 <script src="<?php echo $evaluateJs; ?>"></script>
-
 <?php
+adminListPageEnd();
 include "common/footer.php";
 ?>

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -217,9 +217,46 @@ function adminListSectionGroupId($kicker) {
         'Inventar' => 'inventar',
         'Register' => 'register',
         'System' => 'system',
+        // Admin-Formulare (nicht Listen)
+        'Neuer Termin' => 'termine',
+        'Termin bearbeiten' => 'termine',
+        'Termin kopieren' => 'termine',
+        'Schichten bearbeiten' => 'termine',
+        'Neuer Nutzer' => 'nutzer',
+        'Nutzer bearbeiten' => 'nutzer',
+        'Mein Profil' => 'nutzer',
+        'globale Einstellungen' => 'system',
+        'Datenauswertung' => 'system',
     );
     $k = trim((string)$kicker);
     return isset($map[$k]) ? $map[$k] : 'system';
+}
+
+/**
+ * CSS classes for Admin-Hero (Rechte-Farben wie Nav/Chips).
+ * @param array $options kicker|groupId|permKey, withProfileHero (bool, default true)
+ * @return string
+ */
+function adminHeroClass($options = array()) {
+    if(isset($options['groupId']) && (string)$options['groupId'] !== '') {
+        $gid = (string)$options['groupId'];
+    }
+    elseif(isset($options['permKey']) && (string)$options['permKey'] !== '') {
+        $gid = Permissions::groupIdForPermission((string)$options['permKey']);
+    }
+    elseif(isset($options['kicker'])) {
+        $gid = adminListSectionGroupId((string)$options['kicker']);
+    }
+    else {
+        $gid = 'system';
+    }
+    $gid = preg_replace('/[^a-z0-9_-]/i', '', (string)$gid);
+    if($gid === '') {
+        $gid = 'system';
+    }
+    $withProfile = !array_key_exists('withProfileHero', $options) || !empty($options['withProfileHero']);
+    $base = $withProfile ? 'profile-hero admin-list-hero' : 'admin-list-hero';
+    return $base.' admin-list-hero--'.$gid;
 }
 
 /**
@@ -233,20 +270,14 @@ function adminListPageBegin($kicker, $title, $options = array()) {
     $actionsHtml = isset($options['actionsHtml']) ? (string)$options['actionsHtml'] : '';
     $shellClass = isset($options['shellClass']) ? trim((string)$options['shellClass']) : '';
     $shellCls = 'profile-shell admin-list-shell'.($shellClass !== '' ? ' '.$shellClass : '');
-    if(isset($options['groupId']) && (string)$options['groupId'] !== '') {
-        $gid = (string)$options['groupId'];
+    $heroOpts = array('kicker' => $kicker);
+    if(isset($options['groupId'])) {
+        $heroOpts['groupId'] = $options['groupId'];
     }
-    elseif(isset($options['permKey']) && (string)$options['permKey'] !== '') {
-        $gid = Permissions::groupIdForPermission((string)$options['permKey']);
+    if(isset($options['permKey'])) {
+        $heroOpts['permKey'] = $options['permKey'];
     }
-    else {
-        $gid = adminListSectionGroupId($kicker);
-    }
-    $gid = preg_replace('/[^a-z0-9_-]/i', '', (string)$gid);
-    if($gid === '') {
-        $gid = 'system';
-    }
-    $heroCls = 'profile-hero admin-list-hero admin-list-hero--'.$gid;
+    $heroCls = adminHeroClass($heroOpts);
     echo '<div class="w3-container w3-margin-bottom profile-page">'."\n";
     echo '  <div class="'.htmlspecialchars($shellCls, ENT_QUOTES, 'UTF-8').'">'."\n";
     echo '    <header class="'.htmlspecialchars($heroCls, ENT_QUOTES, 'UTF-8').'">'."\n";

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -213,9 +213,12 @@ function adminListPageBegin($kicker, $title, $options = array()) {
     $actionsHtml = isset($options['actionsHtml']) ? (string)$options['actionsHtml'] : '';
     $shellClass = isset($options['shellClass']) ? trim((string)$options['shellClass']) : '';
     $shellCls = 'profile-shell admin-list-shell'.($shellClass !== '' ? ' '.$shellClass : '');
+    $titleBar = isset($GLOBALS['optionsDB']['colorTitleBar'])
+        ? trim((string)$GLOBALS['optionsDB']['colorTitleBar']) : '';
+    $heroCls = 'profile-hero'.($titleBar !== '' ? ' '.$titleBar : '');
     echo '<div class="w3-container w3-margin-bottom profile-page">'."\n";
     echo '  <div class="'.htmlspecialchars($shellCls, ENT_QUOTES, 'UTF-8').'">'."\n";
-    echo '    <header class="profile-hero">'."\n";
+    echo '    <header class="'.htmlspecialchars($heroCls, ENT_QUOTES, 'UTF-8').'">'."\n";
     echo '      <div class="profile-hero-text">'."\n";
     echo '        <p class="profile-kicker">'.htmlspecialchars((string)$kicker, ENT_QUOTES, 'UTF-8').'</p>'."\n";
     echo '        <h2 class="profile-title">'.htmlspecialchars((string)$title, ENT_QUOTES, 'UTF-8').'</h2>'."\n";

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -204,18 +204,49 @@ function adminNavPermClass($permKey) {
 }
 
 /**
+ * Map Admin-Listen-Kicker (Personen, Inventar, …) auf Rechte-Farbgruppe.
+ * @param string $kicker
+ * @return string nutzer|termine|register|inventar|kommunikation|system
+ */
+function adminListSectionGroupId($kicker) {
+    $map = array(
+        'Personen' => 'nutzer',
+        'Termine' => 'termine',
+        'Meldungen' => 'termine',
+        'Kommunikation' => 'kommunikation',
+        'Inventar' => 'inventar',
+        'Register' => 'register',
+        'System' => 'system',
+    );
+    $k = trim((string)$kicker);
+    return isset($map[$k]) ? $map[$k] : 'system';
+}
+
+/**
  * Open admin list page chrome (profile-shell, same style as new-musiker / permissions).
+ * Hero color follows the Admin-Rechte group (same palette as Nav/Chips).
  * @param string $kicker Section label (Personen, Inventar, …)
  * @param string $title Page title (plain text)
- * @param array $options actionsHtml (string), shellClass (string)
+ * @param array $options actionsHtml (string), shellClass (string), permKey (string), groupId (string)
  */
 function adminListPageBegin($kicker, $title, $options = array()) {
     $actionsHtml = isset($options['actionsHtml']) ? (string)$options['actionsHtml'] : '';
     $shellClass = isset($options['shellClass']) ? trim((string)$options['shellClass']) : '';
     $shellCls = 'profile-shell admin-list-shell'.($shellClass !== '' ? ' '.$shellClass : '');
-    $titleBar = isset($GLOBALS['optionsDB']['colorTitleBar'])
-        ? trim((string)$GLOBALS['optionsDB']['colorTitleBar']) : '';
-    $heroCls = 'profile-hero'.($titleBar !== '' ? ' '.$titleBar : '');
+    if(isset($options['groupId']) && (string)$options['groupId'] !== '') {
+        $gid = (string)$options['groupId'];
+    }
+    elseif(isset($options['permKey']) && (string)$options['permKey'] !== '') {
+        $gid = Permissions::groupIdForPermission((string)$options['permKey']);
+    }
+    else {
+        $gid = adminListSectionGroupId($kicker);
+    }
+    $gid = preg_replace('/[^a-z0-9_-]/i', '', (string)$gid);
+    if($gid === '') {
+        $gid = 'system';
+    }
+    $heroCls = 'profile-hero admin-list-hero admin-list-hero--'.$gid;
     echo '<div class="w3-container w3-margin-bottom profile-page">'."\n";
     echo '  <div class="'.htmlspecialchars($shellCls, ENT_QUOTES, 'UTF-8').'">'."\n";
     echo '    <header class="'.htmlspecialchars($heroCls, ENT_QUOTES, 'UTF-8').'">'."\n";

--- a/new-termin.php
+++ b/new-termin.php
@@ -68,7 +68,7 @@ if($fill && $n) {
 <div class="profile-shell termin-shell">
 <form class="profile-form" action="index.php" method="POST">
 
-  <header class="profile-hero">
+  <header class="<?php echo htmlspecialchars(adminHeroClass(array('kicker' => $terminKicker, 'permKey' => 'perm_editAppmnts')), ENT_QUOTES, 'UTF-8'); ?>">
     <div class="profile-hero-text">
       <p class="profile-kicker"><?php echo htmlspecialchars($terminKicker, ENT_QUOTES, 'UTF-8'); ?></p>
       <h2 class="profile-title"><?php echo htmlspecialchars($terminTitle, ENT_QUOTES, 'UTF-8'); ?></h2>

--- a/public-entry.php
+++ b/public-entry.php
@@ -13,13 +13,12 @@ $state = 1;
 if(isset($_POST['letter'])) {
     $state = 2;
 }
+
+adminListPageBegin('Meldungen', 'Im Auftrag melden', array('permKey' => 'perm_editResponse'));
 ?>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar'] ;?>">
-    <h2>Im Namen eines Anderen anmelden</h2>
-</div>
 <?php if($state == 1) { ?>
-    <div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar'] ;?>">
-	<h3>Erster Buchstabe des Nachnamens</h3>
+    <div class="admin-list-intro">
+      <p>Erster Buchstabe des Nachnamens</p>
     </div>
     <form class="w3-container w3-row" action="" method="POST">
 	<?php
@@ -32,14 +31,14 @@ if(isset($_POST['letter'])) {
 <?php } ?>
 
 <?php if($state == 2) { ?>
-    <div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar'] ;?>">
-	<h3>Name</h3>
+    <div class="admin-list-intro">
+      <p>Name</p>
     </div>
     <form class="w3-container w3-row" action="index.php" method="POST">
 	<?php
 	$sql = sprintf('SELECT * FROM `%sUser` WHERE `Nachname` LIKE "%s%%" AND `Deleted` = 0;',
     $GLOBALS['dbprefix'],
-    $_POST['letter']);
+    mysqli_real_escape_string($conn, (string)$_POST['letter']));
 	$dbr = mysqli_query($conn, $sql);
     sqlerror();
 	while($row = mysqli_fetch_array($dbr)) {
@@ -50,11 +49,11 @@ if(isset($_POST['letter'])) {
 <?php } ?>
 
 <?php if($state > 1) { ?>
-    <form class="w3-container w3-row" action="" method="POST">
+    <form class="w3-container w3-row w3-margin-top" action="" method="POST">
 	<button class="w3-btn w3-border w3-margin-top w3-border-black s12 m12 l12 <?php echo $GLOBALS['optionsDB']['colorBtnEdit'] ;?>" type="submit">zur&uuml;ck</button>
     </form>
 <?php } ?>
-
 <?php
+adminListPageEnd();
 include "common/footer.php";
 ?>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2,8 +2,9 @@
   color: #111;
 }
 
-/* Hero tinted by Admin-Rechte group (same palette as Nav / Chips / Matrix) */
-.profile-shell > .profile-hero.admin-list-hero,
+/* Hero tinted by Admin-Rechte group (same palette as Nav / Chips / Matrix).
+   Descendant (not only >) so Form-Seiten mit .profile-form > header auch treffen. */
+.profile-shell .profile-hero.admin-list-hero,
 .w3-container.admin-list-hero {
   margin: -1px -1px 1.15rem;
   padding: 0.65rem 1rem;
@@ -13,52 +14,52 @@
   color: #222;
 }
 
-.profile-shell > .profile-hero.admin-list-hero .profile-kicker {
+.profile-shell .profile-hero.admin-list-hero .profile-kicker {
   opacity: 0.8;
   color: inherit;
 }
 
-.profile-shell > .profile-hero.admin-list-hero .profile-title {
+.profile-shell .profile-hero.admin-list-hero .profile-title {
   color: inherit;
   font-weight: 700;
 }
 
-.profile-shell > .profile-hero.admin-list-hero .profile-hero-actions .w3-button,
-.profile-shell > .profile-hero.admin-list-hero .profile-hero-actions .w3-btn {
+.profile-shell .profile-hero.admin-list-hero .profile-hero-actions .w3-button,
+.profile-shell .profile-hero.admin-list-hero .profile-hero-actions .w3-btn {
   color: inherit;
 }
 
-.profile-shell > .profile-hero.admin-list-hero--nutzer,
+.profile-shell .profile-hero.admin-list-hero--nutzer,
 .w3-container.admin-list-hero--nutzer {
   background: #90caf9;
   border-left-color: #42a5f5;
 }
 
-.profile-shell > .profile-hero.admin-list-hero--termine,
+.profile-shell .profile-hero.admin-list-hero--termine,
 .w3-container.admin-list-hero--termine {
   background: #a5d6a7;
   border-left-color: #66bb6a;
 }
 
-.profile-shell > .profile-hero.admin-list-hero--register,
+.profile-shell .profile-hero.admin-list-hero--register,
 .w3-container.admin-list-hero--register {
   background: #ffcc80;
   border-left-color: #ffa726;
 }
 
-.profile-shell > .profile-hero.admin-list-hero--inventar,
+.profile-shell .profile-hero.admin-list-hero--inventar,
 .w3-container.admin-list-hero--inventar {
   background: #ce93d8;
   border-left-color: #ab47bc;
 }
 
-.profile-shell > .profile-hero.admin-list-hero--kommunikation,
+.profile-shell .profile-hero.admin-list-hero--kommunikation,
 .w3-container.admin-list-hero--kommunikation {
   background: #80deea;
   border-left-color: #26c6da;
 }
 
-.profile-shell > .profile-hero.admin-list-hero--system,
+.profile-shell .profile-hero.admin-list-hero--system,
 .w3-container.admin-list-hero--system {
   background: #b0bec5;
   border-left-color: #78909c;
@@ -100,6 +101,33 @@
 
 .admin-list-shell .admin-list-intro p {
   margin: 0 0 0.4rem;
+}
+
+.updater-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.65rem;
+  align-items: stretch;
+}
+
+.updater-actions form {
+  margin: 0;
+  flex: 1 1 11rem;
+  min-width: 0;
+}
+
+.updater-actions .w3-button {
+  width: 100%;
+  text-align: center;
+  white-space: normal;
+  line-height: 1.35;
+  padding: 0.65rem 0.85rem;
+}
+
+@media (max-width: 600px) {
+  .updater-actions form {
+    flex: 1 1 100%;
+  }
 }
 
 .admin-list-shell .mail-list-header {

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2,26 +2,58 @@
   color: #111;
 }
 
-/* Colored title bar like older admin pages (colorTitleBar on .profile-hero) */
-.admin-list-shell > .profile-hero {
+/* Hero tinted by Admin-Rechte group (same palette as Nav / Chips / Matrix) */
+.admin-list-shell > .profile-hero.admin-list-hero {
   margin: -1px -1px 1.15rem;
   padding: 0.65rem 1rem;
   border-bottom: 0;
   border-radius: 10px 10px 0 0;
+  border-left: 6px solid transparent;
+  color: #222;
 }
 
-.admin-list-shell > .profile-hero .profile-kicker {
-  opacity: 0.85;
+.admin-list-shell > .profile-hero.admin-list-hero .profile-kicker {
+  opacity: 0.8;
   color: inherit;
 }
 
-.admin-list-shell > .profile-hero .profile-title {
+.admin-list-shell > .profile-hero.admin-list-hero .profile-title {
   color: inherit;
   font-weight: 700;
 }
 
-.admin-list-shell > .profile-hero .profile-hero-actions .w3-button {
+.admin-list-shell > .profile-hero.admin-list-hero .profile-hero-actions .w3-button {
   color: inherit;
+}
+
+.admin-list-shell > .profile-hero.admin-list-hero--nutzer {
+  background: #90caf9;
+  border-left-color: #42a5f5;
+}
+
+.admin-list-shell > .profile-hero.admin-list-hero--termine {
+  background: #a5d6a7;
+  border-left-color: #66bb6a;
+}
+
+.admin-list-shell > .profile-hero.admin-list-hero--register {
+  background: #ffcc80;
+  border-left-color: #ffa726;
+}
+
+.admin-list-shell > .profile-hero.admin-list-hero--inventar {
+  background: #ce93d8;
+  border-left-color: #ab47bc;
+}
+
+.admin-list-shell > .profile-hero.admin-list-hero--kommunikation {
+  background: #80deea;
+  border-left-color: #26c6da;
+}
+
+.admin-list-shell > .profile-hero.admin-list-hero--system {
+  background: #b0bec5;
+  border-left-color: #78909c;
 }
 
 .admin-list-toolbar {

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -3,7 +3,8 @@
 }
 
 /* Hero tinted by Admin-Rechte group (same palette as Nav / Chips / Matrix) */
-.admin-list-shell > .profile-hero.admin-list-hero {
+.profile-shell > .profile-hero.admin-list-hero,
+.w3-container.admin-list-hero {
   margin: -1px -1px 1.15rem;
   padding: 0.65rem 1rem;
   border-bottom: 0;
@@ -12,46 +13,53 @@
   color: #222;
 }
 
-.admin-list-shell > .profile-hero.admin-list-hero .profile-kicker {
+.profile-shell > .profile-hero.admin-list-hero .profile-kicker {
   opacity: 0.8;
   color: inherit;
 }
 
-.admin-list-shell > .profile-hero.admin-list-hero .profile-title {
+.profile-shell > .profile-hero.admin-list-hero .profile-title {
   color: inherit;
   font-weight: 700;
 }
 
-.admin-list-shell > .profile-hero.admin-list-hero .profile-hero-actions .w3-button {
+.profile-shell > .profile-hero.admin-list-hero .profile-hero-actions .w3-button,
+.profile-shell > .profile-hero.admin-list-hero .profile-hero-actions .w3-btn {
   color: inherit;
 }
 
-.admin-list-shell > .profile-hero.admin-list-hero--nutzer {
+.profile-shell > .profile-hero.admin-list-hero--nutzer,
+.w3-container.admin-list-hero--nutzer {
   background: #90caf9;
   border-left-color: #42a5f5;
 }
 
-.admin-list-shell > .profile-hero.admin-list-hero--termine {
+.profile-shell > .profile-hero.admin-list-hero--termine,
+.w3-container.admin-list-hero--termine {
   background: #a5d6a7;
   border-left-color: #66bb6a;
 }
 
-.admin-list-shell > .profile-hero.admin-list-hero--register {
+.profile-shell > .profile-hero.admin-list-hero--register,
+.w3-container.admin-list-hero--register {
   background: #ffcc80;
   border-left-color: #ffa726;
 }
 
-.admin-list-shell > .profile-hero.admin-list-hero--inventar {
+.profile-shell > .profile-hero.admin-list-hero--inventar,
+.w3-container.admin-list-hero--inventar {
   background: #ce93d8;
   border-left-color: #ab47bc;
 }
 
-.admin-list-shell > .profile-hero.admin-list-hero--kommunikation {
+.profile-shell > .profile-hero.admin-list-hero--kommunikation,
+.w3-container.admin-list-hero--kommunikation {
   background: #80deea;
   border-left-color: #26c6da;
 }
 
-.admin-list-shell > .profile-hero.admin-list-hero--system {
+.profile-shell > .profile-hero.admin-list-hero--system,
+.w3-container.admin-list-hero--system {
   background: #b0bec5;
   border-left-color: #78909c;
 }

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2,6 +2,28 @@
   color: #111;
 }
 
+/* Colored title bar like older admin pages (colorTitleBar on .profile-hero) */
+.admin-list-shell > .profile-hero {
+  margin: -1px -1px 1.15rem;
+  padding: 0.65rem 1rem;
+  border-bottom: 0;
+  border-radius: 10px 10px 0 0;
+}
+
+.admin-list-shell > .profile-hero .profile-kicker {
+  opacity: 0.85;
+  color: inherit;
+}
+
+.admin-list-shell > .profile-hero .profile-title {
+  color: inherit;
+  font-weight: 700;
+}
+
+.admin-list-shell > .profile-hero .profile-hero-actions .w3-button {
+  color: inherit;
+}
+
 .admin-list-toolbar {
   display: flex;
   flex-wrap: wrap;

--- a/updater.php
+++ b/updater.php
@@ -129,11 +129,9 @@ $schemaInfo = sprintf(
 );
 
 include 'common/header.php';
+adminListPageBegin('System', 'Updater', array('permKey' => 'perm_editConfig'));
 ?>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-  <h2>Updater</h2>
-</div>
-<div class="w3-container w3-card w3-margin w3-padding <?php echo $GLOBALS['optionsDB']['colorWarning']; ?>">
+<div class="w3-container w3-card w3-margin-bottom w3-padding <?php echo $GLOBALS['optionsDB']['colorWarning']; ?>">
   <div class="w3-col l3 m3 s2 w3-center">
     <i class="fas fa-exclamation-triangle"></i>
   </div>
@@ -158,22 +156,22 @@ include 'common/header.php';
       „Update durchführen“ zieht die Änderungen und repariert die Datenbank bei veraltetem Schema automatisch.
       Datenbank prüfen/reparieren kann unabhängig davon ausgeführt werden.</p>
   </div>
-  <div class="w3-padding">
-    <form action="updater.php" method="post" style="display:inline;">
+  <div class="w3-padding updater-actions">
+    <form action="updater.php" method="post">
       <input type="hidden" name="git_action" value="check">
-      <button class="w3-button w3-blue" type="submit">Auf Updates prüfen</button>
+      <button class="w3-button w3-border w3-blue w3-mobile" type="submit">Auf Updates prüfen</button>
     </form>
-    <form action="updater.php" method="post" style="display:inline;">
+    <form action="updater.php" method="post">
       <input type="hidden" name="git_action" value="update">
-      <button class="w3-button w3-green" type="submit">Update durchführen</button>
+      <button class="w3-button w3-border w3-green w3-mobile" type="submit">Update durchführen</button>
     </form>
-    <form action="updater.php" method="post" style="display:inline;">
+    <form action="updater.php" method="post">
       <input type="hidden" name="db_action" value="check">
-      <button class="w3-button w3-blue" type="submit">Datenbank prüfen</button>
+      <button class="w3-button w3-border w3-blue w3-mobile" type="submit">Datenbank prüfen</button>
     </form>
-    <form action="updater.php" method="post" style="display:inline;">
+    <form action="updater.php" method="post">
       <input type="hidden" name="db_action" value="repair">
-      <button class="w3-button w3-orange" type="submit">Datenbank reparieren</button>
+      <button class="w3-button w3-border w3-orange w3-mobile" type="submit">Datenbank reparieren</button>
     </form>
   </div>
 
@@ -266,5 +264,6 @@ include 'common/header.php';
 </div>
 
 <?php
+adminListPageEnd();
 include 'common/footer.php';
 ?>

--- a/views/profile/layout_a.php
+++ b/views/profile/layout_a.php
@@ -17,13 +17,16 @@ elseif(!$fill) {
 else {
     $profileKicker = 'Nutzer bearbeiten';
 }
+$profileHeroClass = !empty($_SESSION['adminpage'])
+    ? adminHeroClass(array('kicker' => $profileKicker, 'permKey' => 'perm_editUsers'))
+    : 'profile-hero';
 ?>
 <div class="profile-shell profile-layout-a">
   <form class="profile-form" action="<?php echo htmlspecialchars($formAction, ENT_QUOTES, 'UTF-8'); ?>" method="POST">
     <?php include __DIR__.'/form_hidden.php'; ?>
     <input type="hidden" name="Index" <?php if($fill) echo 'value="'.(int)$n->Index.'"'; ?>>
 
-    <header class="profile-hero">
+    <header class="<?php echo htmlspecialchars($profileHeroClass, ENT_QUOTES, 'UTF-8'); ?>">
       <div class="profile-hero-text">
         <p class="profile-kicker"><?php echo htmlspecialchars($profileKicker, ENT_QUOTES, 'UTF-8'); ?></p>
         <h2 class="profile-title"><?php echo htmlspecialchars($profileTitle, ENT_QUOTES, 'UTF-8'); ?></h2>


### PR DESCRIPTION
## Summary
- Admin-Listen und alle Admin-Nav-Seiten nutzen `adminListPageBegin` / Hero mit Rechte-Gruppenfarbe (Personen/Termine/…)
- CSS trifft auch Form-Heroes unter `.profile-form` (Musiker anlegen, Termin erstellen)
- Updater-Buttons skalieren responsiv; Backup/Config/Statistik/Auftrag-Melden auf neues Layout

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-138

## Test plan
- [ ] Admin-Nav: jede Seite hat farbigen Hero passend zur Nav-Gruppe
- [ ] Musiker anlegen / Termin erstellen: Personen- bzw. Termine-Farbe
- [ ] Updater: Buttons auf Desktop und Mobil gut lesbar
- [ ] Backup, Config, Statistik, Im Auftrag melden: neues Shell-Layout


Made with [Cursor](https://cursor.com)