### PR TITLE
MELD-137: Gruppen-Rechte und Group-Migration

### DIFF
--- a/common/include.php
+++ b/common/include.php
@@ -41,7 +41,7 @@ include "libs/usermail.php";
 include "libs/audienceSpec.php";
 include "libs/mailJob.php";
 include "libs/mailOutbox.php";
-include "libs/mailGroup.php";
+include "libs/group.php";
 include "libs/appToken.php";
 include "libs/ics.php";
 include "libs/AppmntFreeTextResponse.php";

--- a/config/DBconfig.json
+++ b/config/DBconfig.json
@@ -71,7 +71,7 @@
 	"Type": {"Type": "int"},
 	"Message": {"Type": "text", "Collation": "utf8mb4_unicode_ci"}
     },
-    "MailGroup": {
+    "Group": {
 	"Index": {"Type": "int", "Extra": "AUTO_INCREMENT"},
 	"Name": {"Type": "text", "Collation": "utf8mb4_unicode_ci"},
 	"MemberSpec": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},

--- a/config/DBconfig.json
+++ b/config/DBconfig.json
@@ -75,6 +75,7 @@
 	"Index": {"Type": "int", "Extra": "AUTO_INCREMENT"},
 	"Name": {"Type": "text", "Collation": "utf8mb4_unicode_ci"},
 	"MemberSpec": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
+	"PermissionSpec": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
 	"CreatedBy": {"Type": "int", "Default": 0},
 	"Created": {"Type": "timestamp", "Default": "CURRENT_TIMESTAMP", "Extra": "DEFAULT_GENERATED"}
     },

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -3,5 +3,5 @@
  * Expected DB schema version number (MELD-51).
  * Bump when DBconfig.json, DatabaseManager migrations, or ConfigDefaults.php change.
  */
-return 19;
+return 20;
 ?>

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -3,5 +3,5 @@
  * Expected DB schema version number (MELD-51).
  * Bump when DBconfig.json, DatabaseManager migrations, or ConfigDefaults.php change.
  */
-return 20;
+return 21;
 ?>

--- a/evaluate.php
+++ b/evaluate.php
@@ -81,7 +81,6 @@ $btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
   <div class="eval-tables">
     <section class="eval-panel" id="eval-ranking">
       <h3>Ranking nach Teilnahme</h3>
-      <p class="w3-text-gray">Quote = Ja-Meldungen / Termine im Zeitraum. Spaltenüberschriften zum Sortieren anklicken.</p>
       <div class="eval-table-scroll">
         <table id="evalRanking" class="w3-table w3-striped w3-bordered w3-hoverable eval-data-table">
           <thead>
@@ -101,7 +100,6 @@ $btnSubmit = $GLOBALS['optionsDB']['colorBtnSubmit'];
 
     <section class="eval-panel" id="eval-inactive">
       <h3>Inaktive Nutzer</h3>
-      <p class="w3-text-gray">Musiker ohne Aktivität (Login und Teilnahme) in den letzten <?php echo (int)$inactiveDays; ?> Tagen. Schwellwert: Konfiguration <code>inactiveUsersDays</code>.</p>
       <div class="eval-table-scroll">
         <table id="evalInactive" class="w3-table w3-striped w3-bordered w3-hoverable eval-data-table">
           <thead>

--- a/group-edit.php
+++ b/group-edit.php
@@ -38,6 +38,11 @@ if(isset($_POST['save'])) {
         $decoded = AudienceSpec::emptySpec();
     }
     $g->setMemberSpecArray($decoded);
+    $permPosted = array();
+    if(isset($_POST['groupPermissions']) && is_array($_POST['groupPermissions'])) {
+        $permPosted = $_POST['groupPermissions'];
+    }
+    $g->setPermissionSpecArray($permPosted);
     if(!(int)$g->Index) {
         $g->CreatedBy = isset($_SESSION['userid']) ? (int)$_SESSION['userid'] : 0;
     }
@@ -58,6 +63,8 @@ if(isset($_GET['saved'])) {
 }
 
 $memberSpec = $g->Index ? $g->getMemberSpecArray() : AudienceSpec::emptySpec();
+$groupPerms = $g->Index ? $g->getPermissionSpecArray() : array();
+$groupPermFlip = array_flip($groupPerms);
 $catalog = AudienceSpec::buildCatalog(array(
     'forMail' => false,
     'includeMailGroups' => false,
@@ -94,6 +101,29 @@ adminListPageBegin('Kommunikation', $groupTitle, array('actionsHtml' => $backLin
       <p class="w3-small w3-margin-top mail-recipient-count-line">
         <span id="mailRecipientCount" class="mail-recipient-count" aria-live="polite">…</span>
       </p>
+    </div>
+  </div>
+
+  <div class="profile-field">
+    <label class="profile-label">Vererbte Rechte</label>
+    <p class="w3-small w3-text-gray">Mitglieder dieser Gruppe erhalten die gesetzten Rechte zusätzlich zu ihren persönlichen Rechten.</p>
+    <div class="profile-perm-tiles w3-padding w3-border <?php echo htmlspecialchars($inputCls, ENT_QUOTES, 'UTF-8'); ?>">
+<?php foreach(Permissions::permissionCatalog() as $item) {
+    $key = $item['key'];
+    $gid = preg_replace('/[^a-z0-9_-]/i', '', (string)$item['groupId']);
+    if($gid === '') {
+        $gid = 'system';
+    }
+    $checked = isset($groupPermFlip[$key]);
+    $id = 'groupPerm_'.$key;
+?>
+      <label class="profile-pref perm-group perm-group--<?php echo htmlspecialchars($gid, ENT_QUOTES, 'UTF-8'); ?>" for="<?php echo htmlspecialchars($id, ENT_QUOTES, 'UTF-8'); ?>">
+        <input type="checkbox" id="<?php echo htmlspecialchars($id, ENT_QUOTES, 'UTF-8'); ?>"
+          name="groupPermissions[]" value="<?php echo htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>"
+          <?php echo $checked ? 'checked' : ''; ?>>
+        <span><?php echo htmlspecialchars($item['label'], ENT_QUOTES, 'UTF-8'); ?></span>
+      </label>
+<?php } ?>
     </div>
   </div>
 

--- a/group-edit.php
+++ b/group-edit.php
@@ -64,11 +64,19 @@ if(isset($_GET['saved'])) {
 
 $memberSpec = $g->Index ? $g->getMemberSpecArray() : AudienceSpec::emptySpec();
 $groupPerms = $g->Index ? $g->getPermissionSpecArray() : array();
-$groupPermFlip = array_flip($groupPerms);
 $catalog = AudienceSpec::buildCatalog(array(
     'forMail' => false,
     'includeNamedGroups' => false,
 ));
+$permCatalog = Permissions::permissionCatalog();
+$permCatalogJson = json_encode(
+    array('permissions' => $permCatalog),
+    JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE
+);
+$groupPermsJson = json_encode(
+    array_values($groupPerms),
+    JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE
+);
 
 include 'common/header.php';
 $inputCls = $GLOBALS['optionsDB']['colorInputBackground'];
@@ -92,7 +100,6 @@ adminListPageBegin('Kommunikation', $groupTitle, array('actionsHtml' => $backLin
 
   <div class="profile-field">
     <label class="profile-label">Mitglieder</label>
-    <p class="w3-small w3-text-gray">Rollen, Register und Personen (Union). Beispiel: Posaunen + Schlagwerk + Klarinetten + einzelne Personen.</p>
     <div class="w3-mobile w3-margin-bottom w3-padding w3-border <?php echo $inputCls; ?>">
       <div id="mailRecipientChips" class="mail-recipient-chips" aria-live="polite"></div>
       <input type="text" id="mailRecipientInput" class="w3-input w3-border <?php echo $inputCls; ?>" placeholder="Rolle, Register oder Person tippen…" autocomplete="off" />
@@ -104,26 +111,17 @@ adminListPageBegin('Kommunikation', $groupTitle, array('actionsHtml' => $backLin
     </div>
   </div>
 
-  <div class="profile-field">
+  <div class="profile-field" id="profile-perms-wrap"
+       data-perm-catalog="<?php echo htmlspecialchars((string)$permCatalogJson, ENT_QUOTES, 'UTF-8'); ?>"
+       data-selected-perms="<?php echo htmlspecialchars((string)$groupPermsJson, ENT_QUOTES, 'UTF-8'); ?>"
+       data-perm-input-name="groupPermissions[]"
+       data-locked-perm="">
     <label class="profile-label">Vererbte Rechte</label>
-    <p class="w3-small w3-text-gray">Mitglieder dieser Gruppe erhalten die gesetzten Rechte zusätzlich zu ihren persönlichen Rechten.</p>
-    <div class="profile-perm-tiles w3-padding w3-border <?php echo htmlspecialchars($inputCls, ENT_QUOTES, 'UTF-8'); ?>">
-<?php foreach(Permissions::permissionCatalog() as $item) {
-    $key = $item['key'];
-    $gid = preg_replace('/[^a-z0-9_-]/i', '', (string)$item['groupId']);
-    if($gid === '') {
-        $gid = 'system';
-    }
-    $checked = isset($groupPermFlip[$key]);
-    $id = 'groupPerm_'.$key;
-?>
-      <label class="profile-pref perm-group perm-group--<?php echo htmlspecialchars($gid, ENT_QUOTES, 'UTF-8'); ?>" for="<?php echo htmlspecialchars($id, ENT_QUOTES, 'UTF-8'); ?>">
-        <input type="checkbox" id="<?php echo htmlspecialchars($id, ENT_QUOTES, 'UTF-8'); ?>"
-          name="groupPermissions[]" value="<?php echo htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>"
-          <?php echo $checked ? 'checked' : ''; ?>>
-        <span><?php echo htmlspecialchars($item['label'], ENT_QUOTES, 'UTF-8'); ?></span>
-      </label>
-<?php } ?>
+    <div class="profile-group-picker profile-perm-picker w3-border <?php echo htmlspecialchars($inputCls, ENT_QUOTES, 'UTF-8'); ?>">
+      <div id="profile-perm-chips" class="mail-recipient-chips profile-perm-tiles" aria-live="polite"></div>
+      <input type="text" id="profile-perm-input" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputCls, ENT_QUOTES, 'UTF-8'); ?>" placeholder="Recht tippen…" autocomplete="off" aria-label="Recht hinzufügen">
+      <div id="profile-perm-suggest" class="mail-recipient-suggest" hidden></div>
+      <div id="profile-perm-hiddens" hidden></div>
     </div>
   </div>
 
@@ -132,6 +130,7 @@ adminListPageBegin('Kommunikation', $groupTitle, array('actionsHtml' => $backLin
 
 <script type="application/json" id="mailRecipientCatalog"><?php echo json_encode($catalog, JSON_UNESCAPED_UNICODE); ?></script>
 <script src="js/mailRecipients.js?<?php echo isset($GLOBALS['version']['Hash']) ? $GLOBALS['version']['Hash'] : '0'; ?>-<?php echo @filemtime(__DIR__.'/js/mailRecipients.js'); ?>"></script>
+<script src="js/profile-layout.js?<?php echo isset($GLOBALS['version']['Hash']) ? $GLOBALS['version']['Hash'] : '0'; ?>-<?php echo @filemtime(__DIR__.'/js/profile-layout.js'); ?>"></script>
 <script>
 (function() {
   if(typeof MailRecipientChips === 'undefined') return;

--- a/group-edit.php
+++ b/group-edit.php
@@ -19,11 +19,11 @@ if(!requirePermission('perm_sendEmail')) {
     denyAccess();
 }
 
-MailGroup::ensureSchema();
+Group::ensureSchema();
 
 $msg = '';
 $err = '';
-$g = new MailGroup();
+$g = new Group();
 $editId = isset($_GET['id']) ? (int)$_GET['id'] : (isset($_POST['Index']) ? (int)$_POST['Index'] : 0);
 if($editId > 0) {
     $g->load_by_id($editId);
@@ -67,7 +67,7 @@ $groupPerms = $g->Index ? $g->getPermissionSpecArray() : array();
 $groupPermFlip = array_flip($groupPerms);
 $catalog = AudienceSpec::buildCatalog(array(
     'forMail' => false,
-    'includeMailGroups' => false,
+    'includeNamedGroups' => false,
 ));
 
 include 'common/header.php';

--- a/groups.php
+++ b/groups.php
@@ -33,7 +33,7 @@ adminListPageBegin('Kommunikation', 'Gruppen', array('actionsHtml' => $actions))
 <?php if($err) { ?><div class="w3-panel w3-red w3-padding"><?php echo htmlspecialchars($err, ENT_QUOTES, 'UTF-8'); ?></div><?php } ?>
 
 <div class="admin-list-intro">
-  <p>Benannte Gruppen mit Rollen, Registern und Personen – nutzbar beim Mailversand und bei der Termin-Sichtbarkeit.</p>
+  <p>Benannte Gruppen mit Rollen, Registern und Personen – nutzbar beim Mailversand und bei der Termin-Sichtbarkeit. Gruppen können zusätzlich Rechte an ihre Mitglieder vererben.</p>
 </div>
 
   <div class="mail-list">
@@ -50,9 +50,15 @@ foreach($groups as $g) {
     $id = (int)$g->Index;
     $count = (int)$g->memberCount(false);
     $countMail = (int)$g->memberCount(true);
+    $permLabel = $g->getPermissionLabel();
 ?>
     <div class="mail-list-item">
-      <div class="mail-list-primary"><?php echo htmlspecialchars((string)$g->Name, ENT_QUOTES, 'UTF-8'); ?></div>
+      <div class="mail-list-primary">
+        <?php echo htmlspecialchars((string)$g->Name, ENT_QUOTES, 'UTF-8'); ?>
+<?php if($permLabel !== '') { ?>
+        <div class="w3-small w3-text-gray">Rechte: <?php echo htmlspecialchars($permLabel, ENT_QUOTES, 'UTF-8'); ?></div>
+<?php } ?>
+      </div>
       <div class="mail-list-status"><?php echo $count; ?> <span class="w3-small w3-text-gray">(<?php echo $countMail; ?> mit Mail)</span></div>
       <div class="mail-list-actions">
         <a class="w3-button w3-small w3-blue" href="group-edit.php?id=<?php echo $id; ?>">Bearbeiten</a>

--- a/groups.php
+++ b/groups.php
@@ -32,10 +32,6 @@ adminListPageBegin('Kommunikation', 'Gruppen', array('actionsHtml' => $actions))
 <?php if($msg) { ?><div class="w3-panel w3-green w3-padding"><?php echo htmlspecialchars($msg, ENT_QUOTES, 'UTF-8'); ?></div><?php } ?>
 <?php if($err) { ?><div class="w3-panel w3-red w3-padding"><?php echo htmlspecialchars($err, ENT_QUOTES, 'UTF-8'); ?></div><?php } ?>
 
-<div class="admin-list-intro">
-  <p>Benannte Gruppen mit Rollen, Registern und Personen – nutzbar beim Mailversand und bei der Termin-Sichtbarkeit. Gruppen können zusätzlich Rechte an ihre Mitglieder vererben.</p>
-</div>
-
   <div class="mail-list">
     <div class="mail-list-header <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
       <div>Name</div>
@@ -50,13 +46,32 @@ foreach($groups as $g) {
     $id = (int)$g->Index;
     $count = (int)$g->memberCount(false);
     $countMail = (int)$g->memberCount(true);
-    $permLabel = $g->getPermissionLabel();
+    $permKeys = $g->getPermissionSpecArray();
+    $permKeySet = array_fill_keys($permKeys, true);
+    $permTiles = array();
+    if(count($permKeys)) {
+        foreach(Permissions::permissionCatalog() as $item) {
+            if(empty($permKeySet[$item['key']])) {
+                continue;
+            }
+            $permTiles[] = $item;
+        }
+    }
 ?>
     <div class="mail-list-item">
       <div class="mail-list-primary">
         <?php echo htmlspecialchars((string)$g->Name, ENT_QUOTES, 'UTF-8'); ?>
-<?php if($permLabel !== '') { ?>
-        <div class="w3-small w3-text-gray">Rechte: <?php echo htmlspecialchars($permLabel, ENT_QUOTES, 'UTF-8'); ?></div>
+<?php if(count($permTiles)) { ?>
+        <div class="profile-perm-tiles mail-list-perm-tiles" aria-label="Vererbte Rechte">
+<?php
+            foreach($permTiles as $item) {
+                $gid = preg_replace('/[^a-z0-9_-]/i', '', (string)$item['groupId']);
+                echo '<span class="profile-perm-tile profile-perm-tile--'.$gid.'">'
+                    .htmlspecialchars($item['label'], ENT_QUOTES, 'UTF-8')
+                    .'</span>';
+            }
+?>
+        </div>
 <?php } ?>
       </div>
       <div class="mail-list-status"><?php echo $count; ?> <span class="w3-small w3-text-gray">(<?php echo $countMail; ?> mit Mail)</span></div>

--- a/groups.php
+++ b/groups.php
@@ -8,13 +8,13 @@ if(!requirePermission('perm_sendEmail')) {
     denyAccess();
 }
 
-MailGroup::ensureSchema();
+Group::ensureSchema();
 
 $msg = '';
 $err = '';
 
 if(isset($_POST['delete']) && isset($_POST['Index'])) {
-    $g = new MailGroup();
+    $g = new Group();
     $g->load_by_id((int)$_POST['Index']);
     if((int)$g->Index && $g->delete()) {
         $msg = 'Gruppe gelöscht.';
@@ -24,7 +24,7 @@ if(isset($_POST['delete']) && isset($_POST['Index'])) {
     }
 }
 
-$groups = MailGroup::listAll();
+$groups = Group::listAll();
 $actions = '<a class="w3-button '.$GLOBALS['optionsDB']['colorBtnSubmit'].'" href="group-edit.php">Neue Gruppe</a>'
     .' <a class="w3-button w3-border" href="mail.php">Email versenden</a>';
 adminListPageBegin('Kommunikation', 'Gruppen', array('actionsHtml' => $actions));

--- a/instrument-types.php
+++ b/instrument-types.php
@@ -60,7 +60,6 @@ adminListPageBegin('Register', 'Instrument-Typen');
 <?php if($err) { ?><div class="w3-panel w3-red w3-padding"><?php echo htmlspecialchars($err); ?></div><?php } ?>
 
 <div class="admin-list-intro">
-  <p>Instrument-Typen (z.B. Flöte, Trompete) gehören zu einem Register. Farbe erscheint in dieser Übersicht; Register-Farben steuern die Orchesterdarstellung.</p>
   <p><a href="register-types.php">Register verwalten</a></p>
 </div>
 

--- a/inventory-types.php
+++ b/inventory-types.php
@@ -64,10 +64,6 @@ adminListPageBegin('Inventar', 'Inventar-Typen');
 <?php if($msg) { ?><div class="w3-panel w3-green w3-padding"><?php echo htmlspecialchars($msg); ?></div><?php } ?>
 <?php if($err) { ?><div class="w3-panel w3-red w3-padding"><?php echo htmlspecialchars($err); ?></div><?php } ?>
 
-<div class="admin-list-intro">
-  <p>Prefix bestimmt den Nummernkreis (z.B. <b>MARSCH-001</b>, <b>INSTR-42</b>). Die Beschriftung erscheint in Listen und Formularen.</p>
-</div>
-
 <div class="w3-row w3-padding w3-teal type-edit-header">
   <div class="w3-col l2 m2 s3"><b>Prefix</b></div>
   <div class="w3-col l3 m3 s4"><b>Beschriftung</b></div>

--- a/js/mailRecipients.js
+++ b/js/mailRecipients.js
@@ -1,5 +1,5 @@
 /**
- * MELD-60/61/135/134: chip picker — roles + registers + users + mailGroups + termine + guestMusicians.
+ * MELD-60/61/135/134: chip picker — roles + registers + users + namedGroups + termine + guestMusicians.
  */
 (function(global) {
   'use strict';
@@ -13,19 +13,19 @@
   var GROUP_IDS = ['musicians', 'members', 'nonmembers', 'users'];
 
   function parseCatalog(el) {
-    if(!el) return {groups: [], registers: [], users: [], mailGroups: [], termine: [], guestMusicians: []};
+    if(!el) return {groups: [], registers: [], users: [], namedGroups: [], termine: [], guestMusicians: []};
     try {
       var c = JSON.parse(el.textContent || '{}');
       return {
         groups: Array.isArray(c.groups) ? c.groups : [],
         registers: Array.isArray(c.registers) ? c.registers : [],
         users: Array.isArray(c.users) ? c.users : [],
-        mailGroups: Array.isArray(c.mailGroups) ? c.mailGroups : [],
+        namedGroups: Array.isArray(c.namedGroups) ? c.namedGroups : [],
         termine: Array.isArray(c.termine) ? c.termine : [],
         guestMusicians: Array.isArray(c.guestMusicians) ? c.guestMusicians : []
       };
     } catch(e) {
-      return {groups: [], registers: [], users: [], mailGroups: [], termine: [], guestMusicians: []};
+      return {groups: [], registers: [], users: [], namedGroups: [], termine: [], guestMusicians: []};
     }
   }
 
@@ -47,14 +47,14 @@
   }
 
   function emptySpec() {
-    return {groups: [], registers: [], users: [], mailGroups: [], termine: [], guestMusicians: []};
+    return {groups: [], registers: [], users: [], namedGroups: [], termine: [], guestMusicians: []};
   }
 
   function isSpecEmpty(spec) {
     return !(spec.groups && spec.groups.length)
       && !(spec.registers && spec.registers.length)
       && !(spec.users && spec.users.length)
-      && !(spec.mailGroups && spec.mailGroups.length)
+      && !(spec.namedGroups && spec.namedGroups.length)
       && !(spec.termine && spec.termine.length);
   }
 
@@ -84,9 +84,9 @@
       }
       var registers = normalizeIdList(s.registers);
       var users = normalizeIdList(s.users);
-      var mailGroups = normalizeIdList(s.mailGroups);
+      var namedGroups = normalizeIdList(s.namedGroups);
       var termine = normalizeIdList(s.termine);
-      if(!groups.length && !registers.length && !users.length && !mailGroups.length && !termine.length) {
+      if(!groups.length && !registers.length && !users.length && !namedGroups.length && !termine.length) {
         if(!allowEmpty && defaultGroups.length) {
           groups = normalizeGroups(defaultGroups);
         }
@@ -95,7 +95,7 @@
         groups: groups,
         registers: registers,
         users: users,
-        mailGroups: mailGroups,
+        namedGroups: namedGroups,
         termine: termine,
         guestMusicians: []
       };
@@ -152,7 +152,7 @@
           groups: this.spec.groups.slice(),
           registers: this.spec.registers.slice(),
           users: this.spec.users.slice(),
-          mailGroups: (this.spec.mailGroups || []).slice(),
+          namedGroups: (this.spec.namedGroups || []).slice(),
           termine: (this.spec.termine || []).slice()
         });
       }
@@ -290,8 +290,8 @@
       return false;
     },
 
-    labelForMailGroup: function(id) {
-      var list = this.catalog.mailGroups || [];
+    labelForNamedGroup: function(id) {
+      var list = this.catalog.namedGroups || [];
       for(var i = 0; i < list.length; i++) {
         if(Number(list[i].id) === Number(id)) return list[i].label;
       }
@@ -320,8 +320,8 @@
       if(!this.chipsEl) return;
       this.chipsEl.innerHTML = '';
       var self = this;
-      (this.spec.mailGroups || []).forEach(function(id) {
-        self.chipsEl.appendChild(self.makeChip('mailGroup', id, 'Gruppe: ' + self.labelForMailGroup(id)));
+      (this.spec.namedGroups || []).forEach(function(id) {
+        self.chipsEl.appendChild(self.makeChip('namedGroup', id, 'Gruppe: ' + self.labelForNamedGroup(id)));
       });
       this.spec.groups.forEach(function(id) {
         self.chipsEl.appendChild(self.makeChip('group', id, self.labelForGroup(id)));
@@ -371,9 +371,9 @@
         id = Number(id);
         this.spec.registers = this.spec.registers.filter(function(x) { return x !== id; });
       }
-      else if(type === 'mailGroup') {
+      else if(type === 'namedGroup') {
         id = Number(id);
-        this.spec.mailGroups = (this.spec.mailGroups || []).filter(function(x) { return x !== id; });
+        this.spec.namedGroups = (this.spec.namedGroups || []).filter(function(x) { return x !== id; });
       }
       else if(type === 'termin') {
         id = Number(id);
@@ -407,9 +407,9 @@
       if(type === 'register') {
         if(this.spec.registers.indexOf(id) === -1) this.spec.registers.push(id);
       }
-      else if(type === 'mailGroup') {
-        if(!this.spec.mailGroups) this.spec.mailGroups = [];
-        if(this.spec.mailGroups.indexOf(id) === -1) this.spec.mailGroups.push(id);
+      else if(type === 'namedGroup') {
+        if(!this.spec.namedGroups) this.spec.namedGroups = [];
+        if(this.spec.namedGroups.indexOf(id) === -1) this.spec.namedGroups.push(id);
       }
       else if(type === 'termin') {
         if(!this.spec.termine) this.spec.termine = [];
@@ -442,10 +442,10 @@
             {id: 'users', label: GROUP_LABELS.users, meta: 'Rolle'}
           ];
 
-      (this.catalog.mailGroups || []).forEach(function(g) {
-        if((self.spec.mailGroups || []).indexOf(Number(g.id)) !== -1) return;
+      (this.catalog.namedGroups || []).forEach(function(g) {
+        if((self.spec.namedGroups || []).indexOf(Number(g.id)) !== -1) return;
         if(q === '' || normalize(g.label).indexOf(q) !== -1) {
-          items.push({type: 'mailGroup', id: g.id, label: g.label, meta: g.meta || 'Gruppe'});
+          items.push({type: 'namedGroup', id: g.id, label: g.label, meta: g.meta || 'Gruppe'});
         }
       });
 
@@ -611,8 +611,8 @@
         else if(this.spec.groups.length) {
           this.removeChip('group', this.spec.groups[this.spec.groups.length - 1]);
         }
-        else if(this.spec.mailGroups && this.spec.mailGroups.length) {
-          this.removeChip('mailGroup', this.spec.mailGroups[this.spec.mailGroups.length - 1]);
+        else if(this.spec.namedGroups && this.spec.namedGroups.length) {
+          this.removeChip('namedGroup', this.spec.namedGroups[this.spec.namedGroups.length - 1]);
         }
       }
     },

--- a/js/profile-layout.js
+++ b/js/profile-layout.js
@@ -43,8 +43,8 @@
     var hiddensEl = document.getElementById('profile-group-hiddens');
     if (!chipsEl || !inputEl || !suggestEl || !hiddensEl) return;
 
-    var catalog = parseJsonAttr(wrap, 'data-group-catalog', { mailGroups: [] });
-    var mailGroups = Array.isArray(catalog.mailGroups) ? catalog.mailGroups : [];
+    var catalog = parseJsonAttr(wrap, 'data-group-catalog', { namedGroups: [] });
+    var namedGroups = Array.isArray(catalog.namedGroups) ? catalog.namedGroups : [];
     var selected = parseJsonAttr(wrap, 'data-selected-groups', []);
     if (!Array.isArray(selected)) selected = [];
     selected = selected.map(Number).filter(function (id) { return id > 0; });
@@ -52,8 +52,8 @@
     var readonly = !!inputEl.disabled;
 
     function labelFor(id) {
-      for (var i = 0; i < mailGroups.length; i++) {
-        if (Number(mailGroups[i].id) === Number(id)) return mailGroups[i].label || ('#' + id);
+      for (var i = 0; i < namedGroups.length; i++) {
+        if (Number(namedGroups[i].id) === Number(id)) return namedGroups[i].label || ('#' + id);
       }
       return 'Gruppe #' + id;
     }
@@ -63,7 +63,7 @@
       selected.forEach(function (id) {
         var input = document.createElement('input');
         input.type = 'hidden';
-        input.name = 'userMailGroups[]';
+        input.name = 'userNamedGroups[]';
         input.value = String(id);
         hiddensEl.appendChild(input);
       });
@@ -73,7 +73,7 @@
       chipsEl.innerHTML = '';
       selected.forEach(function (id) {
         var chip = document.createElement('span');
-        chip.className = 'mail-recipient-chip mail-recipient-chip--mailGroup';
+        chip.className = 'mail-recipient-chip mail-recipient-chip--namedGroup';
         chip.setAttribute('data-id', String(id));
         var text = document.createElement('span');
         text.textContent = labelFor(id);
@@ -98,7 +98,7 @@
     function filteredSuggestions() {
       var q = normalize(inputEl.value);
       var items = [];
-      mailGroups.forEach(function (g) {
+      namedGroups.forEach(function (g) {
         var id = Number(g.id);
         if (selected.indexOf(id) !== -1) return;
         if (q === '' || normalize(g.label).indexOf(q) !== -1) {
@@ -414,11 +414,11 @@
     if (attrs.active && regName && regName.toLowerCase() !== 'keins') {
       chips.push({ type: 'register', label: 'Register: ' + regName });
     }
-    var mailGroups = catalog.mailGroups || [];
-    for (i = 0; i < mailGroups.length; i++) {
-      var g = mailGroups[i];
+    var namedGroups = catalog.namedGroups || [];
+    for (i = 0; i < namedGroups.length; i++) {
+      var g = namedGroups[i];
       if (attrsMatchSpec(attrs, g.groups || [], g.registers || [])) {
-        chips.push({ type: 'mailGroup', label: 'Gruppe: ' + (g.name || '') });
+        chips.push({ type: 'namedGroup', label: 'Gruppe: ' + (g.name || '') });
       }
     }
     return chips;

--- a/js/profile-layout.js
+++ b/js/profile-layout.js
@@ -205,7 +205,20 @@
     var selected = parseJsonAttr(wrap, 'data-selected-perms', []);
     if (!Array.isArray(selected)) selected = [];
     selected = selected.map(String).filter(function (k) { return !!k; });
+    var inheritedRaw = parseJsonAttr(wrap, 'data-inherited-perms', {});
+    var inherited = {};
+    if (inheritedRaw && typeof inheritedRaw === 'object' && !Array.isArray(inheritedRaw)) {
+      Object.keys(inheritedRaw).forEach(function (k) {
+        var groups = inheritedRaw[k];
+        if (!Array.isArray(groups) || !groups.length) return;
+        inherited[String(k)] = groups.map(String);
+      });
+    }
     var lockedKey = String(wrap.getAttribute('data-locked-perm') || '');
+    var inputName = String(wrap.getAttribute('data-perm-input-name') || 'userPermissions[]');
+    if(inputName.indexOf('[]') === -1) {
+      inputName = inputName + '[]';
+    }
     var activeIndex = -1;
 
     function metaFor(key) {
@@ -215,16 +228,36 @@
       return { key: key, label: key, group: '', groupId: 'sonst' };
     }
 
-    function sortSelected() {
+    function groupNamesFor(key) {
+      return inherited[String(key)] || [];
+    }
+
+    function isInheritedOnly(key) {
+      return selected.indexOf(String(key)) === -1 && groupNamesFor(key).length > 0;
+    }
+
+    function sortKeys(keys) {
       var order = {};
       permissions.forEach(function (p, idx) {
         order[String(p.key)] = idx;
       });
-      selected.sort(function (a, b) {
+      keys.sort(function (a, b) {
         var ia = order.hasOwnProperty(a) ? order[a] : 999;
         var ib = order.hasOwnProperty(b) ? order[b] : 999;
         return ia - ib;
       });
+      return keys;
+    }
+
+    function displayKeys() {
+      var keys = selected.slice();
+      Object.keys(inherited).forEach(function (k) {
+        if (keys.indexOf(k) === -1) keys.push(k);
+      });
+      if (lockedKey && keys.indexOf(lockedKey) === -1) {
+        keys.push(lockedKey);
+      }
+      return sortKeys(keys);
     }
 
     function syncHiddens() {
@@ -232,7 +265,7 @@
       selected.forEach(function (key) {
         var input = document.createElement('input');
         input.type = 'hidden';
-        input.name = 'userPermissions[]';
+        input.name = inputName;
         input.value = String(key);
         hiddensEl.appendChild(input);
       });
@@ -242,18 +275,28 @@
       if (lockedKey && selected.indexOf(lockedKey) === -1) {
         selected.push(lockedKey);
       }
-      sortSelected();
+      selected = sortKeys(selected.slice());
       chipsEl.innerHTML = '';
-      selected.forEach(function (key) {
+      displayKeys().forEach(function (key) {
         var meta = metaFor(key);
         var gid = String(meta.groupId || 'sonst').replace(/[^a-z0-9_-]/gi, '');
+        var groups = groupNamesFor(key);
+        var inheritedOnly = isInheritedOnly(key);
         var chip = document.createElement('span');
         chip.className = 'profile-perm-tile profile-perm-tile--' + gid;
+        if (inheritedOnly) {
+          chip.className += ' profile-perm-tile--inherited';
+        }
         chip.setAttribute('data-key', String(key));
+        if (groups.length) {
+          chip.title = (inheritedOnly ? 'Nur über Gruppe: ' : 'Auch Gruppe: ') + groups.join(', ');
+        } else if (key === lockedKey) {
+          chip.title = 'Eigenes Recht „Berechtigungen bearbeiten“ kann nicht entfernt werden';
+        }
         var text = document.createElement('span');
         text.textContent = meta.label || key;
         chip.appendChild(text);
-        if (key !== lockedKey) {
+        if (key !== lockedKey && !inheritedOnly) {
           var btn = document.createElement('button');
           btn.type = 'button';
           btn.className = 'mail-recipient-chip-remove';
@@ -276,6 +319,7 @@
       permissions.forEach(function (p) {
         var key = String(p.key);
         if (selected.indexOf(key) !== -1) return;
+        if (groupNamesFor(key).length) return;
         if (q === '' || normalize(p.label).indexOf(q) !== -1 || normalize(p.group).indexOf(q) !== -1) {
           items.push(p);
         }
@@ -355,7 +399,7 @@
       } else if (e.key === 'Backspace' && !inputEl.value && selected.length) {
         var last = selected[selected.length - 1];
         if (last !== lockedKey) {
-          selected.pop();
+          selected = selected.slice(0, -1);
           render();
         }
       } else if (e.key === 'Escape') {

--- a/libs/DatabaseManager.php
+++ b/libs/DatabaseManager.php
@@ -260,10 +260,49 @@ class DatabaseManager
     public function check() {
         $this->report = array();
         $this->migratePermissionsRegisterColumns(false);
+        $this->migrateMailGroupTableToGroup(false);
         $this->processSchema(false, false);
         $this->pruneObsoleteSchema(false);
         $this->checkConfigDefaults(false);
         return $this->report;
+    }
+
+    /**
+     * MELD-137: rename/merge MailGroup → Group before processSchema can create an empty Group.
+     *
+     * @param bool $apply
+     */
+    private function migrateMailGroupTableToGroup($apply = true) {
+        $old = new SQLtable('MailGroup');
+        if(!$old->exists()) {
+            return;
+        }
+        $new = new SQLtable('Group');
+        if(!$apply) {
+            $msg = $new->exists()
+                ? 'MailGroup noch vorhanden — Merge/Rename nach Group nötig'
+                : 'MailGroup → Group Rename nötig';
+            $this->addReport('table', 'Group', 'missing', $msg);
+            return;
+        }
+        if(!class_exists('Group')) {
+            require_once dirname(__DIR__).'/libs/group.php';
+        }
+        $ok = Group::migrateTableFromMailGroup();
+        if($ok && !(new SQLtable('MailGroup'))->exists() && (new SQLtable('Group'))->exists()) {
+            $this->addReport('table', 'Group', 'fixed', 'MailGroup nach Group migriert (Daten erhalten)');
+            return;
+        }
+        if((new SQLtable('MailGroup'))->exists()) {
+            $this->addReport(
+                'table',
+                'MailGroup',
+                'error',
+                'Migration MailGroup → Group unvollständig — Daten nicht verworfen'
+            );
+            return;
+        }
+        $this->addReport('table', 'Group', 'ok', 'Group-Tabelle vorhanden');
     }
 
     /**
@@ -369,7 +408,9 @@ class DatabaseManager
     public function create() {
         $this->report = array();
         $this->migratePermissionsRegisterColumns();
+        $this->migrateMailGroupTableToGroup();
         $this->processSchema(true, false);
+        $this->migrateMailGroupTableToGroup();
         $this->migrateAudienceLegacyColumns();
         $this->pruneObsoleteSchema(true);
         $this->checkConfigDefaults(true);
@@ -388,7 +429,9 @@ class DatabaseManager
     public function repair() {
         $this->report = array();
         $this->migratePermissionsRegisterColumns();
+        $this->migrateMailGroupTableToGroup();
         $this->processSchema(true, true);
+        $this->migrateMailGroupTableToGroup();
         $this->migrateAudienceLegacyColumns();
         $this->pruneObsoleteSchema(true);
         $this->checkConfigDefaults(true);
@@ -1058,11 +1101,42 @@ class DatabaseManager
             }
         }
 
-        // Leftover tables after inventory migration / MELD-134 Gastmusiker.
-        foreach(array('Instruments', 'Loans', 'Aushilfen', 'AushilfenShift') as $obsoleteTable) {
+        // Leftover tables after inventory migration / MELD-134 Gastmusiker / MELD-137 Group rename.
+        foreach(array('Instruments', 'Loans', 'Aushilfen', 'AushilfenShift', 'MailGroup') as $obsoleteTable) {
             $SQL = new SQLtable($obsoleteTable);
             if(!$SQL->exists()) {
                 continue;
+            }
+            if($obsoleteTable === 'MailGroup') {
+                // Never drop MailGroup with rows — migrate first.
+                if(!class_exists('Group')) {
+                    require_once dirname(__DIR__).'/libs/group.php';
+                }
+                if($apply) {
+                    Group::migrateTableFromMailGroup();
+                }
+                if((new SQLtable('MailGroup'))->exists()) {
+                    $cntSql = sprintf(
+                        'SELECT COUNT(*) AS `c` FROM `%sMailGroup`;',
+                        $GLOBALS['dbprefix']
+                    );
+                    $dbr = mysqli_query($GLOBALS['conn'], $cntSql);
+                    $row = $dbr ? mysqli_fetch_assoc($dbr) : null;
+                    $cnt = $row ? (int)$row['c'] : -1;
+                    if($cnt > 0) {
+                        $this->addReport(
+                            'table',
+                            'MailGroup',
+                            'error',
+                            'MailGroup enthält noch '.$cnt.' Zeile(n) — nicht gelöscht'
+                        );
+                        continue;
+                    }
+                }
+                else {
+                    $this->addReport('table', 'MailGroup', 'removed', 'Leere/migrierte MailGroup entfernt');
+                    continue;
+                }
             }
             if(!$apply) {
                 $this->addReport('table', $obsoleteTable, 'obsolete', 'Tabelle nicht mehr benötigt');

--- a/libs/DatabaseManager.php
+++ b/libs/DatabaseManager.php
@@ -806,7 +806,7 @@ class DatabaseManager
                         $id = (int)$row['Index'];
                         $rawVis = isset($row['VisibilitySpec']) ? $row['VisibilitySpec'] : null;
                         $spec = AudienceSpec::normalize($rawVis, array(
-                            'allowMailGroups' => true,
+                            'allowNamedGroups' => true,
                             'defaultGroups' => null,
                         ));
                         $isEmpty = AudienceSpec::isEmpty($spec);
@@ -909,14 +909,14 @@ class DatabaseManager
                         $spec = AudienceSpec::normalize(
                             isset($row['RecipientSpec']) ? $row['RecipientSpec'] : null,
                             array(
-                                'allowMailGroups' => true,
+                                'allowNamedGroups' => true,
                                 'defaultGroups' => null,
                                 'legacyRegister' => $legacyRegister,
                                 'legacyMemberOnly' => $legacyMemberOnly,
                             )
                         );
                         $raw = isset($row['RecipientSpec']) ? trim((string)$row['RecipientSpec']) : '';
-                        if($raw !== '' && !AudienceSpec::isEmpty(AudienceSpec::normalize($raw, array('allowMailGroups' => true, 'defaultGroups' => null)))) {
+                        if($raw !== '' && !AudienceSpec::isEmpty(AudienceSpec::normalize($raw, array('allowNamedGroups' => true, 'defaultGroups' => null)))) {
                             continue;
                         }
                         if(AudienceSpec::isEmpty($spec) && $legacyRegister <= 0 && !$legacyMemberOnly) {
@@ -926,7 +926,7 @@ class DatabaseManager
                             'groups' => $spec['groups'],
                             'registers' => $spec['registers'],
                             'users' => $spec['users'],
-                            'mailGroups' => $spec['mailGroups'],
+                            'namedGroups' => $spec['namedGroups'],
                             'termine' => isset($spec['termine']) ? $spec['termine'] : array(),
                         ));
                         $update = sprintf(

--- a/libs/audienceSpec.php
+++ b/libs/audienceSpec.php
@@ -7,12 +7,43 @@
  *   "groups": ["musicians"|"members"|"nonmembers"|"users", ...],
  *   "registers": [id, ...],
  *   "users": [id, ...],
- *   "mailGroups": [id, ...],  // named MailGroup rows; not nested inside MemberSpec
+ *   "namedGroups": [id, ...],  // named Group rows; not nested inside MemberSpec
+ *   "mailGroups": [id, ...],   // legacy alias for namedGroups (still read)
  *   "termine": [id, ...]      // Termin-Teilnehmer (ja+vielleicht); Mail-Verteiler only
  * }
  */
 class AudienceSpec
 {
+
+    /**
+     * Whether named Group chips are allowed (opts: allowNamedGroups; legacy allowMailGroups).
+     * @param array $opts
+     * @return bool
+     */
+    public static function allowNamedGroupsOpt($opts) {
+        if(array_key_exists('allowNamedGroups', $opts)) {
+            return !empty($opts['allowNamedGroups']);
+        }
+        if(array_key_exists('allowMailGroups', $opts)) {
+            return !empty($opts['allowMailGroups']);
+        }
+        return true;
+    }
+
+    /**
+     * Whether named groups are included in catalogs (opts: includeNamedGroups; legacy includeMailGroups).
+     * @param array $opts
+     * @return bool
+     */
+    public static function includeNamedGroupsOpt($opts) {
+        if(array_key_exists('includeNamedGroups', $opts)) {
+            return !empty($opts['includeNamedGroups']);
+        }
+        if(array_key_exists('includeMailGroups', $opts)) {
+            return !empty($opts['includeMailGroups']);
+        }
+        return true;
+    }
     public static function allowedGroupIds() {
         return array('musicians', 'members', 'nonmembers', 'users');
     }
@@ -48,24 +79,24 @@ class AudienceSpec
      * @return bool
      */
     public static function isAlleUserSpec($spec) {
-        $norm = self::normalize($spec, array('allowMailGroups' => true, 'defaultGroups' => null));
+        $norm = self::normalize($spec, array('allowNamedGroups' => true, 'defaultGroups' => null));
         return count($norm['groups']) === 1
             && $norm['groups'][0] === 'users'
             && empty($norm['registers'])
             && empty($norm['users'])
-            && empty($norm['mailGroups'])
+            && empty($norm['namedGroups'])
             && empty($norm['termine']);
     }
 
     /**
-     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[],termine:int[]}
+     * @return array{groups:string[],registers:int[],users:int[],namedGroups:int[],termine:int[]}
      */
     public static function emptySpec() {
         return array(
             'groups' => array(),
             'registers' => array(),
             'users' => array(),
-            'mailGroups' => array(),
+            'namedGroups' => array(),
             'termine' => array(),
         );
     }
@@ -73,14 +104,14 @@ class AudienceSpec
     /**
      * Default termin visibility: chip „Alle User“.
      *
-     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[],termine:int[]}
+     * @return array{groups:string[],registers:int[],users:int[],namedGroups:int[],termine:int[]}
      */
     public static function defaultVisibilitySpec() {
         return array(
             'groups' => array('users'),
             'registers' => array(),
             'users' => array(),
-            'mailGroups' => array(),
+            'namedGroups' => array(),
             'termine' => array(),
         );
     }
@@ -145,11 +176,11 @@ class AudienceSpec
 
     /**
      * @param mixed $input array or JSON string
-     * @param array $opts allowMailGroups (bool), allowTermine (bool), defaultGroups (string[]|null), legacyRegister, legacyMemberOnly
-     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[],termine:int[]}
+     * @param array $opts allowNamedGroups (bool; legacy allowMailGroups), allowTermine (bool), defaultGroups (string[]|null), legacyRegister, legacyMemberOnly
+     * @return array{groups:string[],registers:int[],users:int[],namedGroups:int[],termine:int[]}
      */
     public static function normalize($input, $opts = array()) {
-        $allowMailGroups = !array_key_exists('allowMailGroups', $opts) || !empty($opts['allowMailGroups']);
+        $allowNamedGroups = self::allowNamedGroupsOpt($opts);
         $allowTermine = !empty($opts['allowTermine']);
         $defaultGroups = array_key_exists('defaultGroups', $opts) ? $opts['defaultGroups'] : null;
         $legacyRegister = isset($opts['legacyRegister']) ? (int)$opts['legacyRegister'] : 0;
@@ -205,10 +236,17 @@ class AudienceSpec
                     if($id > 0) $out['users'][] = $id;
                 }
             }
-            if($allowMailGroups && isset($decoded['mailGroups']) && is_array($decoded['mailGroups'])) {
-                foreach($decoded['mailGroups'] as $id) {
-                    $id = (int)$id;
-                    if($id > 0) $out['mailGroups'][] = $id;
+            if($allowNamedGroups) {
+                foreach(array('namedGroups', 'mailGroups') as $ngKey) {
+                    if(!isset($decoded[$ngKey]) || !is_array($decoded[$ngKey])) {
+                        continue;
+                    }
+                    foreach($decoded[$ngKey] as $id) {
+                        $id = (int)$id;
+                        if($id > 0) {
+                            $out['namedGroups'][] = $id;
+                        }
+                    }
                 }
             }
             if($allowTermine && isset($decoded['termine']) && is_array($decoded['termine'])) {
@@ -228,7 +266,7 @@ class AudienceSpec
         $out['groups'] = array_values(array_unique($out['groups']));
         $out['registers'] = array_values(array_unique($out['registers']));
         $out['users'] = array_values(array_unique($out['users']));
-        $out['mailGroups'] = array_values(array_unique($out['mailGroups']));
+        $out['namedGroups'] = array_values(array_unique($out['namedGroups']));
         $out['termine'] = array_values(array_unique($out['termine']));
 
         if(self::isEmpty($out) && is_array($defaultGroups) && count($defaultGroups) > 0) {
@@ -250,27 +288,27 @@ class AudienceSpec
      */
     public static function isEmpty($spec) {
         if(!is_array($spec)) return true;
-        return empty($spec['groups']) && empty($spec['registers']) && empty($spec['users']) && empty($spec['mailGroups']) && empty($spec['termine']);
+        return empty($spec['groups']) && empty($spec['registers']) && empty($spec['users']) && empty($spec['namedGroups']) && empty($spec['termine']);
     }
 
     /**
-     * Expand named mailGroups into groups/registers/users (union). Nested mailGroups ignored.
+     * Expand namedGroups into groups/registers/users (union). Nested namedGroups ignored.
      * Termin-IDs remain on the spec for resolveUserIds.
      *
      * @param array $spec
-     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[],termine:int[]}
+     * @return array{groups:string[],registers:int[],users:int[],namedGroups:int[],termine:int[]}
      */
     public static function expand($spec) {
         $spec = self::normalize($spec, array(
-            'allowMailGroups' => true,
+            'allowNamedGroups' => true,
             'allowTermine' => true,
             'defaultGroups' => null,
         ));
-        if(empty($spec['mailGroups'])) {
+        if(empty($spec['namedGroups'])) {
             return $spec;
         }
-        foreach($spec['mailGroups'] as $gid) {
-            $g = new MailGroup();
+        foreach($spec['namedGroups'] as $gid) {
+            $g = new Group();
             $g->load_by_id((int)$gid);
             if(!(int)$g->Index) continue;
             $member = $g->getMemberSpecArray();
@@ -284,7 +322,7 @@ class AudienceSpec
                 $spec['users'][] = (int)$uid;
             }
         }
-        $spec['mailGroups'] = array();
+        $spec['namedGroups'] = array();
         $spec['groups'] = array_values(array_unique($spec['groups']));
         $spec['registers'] = array_values(array_unique($spec['registers']));
         $spec['users'] = array_values(array_unique($spec['users']));
@@ -403,7 +441,7 @@ class AudienceSpec
     public static function userMatches($userId, $spec) {
         $userId = (int)$userId;
         if($userId <= 0) return false;
-        $norm = self::normalize($spec, array('allowMailGroups' => true, 'defaultGroups' => null));
+        $norm = self::normalize($spec, array('allowNamedGroups' => true, 'defaultGroups' => null));
         if(self::isEmpty($norm)) {
             return true;
         }
@@ -448,11 +486,11 @@ class AudienceSpec
             }
         }
 
-        foreach(MailGroup::listAll() as $g) {
+        foreach(Group::listAll() as $g) {
             $memberIds = self::resolveUserIds($g->getMemberSpecArray(), false);
             if(in_array($userId, $memberIds, true)) {
                 $items[] = array(
-                    'type' => 'mailGroup',
+                    'type' => 'namedGroup',
                     'label' => 'Gruppe: '.(string)$g->Name,
                 );
             }
@@ -478,11 +516,11 @@ class AudienceSpec
         $userId = isset($attrs['userId']) ? (int)$attrs['userId'] : 0;
 
         $norm = self::normalize($spec, array(
-            'allowMailGroups' => false,
+            'allowNamedGroups' => false,
             'defaultGroups' => null,
         ));
-        unset($norm['mailGroups']);
-        $norm['mailGroups'] = array();
+        unset($norm['namedGroups']);
+        $norm['namedGroups'] = array();
 
         if($includeUsers && $userId > 0 && in_array($userId, array_map('intval', $norm['users']), true)) {
             return true;
@@ -559,11 +597,11 @@ class AudienceSpec
             );
         }
 
-        foreach(MailGroup::listAll() as $g) {
+        foreach(Group::listAll() as $g) {
             $member = $g->getMemberSpecArray();
             if(self::attributesMatchMemberSpec($attrs, $member, array('includeUsers' => false))) {
                 $items[] = array(
-                    'type' => 'mailGroup',
+                    'type' => 'namedGroup',
                     'label' => 'Gruppe: '.(string)$g->Name,
                 );
             }
@@ -598,10 +636,10 @@ class AudienceSpec
             }
         }
 
-        $mailGroups = array();
-        foreach(MailGroup::listAll() as $g) {
+        $namedGroups = array();
+        foreach(Group::listAll() as $g) {
             $spec = $g->getMemberSpecArray();
-            $mailGroups[] = array(
+            $namedGroups[] = array(
                 'id' => (int)$g->Index,
                 'name' => (string)$g->Name,
                 'groups' => $spec['groups'],
@@ -613,7 +651,7 @@ class AudienceSpec
             'groupLabels' => self::groupLabels(),
             'groupIds' => self::allowedGroupIds(),
             'instruments' => $instruments,
-            'mailGroups' => $mailGroups,
+            'namedGroups' => $namedGroups,
         );
     }
 
@@ -621,14 +659,14 @@ class AudienceSpec
      * Human-readable audience for logs/UI (roles, registers, users, named groups).
      *
      * @param mixed $spec
-     * @param array $opts allowMailGroups (bool)
+     * @param array $opts allowNamedGroups (bool; legacy allowMailGroups)
      * @return string
      */
     public static function formatLabel($spec, $opts = array()) {
-        $allowMailGroups = !array_key_exists('allowMailGroups', $opts) || !empty($opts['allowMailGroups']);
+        $allowNamedGroups = self::allowNamedGroupsOpt($opts);
         $allowTermine = !empty($opts['allowTermine']);
         $norm = self::normalize($spec, array(
-            'allowMailGroups' => $allowMailGroups,
+            'allowNamedGroups' => $allowNamedGroups,
             'allowTermine' => $allowTermine,
             'defaultGroups' => null,
         ));
@@ -636,9 +674,9 @@ class AudienceSpec
             return '—';
         }
         $bits = array();
-        if($allowMailGroups) {
-            foreach($norm['mailGroups'] as $gid) {
-                $g = new MailGroup();
+        if($allowNamedGroups) {
+            foreach($norm['namedGroups'] as $gid) {
+                $g = new Group();
                 $g->load_by_id((int)$gid);
                 if((int)$g->Index) {
                     $bits[] = 'Gruppe: '.(string)$g->Name;
@@ -675,24 +713,24 @@ class AudienceSpec
      * Chip items for read-only display (same types/labels as mailRecipients.js).
      *
      * @param mixed $spec
-     * @param array $opts allowMailGroups (bool), allowTermine (bool)
+     * @param array $opts allowNamedGroups (bool; legacy allowMailGroups), allowTermine (bool)
      * @return array<int,array{type:string,label:string}>
      */
     public static function chipsForSpec($spec, $opts = array()) {
-        $allowMailGroups = !array_key_exists('allowMailGroups', $opts) || !empty($opts['allowMailGroups']);
+        $allowNamedGroups = self::allowNamedGroupsOpt($opts);
         $allowTermine = !empty($opts['allowTermine']);
         $norm = self::normalize($spec, array(
-            'allowMailGroups' => $allowMailGroups,
+            'allowNamedGroups' => $allowNamedGroups,
             'allowTermine' => $allowTermine,
             'defaultGroups' => null,
         ));
         $chips = array();
-        if($allowMailGroups) {
-            foreach($norm['mailGroups'] as $gid) {
-                $g = new MailGroup();
+        if($allowNamedGroups) {
+            foreach($norm['namedGroups'] as $gid) {
+                $g = new Group();
                 $g->load_by_id((int)$gid);
                 if((int)$g->Index) {
-                    $chips[] = array('type' => 'mailGroup', 'label' => 'Gruppe: '.(string)$g->Name);
+                    $chips[] = array('type' => 'namedGroup', 'label' => 'Gruppe: '.(string)$g->Name);
                 }
             }
         }
@@ -739,7 +777,7 @@ class AudienceSpec
      * Read-only chip HTML (no remove buttons).
      *
      * @param mixed $spec
-     * @param array $opts allowMailGroups, ariaLabel, emptyHtml
+     * @param array $opts allowNamedGroups (legacy allowMailGroups), ariaLabel, emptyHtml
      * @return string
      */
     public static function renderChipsHtml($spec, $opts = array()) {
@@ -764,19 +802,19 @@ class AudienceSpec
      * Canonical JSON for equality checks in change logs.
      *
      * @param mixed $spec
-     * @param array $opts allowMailGroups (bool)
+     * @param array $opts allowNamedGroups (bool; legacy allowMailGroups)
      * @return string
      */
     public static function canonicalJson($spec, $opts = array()) {
-        $allowMailGroups = !array_key_exists('allowMailGroups', $opts) || !empty($opts['allowMailGroups']);
+        $allowNamedGroups = self::allowNamedGroupsOpt($opts);
         $allowTermine = !empty($opts['allowTermine']);
         $norm = self::normalize($spec, array(
-            'allowMailGroups' => $allowMailGroups,
+            'allowNamedGroups' => $allowNamedGroups,
             'allowTermine' => $allowTermine,
             'defaultGroups' => null,
         ));
-        if(!$allowMailGroups) {
-            $norm['mailGroups'] = array();
+        if(!$allowNamedGroups) {
+            $norm['namedGroups'] = array();
         }
         if(!$allowTermine) {
             $norm['termine'] = array();
@@ -788,7 +826,7 @@ class AudienceSpec
             'groups' => $norm['groups'],
             'registers' => $norm['registers'],
             'users' => $norm['users'],
-            'mailGroups' => $norm['mailGroups'],
+            'namedGroups' => $norm['namedGroups'],
             'termine' => $norm['termine'],
         ));
     }
@@ -796,19 +834,19 @@ class AudienceSpec
     /**
      * Catalog for chip autocomplete.
      *
-     * @param array $opts forMail (bool), includeMailGroups (bool), includeTermine (bool)
+     * @param array $opts forMail (bool), includeNamedGroups (bool; legacy includeMailGroups), includeTermine (bool)
      * @return array
      */
     public static function buildCatalog($opts = array()) {
         $forMail = !empty($opts['forMail']);
-        $includeMailGroups = !array_key_exists('includeMailGroups', $opts) || !empty($opts['includeMailGroups']);
+        $includeNamedGroups = self::includeNamedGroupsOpt($opts);
         $includeTermine = !empty($opts['includeTermine']);
 
         $catalog = array(
             'groups' => array(),
             'registers' => array(),
             'users' => array(),
-            'mailGroups' => array(),
+            'namedGroups' => array(),
             'termine' => array(),
         );
         foreach(self::groupLabels() as $id => $label) {
@@ -860,9 +898,9 @@ class AudienceSpec
             }
         }
 
-        if($includeMailGroups) {
-            foreach(MailGroup::listAll() as $g) {
-                $catalog['mailGroups'][] = array(
+        if($includeNamedGroups) {
+            foreach(Group::listAll() as $g) {
+                $catalog['namedGroups'][] = array(
                     'id' => (int)$g->Index,
                     'label' => (string)$g->Name,
                     'meta' => 'Gruppe',

--- a/libs/form-response.php
+++ b/libs/form-response.php
@@ -73,12 +73,12 @@ function handleUserFormPost($options = array()) {
                 $n->save();
             }
 
-            if(isset($_POST['userMailGroupsPosted']) && (int)$n->Index > 0) {
-                $ids = isset($_POST['userMailGroups']) ? $_POST['userMailGroups'] : array();
+            if(isset($_POST['userNamedGroupsPosted']) && (int)$n->Index > 0) {
+                $ids = isset($_POST['userNamedGroups']) ? $_POST['userNamedGroups'] : array();
                 if(!is_array($ids)) {
                     $ids = array();
                 }
-                MailGroup::syncUserExplicitMembership((int)$n->Index, $ids);
+                Group::syncUserExplicitMembership((int)$n->Index, $ids);
             }
 
             if(isset($_POST['userPermissionsPosted']) && (int)$n->Index > 0) {

--- a/libs/group.php
+++ b/libs/group.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Named audience groups for mail and termin visibility (MELD-61).
- * MemberSpec uses AudienceSpec shape without nested mailGroups.
- * PermissionSpec (MELD-137): JSON array of permission keys granted to members.
+ * Named audience groups for mail, termin visibility, and permission inheritance (MELD-61 / MELD-137).
+ * MemberSpec uses AudienceSpec shape without nested namedGroups.
+ * PermissionSpec: JSON array of permission keys granted to members.
  */
-class MailGroup
+class Group
 {
     private $_data = array(
         'Index' => null,
@@ -56,24 +56,38 @@ class MailGroup
     public static function ensureSchema() {
         static $done = false;
         if($done) return true;
-        $table = new SQLtable('MailGroup');
+        self::migrateLegacyTableName();
+        $table = new SQLtable('Group');
         if(!$table->exists()
             || !$table->columnExists('MemberSpec')
             || !$table->columnExists('PermissionSpec')) {
             $manager = new DatabaseManager();
             $manager->create();
             $manager->repair();
+            self::migrateLegacyTableName();
         }
         $done = true;
-        return (new SQLtable('MailGroup'))->exists();
+        return (new SQLtable('Group'))->exists();
+    }
+
+    /** Rename legacy MailGroup table to Group when present. */
+    private static function migrateLegacyTableName() {
+        $prefix = isset($GLOBALS['dbprefix']) ? (string)$GLOBALS['dbprefix'] : '';
+        $old = new SQLtable('MailGroup');
+        $new = new SQLtable('Group');
+        if($old->exists() && !$new->exists()) {
+            $sql = sprintf('RENAME TABLE `%sMailGroup` TO `%sGroup`;', $prefix, $prefix);
+            mysqli_query($GLOBALS['conn'], $sql);
+            sqlerror();
+        }
     }
 
     /**
-     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[]}
+     * @return array{groups:string[],registers:int[],users:int[],namedGroups:int[]}
      */
     public function getMemberSpecArray() {
         return AudienceSpec::normalize($this->MemberSpec, array(
-            'allowMailGroups' => false,
+            'allowNamedGroups' => false,
             'defaultGroups' => null,
         ));
     }
@@ -83,10 +97,10 @@ class MailGroup
      */
     public function setMemberSpecArray($spec) {
         $norm = AudienceSpec::normalize($spec, array(
-            'allowMailGroups' => false,
+            'allowNamedGroups' => false,
             'defaultGroups' => null,
         ));
-        unset($norm['mailGroups']);
+        unset($norm['namedGroups']);
         $payload = array(
             'groups' => $norm['groups'],
             'registers' => $norm['registers'],
@@ -194,7 +208,7 @@ class MailGroup
     }
 
     public function getMemberLabel() {
-        return AudienceSpec::formatLabel($this->getMemberSpecArray(), array('allowMailGroups' => false));
+        return AudienceSpec::formatLabel($this->getMemberSpecArray(), array('allowNamedGroups' => false));
     }
 
     public function getVars() {
@@ -210,15 +224,15 @@ class MailGroup
     }
 
     public function getChanges() {
-        $old = new MailGroup();
+        $old = new Group();
         $old->load_by_id((int)$this->Index);
         $str = sprintf('Gruppen-ID: %d, <b>%s</b>', (int)$this->Index, htmlspecialchars((string)$this->Name, ENT_QUOTES, 'UTF-8'));
         if((string)$this->Name !== (string)$old->Name) {
             $str .= ', Name: '.htmlspecialchars((string)$old->Name, ENT_QUOTES, 'UTF-8')
                 .' &rArr; <b>'.htmlspecialchars((string)$this->Name, ENT_QUOTES, 'UTF-8').'</b>';
         }
-        $oldJson = AudienceSpec::canonicalJson($old->MemberSpec, array('allowMailGroups' => false));
-        $newJson = AudienceSpec::canonicalJson($this->MemberSpec, array('allowMailGroups' => false));
+        $oldJson = AudienceSpec::canonicalJson($old->MemberSpec, array('allowNamedGroups' => false));
+        $newJson = AudienceSpec::canonicalJson($this->MemberSpec, array('allowNamedGroups' => false));
         if($oldJson !== $newJson) {
             $str .= ', Mitglieder: '.htmlspecialchars($old->getMemberLabel(), ENT_QUOTES, 'UTF-8')
                 .' &rArr; <b>'.htmlspecialchars($this->getMemberLabel(), ENT_QUOTES, 'UTF-8').'</b>';
@@ -236,7 +250,7 @@ class MailGroup
         self::ensureSchema();
         $Index = (int)$Index;
         $sql = sprintf(
-            'SELECT * FROM `%sMailGroup` WHERE `Index` = %d;',
+            'SELECT * FROM `%sGroup` WHERE `Index` = %d;',
             $GLOBALS['dbprefix'],
             $Index
         );
@@ -249,20 +263,20 @@ class MailGroup
     }
 
     /**
-     * @return MailGroup[]
+     * @return Group[]
      */
     public static function listAll() {
         self::ensureSchema();
         $out = array();
         $sql = sprintf(
-            'SELECT * FROM `%sMailGroup` ORDER BY `Name`, `Index`;',
+            'SELECT * FROM `%sGroup` ORDER BY `Name`, `Index`;',
             $GLOBALS['dbprefix']
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
         sqlerror();
         if(!$dbr) return $out;
         while($row = mysqli_fetch_array($dbr)) {
-            $g = new MailGroup();
+            $g = new Group();
             $g->fill_from_array($row);
             $out[] = $g;
         }
@@ -288,7 +302,7 @@ class MailGroup
      * Membership via roles/registers is unchanged.
      *
      * @param int $userId
-     * @param array $wantGroupIds MailGroup Index values that should include the user
+     * @param array $wantGroupIds Group Index values that should include the user
      */
     public static function syncUserExplicitMembership($userId, $wantGroupIds) {
         $userId = (int)$userId;
@@ -351,7 +365,7 @@ class MailGroup
             $createdBy = (int)$_SESSION['userid'];
         }
         $sql = sprintf(
-            'INSERT INTO `%sMailGroup` (`Name`, `MemberSpec`, `PermissionSpec`, `CreatedBy`) VALUES ("%s", %s, %s, %d);',
+            'INSERT INTO `%sGroup` (`Name`, `MemberSpec`, `PermissionSpec`, `CreatedBy`) VALUES ("%s", %s, %s, %d);',
             $GLOBALS['dbprefix'],
             mysqli_real_escape_string($GLOBALS['conn'], $this->Name),
             $this->sqlMemberSpec(),
@@ -367,7 +381,7 @@ class MailGroup
 
     protected function update() {
         $sql = sprintf(
-            'UPDATE `%sMailGroup` SET `Name` = "%s", `MemberSpec` = %s, `PermissionSpec` = %s WHERE `Index` = %d;',
+            'UPDATE `%sGroup` SET `Name` = "%s", `MemberSpec` = %s, `PermissionSpec` = %s WHERE `Index` = %d;',
             $GLOBALS['dbprefix'],
             mysqli_real_escape_string($GLOBALS['conn'], $this->Name),
             $this->sqlMemberSpec(),
@@ -400,7 +414,7 @@ class MailGroup
         self::ensureSchema();
         $vars = $this->getVars();
         $sql = sprintf(
-            'DELETE FROM `%sMailGroup` WHERE `Index` = %d;',
+            'DELETE FROM `%sGroup` WHERE `Index` = %d;',
             $GLOBALS['dbprefix'],
             (int)$this->Index
         );

--- a/libs/group.php
+++ b/libs/group.php
@@ -56,7 +56,7 @@ class Group
     public static function ensureSchema() {
         static $done = false;
         if($done) return true;
-        self::migrateLegacyTableName();
+        self::migrateTableFromMailGroup();
         $table = new SQLtable('Group');
         if(!$table->exists()
             || !$table->columnExists('MemberSpec')
@@ -64,22 +64,159 @@ class Group
             $manager = new DatabaseManager();
             $manager->create();
             $manager->repair();
-            self::migrateLegacyTableName();
+            self::migrateTableFromMailGroup();
         }
         $done = true;
         return (new SQLtable('Group'))->exists();
     }
 
-    /** Rename legacy MailGroup table to Group when present. */
-    private static function migrateLegacyTableName() {
+    /**
+     * MELD-137: MailGroup → Group ohne Datenverlust.
+     * - Nur MailGroup: RENAME (inkl. Index/AUTO_INCREMENT/PermissionSpec).
+     * - Leere Group + MailGroup mit Daten: leere Group droppen, dann RENAME
+     *   (passiert, wenn repair() Group aus DBconfig anlegt, bevor umbenannt wurde).
+     * - Beide mit Daten: fehlende Zeilen aus MailGroup nach Group kopieren, dann MailGroup droppen.
+     *
+     * @return bool true wenn kein MailGroup mit Daten mehr übrig ist
+     */
+    public static function migrateTableFromMailGroup() {
         $prefix = isset($GLOBALS['dbprefix']) ? (string)$GLOBALS['dbprefix'] : '';
+        $conn = $GLOBALS['conn'];
         $old = new SQLtable('MailGroup');
         $new = new SQLtable('Group');
-        if($old->exists() && !$new->exists()) {
-            $sql = sprintf('RENAME TABLE `%sMailGroup` TO `%sGroup`;', $prefix, $prefix);
-            mysqli_query($GLOBALS['conn'], $sql);
-            sqlerror();
+        if(!$old->exists()) {
+            return true;
         }
+
+        $oldName = $prefix.'MailGroup';
+        $newName = $prefix.'Group';
+
+        if(!$new->exists()) {
+            $sql = sprintf('RENAME TABLE `%s` TO `%s`;', $oldName, $newName);
+            $ok = mysqli_query($conn, $sql);
+            sqlerror();
+            return (bool)$ok && !(new SQLtable('MailGroup'))->exists() && (new SQLtable('Group'))->exists();
+        }
+
+        $oldCount = self::tableRowCount($oldName);
+        $newCount = self::tableRowCount($newName);
+        if($oldCount < 0 || $newCount < 0) {
+            return false;
+        }
+
+        // Empty Group shell from processSchema while MailGroup still holds data.
+        if($newCount === 0) {
+            $drop = sprintf('DROP TABLE `%s`;', $newName);
+            if(!mysqli_query($conn, $drop)) {
+                sqlerror();
+                return false;
+            }
+            $sql = sprintf('RENAME TABLE `%s` TO `%s`;', $oldName, $newName);
+            $ok = mysqli_query($conn, $sql);
+            sqlerror();
+            return (bool)$ok && !(new SQLtable('MailGroup'))->exists();
+        }
+
+        // Both have rows: copy any MailGroup rows missing in Group, then drop legacy table.
+        if(!self::copyMissingMailGroupRows($oldName, $newName)) {
+            return false;
+        }
+        $remaining = self::tableRowCount($oldName);
+        if($remaining !== 0) {
+            // Still rows that could not be copied (should not happen after INSERT IGNORE by Index).
+            return false;
+        }
+        $dropOld = sprintf('DROP TABLE `%s`;', $oldName);
+        $ok = mysqli_query($conn, $dropOld);
+        sqlerror();
+        return (bool)$ok;
+    }
+
+    /**
+     * @param string $tableName fully prefixed table name
+     * @return int row count, or -1 on error
+     */
+    private static function tableRowCount($tableName) {
+        $sql = sprintf('SELECT COUNT(*) AS `c` FROM `%s`;', $tableName);
+        $dbr = mysqli_query($GLOBALS['conn'], $sql);
+        if(!$dbr) {
+            sqlerror();
+            return -1;
+        }
+        $row = mysqli_fetch_assoc($dbr);
+        return $row ? (int)$row['c'] : 0;
+    }
+
+    /**
+     * Insert MailGroup rows whose Index is not yet in Group (never overwrite Group rows).
+     * @param string $oldName
+     * @param string $newName
+     * @return bool
+     */
+    private static function copyMissingMailGroupRows($oldName, $newName) {
+        $conn = $GLOBALS['conn'];
+        $old = new SQLtable('MailGroup');
+        $new = new SQLtable('Group');
+        $hasPerm = $old->columnExists('PermissionSpec');
+        if(!$new->columnExists('PermissionSpec')) {
+            $add = sprintf(
+                'ALTER TABLE `%s` ADD `PermissionSpec` text NULL COLLATE utf8mb4_unicode_ci;',
+                $newName
+            );
+            if(!mysqli_query($conn, $add)) {
+                sqlerror();
+                return false;
+            }
+        }
+        $hasNewPerm = (new SQLtable('Group'))->columnExists('PermissionSpec');
+
+        if($hasPerm && $hasNewPerm) {
+            $sql = sprintf(
+                'INSERT INTO `%s` (`Index`, `Name`, `MemberSpec`, `PermissionSpec`, `CreatedBy`, `Created`)'
+                .' SELECT `o`.`Index`, `o`.`Name`, `o`.`MemberSpec`, `o`.`PermissionSpec`, `o`.`CreatedBy`, `o`.`Created`'
+                .' FROM `%s` `o`'
+                .' LEFT JOIN `%s` `g` ON `g`.`Index` = `o`.`Index`'
+                .' WHERE `g`.`Index` IS NULL;',
+                $newName,
+                $oldName,
+                $newName
+            );
+        }
+        else {
+            $sql = sprintf(
+                'INSERT INTO `%s` (`Index`, `Name`, `MemberSpec`, `CreatedBy`, `Created`)'
+                .' SELECT `o`.`Index`, `o`.`Name`, `o`.`MemberSpec`, `o`.`CreatedBy`, `o`.`Created`'
+                .' FROM `%s` `o`'
+                .' LEFT JOIN `%s` `g` ON `g`.`Index` = `o`.`Index`'
+                .' WHERE `g`.`Index` IS NULL;',
+                $newName,
+                $oldName,
+                $newName
+            );
+        }
+        if(!mysqli_query($conn, $sql)) {
+            sqlerror();
+            return false;
+        }
+
+        // Remove successfully migrated legacy rows (matched by Index).
+        $del = sprintf(
+            'DELETE `o` FROM `%s` `o` INNER JOIN `%s` `g` ON `g`.`Index` = `o`.`Index`;',
+            $oldName,
+            $newName
+        );
+        if(!mysqli_query($conn, $del)) {
+            sqlerror();
+            return false;
+        }
+
+        // Keep AUTO_INCREMENT above max Index.
+        $maxSql = sprintf('SELECT COALESCE(MAX(`Index`), 0) AS `m` FROM `%s`;', $newName);
+        $dbr = mysqli_query($conn, $maxSql);
+        $row = $dbr ? mysqli_fetch_assoc($dbr) : null;
+        $next = $row ? ((int)$row['m'] + 1) : 1;
+        mysqli_query($conn, sprintf('ALTER TABLE `%s` AUTO_INCREMENT = %d;', $newName, $next));
+        return true;
     }
 
     /**

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -569,9 +569,7 @@ function loadconfig() {
 }
 
 function loadPermissions($user) {
-    $p = new Permissions;
-    $p->load_by_user($user);
-    return $p;
+    return Permissions::loadEffectiveByUser($user);
 }
 
 /**
@@ -851,9 +849,11 @@ function RegisterOption($val) {
 }
 
 function requirePermission($perm) {
-    $P = new Permissions;
-    $P->load_by_user($_SESSION['userid']);
-    return $P->getPermission($perm);
+    $uid = isset($_SESSION['userid']) ? (int)$_SESSION['userid'] : 0;
+    if($uid < 1) {
+        return false;
+    }
+    return Permissions::loadEffectiveByUser($uid)->getPermission($perm);
 }
 
 /**
@@ -886,9 +886,11 @@ function denyAccess($message = 'Keine Berechtigung für diesen Bereich.') {
 }
 
 function isAdmin() {
-    $P = new Permissions;
-    $P->load_by_user($_SESSION['userid']);
-    return $P->getAdmin();
+    $uid = isset($_SESSION['userid']) ? (int)$_SESSION['userid'] : 0;
+    if($uid < 1) {
+        return false;
+    }
+    return (bool)Permissions::loadEffectiveByUser($uid)->getAdmin();
 }
 
 function sql2time($time) {

--- a/libs/mailGroup.php
+++ b/libs/mailGroup.php
@@ -2,6 +2,7 @@
 /**
  * Named audience groups for mail and termin visibility (MELD-61).
  * MemberSpec uses AudienceSpec shape without nested mailGroups.
+ * PermissionSpec (MELD-137): JSON array of permission keys granted to members.
  */
 class MailGroup
 {
@@ -9,6 +10,7 @@ class MailGroup
         'Index' => null,
         'Name' => null,
         'MemberSpec' => null,
+        'PermissionSpec' => null,
         'CreatedBy' => 0,
         'Created' => null,
     );
@@ -30,6 +32,7 @@ class MailGroup
             $this->_data[$key] = trim((string)$val);
             break;
         case 'MemberSpec':
+        case 'PermissionSpec':
         case 'Created':
             $this->_data[$key] = $val === null ? null : trim((string)$val);
             break;
@@ -54,7 +57,9 @@ class MailGroup
         static $done = false;
         if($done) return true;
         $table = new SQLtable('MailGroup');
-        if(!$table->exists() || !$table->columnExists('MemberSpec')) {
+        if(!$table->exists()
+            || !$table->columnExists('MemberSpec')
+            || !$table->columnExists('PermissionSpec')) {
             $manager = new DatabaseManager();
             $manager->create();
             $manager->repair();
@@ -90,6 +95,100 @@ class MailGroup
         $this->MemberSpec = json_encode($payload);
     }
 
+    /**
+     * Known permission keys granted by this group (unknown keys dropped).
+     * @return string[]
+     */
+    public function getPermissionSpecArray() {
+        return self::normalizePermissionSpec($this->PermissionSpec);
+    }
+
+    /**
+     * @param array|string|null $spec
+     */
+    public function setPermissionSpecArray($spec) {
+        $keys = self::normalizePermissionSpec($spec);
+        $this->PermissionSpec = count($keys) ? json_encode(array_values($keys)) : null;
+    }
+
+    /**
+     * @param array|string|null $raw
+     * @return string[]
+     */
+    public static function normalizePermissionSpec($raw) {
+        if(is_string($raw)) {
+            $decoded = json_decode($raw, true);
+            $raw = is_array($decoded) ? $decoded : array();
+        }
+        if(!is_array($raw)) {
+            return array();
+        }
+        $allowed = array_flip(Permissions::permissionKeys());
+        $out = array();
+        foreach($raw as $key) {
+            if(is_string($key) && isset($allowed[$key])) {
+                $out[$key] = true;
+            }
+        }
+        return array_keys($out);
+    }
+
+    /**
+     * Short labels for granted permissions (empty string if none).
+     */
+    public function getPermissionLabel() {
+        $keys = $this->getPermissionSpecArray();
+        if(!count($keys)) {
+            return '';
+        }
+        $labels = Permissions::permissionLabels();
+        $parts = array();
+        foreach($keys as $key) {
+            $parts[] = isset($labels[$key]['short']) ? $labels[$key]['short'] : $key;
+        }
+        return implode(', ', $parts);
+    }
+
+    /**
+     * Permission keys granted to a user via group membership (union).
+     * @return string[]
+     */
+    public static function permissionsGrantedToUser($userId) {
+        $sources = self::inheritedPermissionSources($userId);
+        return array_keys($sources);
+    }
+
+    /**
+     * Map permission key => group names that grant it (membership via MemberSpec).
+     * @return array<string,string[]>
+     */
+    public static function inheritedPermissionSources($userId) {
+        $userId = (int)$userId;
+        $out = array();
+        if($userId < 1) {
+            return $out;
+        }
+        self::ensureSchema();
+        foreach(self::listAll() as $g) {
+            $granted = $g->getPermissionSpecArray();
+            if(!count($granted)) {
+                continue;
+            }
+            $memberIds = AudienceSpec::resolveUserIds($g->getMemberSpecArray(), false);
+            if(!in_array($userId, array_map('intval', $memberIds), true)) {
+                continue;
+            }
+            $name = (string)$g->Name;
+            foreach($granted as $key) {
+                if(!isset($out[$key])) {
+                    $out[$key] = array();
+                }
+                $out[$key][] = $name;
+            }
+        }
+        return $out;
+    }
+
     public function memberCount($requireMail = false) {
         return count(AudienceSpec::resolveUserIds($this->getMemberSpecArray(), $requireMail));
     }
@@ -103,6 +202,10 @@ class MailGroup
         $parts[] = sprintf('Gruppen-ID: <b>%d</b>', (int)$this->Index);
         $parts[] = logPart('Name', htmlspecialchars((string)$this->Name, ENT_QUOTES, 'UTF-8'));
         $parts[] = logPart('Mitglieder', htmlspecialchars($this->getMemberLabel(), ENT_QUOTES, 'UTF-8'));
+        $permLabel = $this->getPermissionLabel();
+        if($permLabel !== '') {
+            $parts[] = logPart('Rechte', htmlspecialchars($permLabel, ENT_QUOTES, 'UTF-8'));
+        }
         return implode(', ', $parts);
     }
 
@@ -119,6 +222,12 @@ class MailGroup
         if($oldJson !== $newJson) {
             $str .= ', Mitglieder: '.htmlspecialchars($old->getMemberLabel(), ENT_QUOTES, 'UTF-8')
                 .' &rArr; <b>'.htmlspecialchars($this->getMemberLabel(), ENT_QUOTES, 'UTF-8').'</b>';
+        }
+        $oldPerm = $old->getPermissionSpecArray();
+        $newPerm = $this->getPermissionSpecArray();
+        if($oldPerm !== $newPerm) {
+            $str .= ', Rechte: '.htmlspecialchars($old->getPermissionLabel() !== '' ? $old->getPermissionLabel() : '—', ENT_QUOTES, 'UTF-8')
+                .' &rArr; <b>'.htmlspecialchars($this->getPermissionLabel() !== '' ? $this->getPermissionLabel() : '—', ENT_QUOTES, 'UTF-8').'</b>';
         }
         return $str;
     }
@@ -211,6 +320,7 @@ class MailGroup
                 $g->save();
             }
         }
+        Permissions::clearEffectiveCache($userId);
     }
 
     public function save() {
@@ -219,13 +329,16 @@ class MailGroup
         if((int)$this->Index > 0) {
             $logentry = new Log;
             $logentry->DBupdate($this->getChanges());
-            return $this->update();
+            $ok = $this->update();
+            Permissions::clearEffectiveCache();
+            return $ok;
         }
         if(!$this->insert()) {
             return false;
         }
         $logentry = new Log;
         $logentry->DBinsert($this->getVars());
+        Permissions::clearEffectiveCache();
         return true;
     }
 
@@ -238,10 +351,11 @@ class MailGroup
             $createdBy = (int)$_SESSION['userid'];
         }
         $sql = sprintf(
-            'INSERT INTO `%sMailGroup` (`Name`, `MemberSpec`, `CreatedBy`) VALUES ("%s", %s, %d);',
+            'INSERT INTO `%sMailGroup` (`Name`, `MemberSpec`, `PermissionSpec`, `CreatedBy`) VALUES ("%s", %s, %s, %d);',
             $GLOBALS['dbprefix'],
             mysqli_real_escape_string($GLOBALS['conn'], $this->Name),
             $this->sqlMemberSpec(),
+            $this->sqlPermissionSpec(),
             $createdBy
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
@@ -253,10 +367,11 @@ class MailGroup
 
     protected function update() {
         $sql = sprintf(
-            'UPDATE `%sMailGroup` SET `Name` = "%s", `MemberSpec` = %s WHERE `Index` = %d;',
+            'UPDATE `%sMailGroup` SET `Name` = "%s", `MemberSpec` = %s, `PermissionSpec` = %s WHERE `Index` = %d;',
             $GLOBALS['dbprefix'],
             mysqli_real_escape_string($GLOBALS['conn'], $this->Name),
             $this->sqlMemberSpec(),
+            $this->sqlPermissionSpec(),
             (int)$this->Index
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
@@ -270,6 +385,14 @@ class MailGroup
             return 'NULL';
         }
         return '"'.mysqli_real_escape_string($GLOBALS['conn'], (string)$raw).'"';
+    }
+
+    protected function sqlPermissionSpec() {
+        $keys = $this->getPermissionSpecArray();
+        if(!count($keys)) {
+            return 'NULL';
+        }
+        return '"'.mysqli_real_escape_string($GLOBALS['conn'], json_encode(array_values($keys))).'"';
     }
 
     public function delete() {
@@ -287,6 +410,7 @@ class MailGroup
         $logentry = new Log;
         $logentry->DBdelete($vars);
         $this->_data['Index'] = null;
+        Permissions::clearEffectiveCache();
         return true;
     }
 }

--- a/libs/mailJob.php
+++ b/libs/mailJob.php
@@ -143,7 +143,7 @@ class MailJob
                 'groups' => array(),
                 'registers' => array(),
                 'users' => array(),
-                'mailGroups' => array(),
+                'namedGroups' => array(),
                 'termine' => array($termin),
             ));
         }
@@ -246,11 +246,11 @@ class MailJob
      * @param string|null $json
      * @param int $legacyRegister
      * @param int $legacyMemberOnly
-     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[]}
+     * @return array{groups:string[],registers:int[],users:int[],namedGroups:int[]}
      */
     public static function parseRecipientSpec($json, $legacyRegister = 0, $legacyMemberOnly = 0) {
         return AudienceSpec::normalize($json, array(
-            'allowMailGroups' => true,
+            'allowNamedGroups' => true,
             'allowTermine' => true,
             'defaultGroups' => null,
             'legacyRegister' => $legacyRegister,
@@ -263,7 +263,7 @@ class MailJob
      */
     public function setRecipientSpecArray($spec) {
         $norm = AudienceSpec::normalize($spec, array(
-            'allowMailGroups' => true,
+            'allowNamedGroups' => true,
             'allowTermine' => true,
             'defaultGroups' => null,
         ));
@@ -271,7 +271,7 @@ class MailJob
             'groups' => $norm['groups'],
             'registers' => $norm['registers'],
             'users' => $norm['users'],
-            'mailGroups' => $norm['mailGroups'],
+            'namedGroups' => $norm['namedGroups'],
             'termine' => $norm['termine'],
         );
         $this->RecipientSpec = json_encode($payload);
@@ -282,7 +282,7 @@ class MailJob
             'groups' => array('musicians'),
             'registers' => array(),
             'users' => array(),
-            'mailGroups' => array(),
+            'namedGroups' => array(),
             'termine' => array(),
         );
     }

--- a/libs/permissions.php
+++ b/libs/permissions.php
@@ -91,6 +91,9 @@ class Permissions
             $logentry = new Log;
             $logentry->DBinsert($this->getVars());
         }
+        if((int)$this->User > 0) {
+            self::clearEffectiveCache((int)$this->User);
+        }
     }
     
     public function is_valid() {
@@ -198,6 +201,42 @@ class Permissions
             $this->User = $Index;
             $this->save();
         }
+    }
+
+    /** @var array<int,Permissions> */
+    private static $effectiveCache = array();
+
+    /**
+     * Drop request-level effective-permission cache (after personal or group changes).
+     * @param int|null $userId null = clear all
+     */
+    public static function clearEffectiveCache($userId = null) {
+        if($userId === null) {
+            self::$effectiveCache = array();
+            return;
+        }
+        unset(self::$effectiveCache[(int)$userId]);
+    }
+
+    /**
+     * Personal Permissions row OR-merged with MailGroup PermissionSpec for members.
+     * @param int $userId
+     * @return Permissions
+     */
+    public static function loadEffectiveByUser($userId) {
+        $userId = (int)$userId;
+        if(isset(self::$effectiveCache[$userId])) {
+            return self::$effectiveCache[$userId];
+        }
+        $p = new Permissions();
+        $p->load_by_user($userId);
+        foreach(MailGroup::permissionsGrantedToUser($userId) as $key) {
+            if(in_array($key, self::permissionKeys(), true)) {
+                $p->$key = 1;
+            }
+        }
+        self::$effectiveCache[$userId] = $p;
+        return $p;
     }
 
     public function getAdmin() {
@@ -398,6 +437,7 @@ class Permissions
             $p->$key = $val;
         }
         $p->save();
+        self::clearEffectiveCache($userId);
         if($sessionUserId === $userId) {
             $_SESSION['permissions'] = loadPermissions($userId);
             $_SESSION['admin'] = isAdmin() ? 1 : 0;

--- a/libs/permissions.php
+++ b/libs/permissions.php
@@ -219,7 +219,7 @@ class Permissions
     }
 
     /**
-     * Personal Permissions row OR-merged with MailGroup PermissionSpec for members.
+     * Personal Permissions row OR-merged with Group PermissionSpec for members.
      * @param int $userId
      * @return Permissions
      */
@@ -230,7 +230,7 @@ class Permissions
         }
         $p = new Permissions();
         $p->load_by_user($userId);
-        foreach(MailGroup::permissionsGrantedToUser($userId) as $key) {
+        foreach(Group::permissionsGrantedToUser($userId) as $key) {
             if(in_array($key, self::permissionKeys(), true)) {
                 $p->$key = 1;
             }

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -112,8 +112,8 @@ class Termin
         if($this->Ort3 != $old->Ort3) $str.=", Ort3: ".$old->Ort3." &rArr; <b>".$this->Ort3."</b>";
         if($this->Ort4 != $old->Ort4) $str.=", Ort4: ".$old->Ort4." &rArr; <b>".$this->Ort4."</b>";
         if($this->Beschreibung != $old->Beschreibung) $str.=", Beschreibung: ".$old->Beschreibung." &rArr; <b>".$this->Beschreibung."</b>";
-        $oldVis = AudienceSpec::canonicalJson($old->VisibilitySpec, array('allowMailGroups' => true));
-        $newVis = AudienceSpec::canonicalJson($this->VisibilitySpec, array('allowMailGroups' => true));
+        $oldVis = AudienceSpec::canonicalJson($old->VisibilitySpec, array('allowNamedGroups' => true));
+        $newVis = AudienceSpec::canonicalJson($this->VisibilitySpec, array('allowNamedGroups' => true));
         if($oldVis !== $newVis) {
             $str.=", sichtbar für: ".htmlspecialchars($old->getVisibilityLabel(), ENT_QUOTES, 'UTF-8')
                 ." &rArr; <b>".htmlspecialchars($this->getVisibilityLabel(), ENT_QUOTES, 'UTF-8')."</b>";
@@ -617,11 +617,11 @@ class Termin
     }
 
     /**
-     * @return array{groups:string[],registers:int[],users:int[],mailGroups:int[]}
+     * @return array{groups:string[],registers:int[],users:int[],namedGroups:int[]}
      */
     public function getVisibilitySpecArray() {
         return AudienceSpec::normalize($this->VisibilitySpec, array(
-            'allowMailGroups' => true,
+            'allowNamedGroups' => true,
             'defaultGroups' => null,
         ));
     }
@@ -632,7 +632,7 @@ class Termin
      */
     public function setVisibilitySpecArray($spec, $syncGuests = true) {
         $norm = AudienceSpec::normalize($spec, array(
-            'allowMailGroups' => true,
+            'allowNamedGroups' => true,
             'defaultGroups' => null,
         ));
         if(AudienceSpec::isEmpty($norm)) {
@@ -646,7 +646,7 @@ class Termin
             'groups' => $norm['groups'],
             'registers' => $norm['registers'],
             'users' => $norm['users'],
-            'mailGroups' => $norm['mailGroups'],
+            'namedGroups' => $norm['namedGroups'],
         ));
         if($syncGuests) {
             $this->syncGuestMusiciansFromVisibility();
@@ -658,7 +658,7 @@ class Termin
         if($raw === null || $raw === '') {
             return 'NULL';
         }
-        $norm = AudienceSpec::normalize($raw, array('allowMailGroups' => true, 'defaultGroups' => null));
+        $norm = AudienceSpec::normalize($raw, array('allowNamedGroups' => true, 'defaultGroups' => null));
         if(AudienceSpec::isEmpty($norm)) {
             return 'NULL';
         }
@@ -666,7 +666,7 @@ class Termin
             'groups' => $norm['groups'],
             'registers' => $norm['registers'],
             'users' => $norm['users'],
-            'mailGroups' => $norm['mailGroups'],
+            'namedGroups' => $norm['namedGroups'],
         ))).'"';
     }
 
@@ -834,7 +834,7 @@ class Termin
      * @return string
      */
     public function getVisibilityLabel() {
-        return AudienceSpec::formatLabel($this->getVisibilitySpecArray(), array('allowMailGroups' => true));
+        return AudienceSpec::formatLabel($this->getVisibilitySpecArray(), array('allowNamedGroups' => true));
     }
 
     /**

--- a/libs/usermail.php
+++ b/libs/usermail.php
@@ -273,7 +273,7 @@ class Usermail {
         if($count > 0) {
             $specLabel = AudienceSpec::formatLabel(
                 $job->getRecipientSpecArray(),
-                array('allowMailGroups' => true, 'allowTermine' => true)
+                array('allowNamedGroups' => true, 'allowTermine' => true)
             );
             $logentry->email(sprintf(
                 "In Warteschlange gestellt | Email-ID: <b>%d</b>, Betreff: <b>%s</b>, Empfänger: <b>%d</b>, Quelle: <b>%s</b>, Auswahl: <b>%s</b>",
@@ -785,7 +785,7 @@ class Usermail {
 
         $spec = is_array($this->recipientSpec)
             ? AudienceSpec::normalize($this->recipientSpec, array(
-                'allowMailGroups' => true,
+                'allowNamedGroups' => true,
                 'allowTermine' => true,
                 'defaultGroups' => array('musicians'),
                 'legacyRegister' => (int)$this->register,

--- a/mail.php
+++ b/mail.php
@@ -165,14 +165,14 @@ if($job && $job->Status === 'draft' && (int)$job->Termin > 0) {
         'groups' => array(),
         'registers' => array(),
         'users' => array(),
-        'mailGroups' => array(),
+        'namedGroups' => array(),
         'termine' => array($legacyTermin),
     ));
     $job->save();
     $recipientSpec = $job->getRecipientSpecArray();
 }
 // Neue / leere Entwürfe: Alle Musiker vorauswählen und im Job speichern
-// (mailGroups/termine zählen mit — sonst würden reine Gruppen-/Termin-Chips überschrieben)
+// (namedGroups/termine zählen mit — sonst würden reine Gruppen-/Termin-Chips überschrieben)
 if(
     $job
     && $job->Status === 'draft'
@@ -190,10 +190,10 @@ $anrede = 'Hallo {VORNAME},';
 $postDiscord = ($discordAvailable && $job) ? ((int)$job->PostDiscord === 1) : false;
 
 // Catalog for chip autocomplete
-MailGroup::ensureSchema();
+Group::ensureSchema();
 $mailRecipientCatalog = AudienceSpec::buildCatalog(array(
     'forMail' => true,
-    'includeMailGroups' => true,
+    'includeNamedGroups' => true,
     'includeTermine' => true,
 ));
 // Ensure already selected termine appear (also past events)
@@ -421,7 +421,7 @@ foreach($allJobs as $rowJob) {
         && spec.groups[0] === 'musicians'
         && (!spec.registers || !spec.registers.length)
         && (!spec.users || !spec.users.length)
-        && (!spec.mailGroups || !spec.mailGroups.length)
+        && (!spec.namedGroups || !spec.namedGroups.length)
         && (!spec.termine || !spec.termine.length);
       cb.checked = !!isDefaultAll;
     } catch(e) {
@@ -672,7 +672,7 @@ function delFile(hash) {
     }
     else {
         $verteilerHtml = AudienceSpec::renderChipsHtml($recipientSpecView, array(
-            'allowMailGroups' => true,
+            'allowNamedGroups' => true,
             'allowTermine' => true,
             'ariaLabel' => 'Verteiler',
             'emptyHtml' => '<span class="w3-text-gray">—</span>',

--- a/mailRecipientCount.php
+++ b/mailRecipientCount.php
@@ -47,7 +47,7 @@ elseif($requireMail) {
 }
 else {
     $norm = AudienceSpec::normalize($spec, array(
-        'allowMailGroups' => true,
+        'allowNamedGroups' => true,
         'allowTermine' => false,
         'defaultGroups' => null,
     ));

--- a/new-termin.php
+++ b/new-termin.php
@@ -317,10 +317,10 @@ function clearInput(name) {
 }
 </script>
 <?php
-MailGroup::ensureSchema();
+Group::ensureSchema();
 $terminVisibilityCatalog = AudienceSpec::buildCatalog(array(
     'forMail' => false,
-    'includeMailGroups' => true,
+    'includeNamedGroups' => true,
 ));
 ?>
 <script type="application/json" id="terminVisibilityCatalog"><?php echo json_encode($terminVisibilityCatalog, JSON_UNESCAPED_UNICODE); ?></script>
@@ -350,7 +350,7 @@ $terminVisibilityCatalog = AudienceSpec::buildCatalog(array(
       && spec.groups[0] === 'users'
       && (!spec.registers || !spec.registers.length)
       && (!spec.users || !spec.users.length)
-      && (!spec.mailGroups || !spec.mailGroups.length);
+      && (!spec.namedGroups || !spec.namedGroups.length);
   }
   function syncTerminDiscordDefault() {
     try {

--- a/permissions.php
+++ b/permissions.php
@@ -33,11 +33,14 @@ while($row = mysqli_fetch_array($dbr)) {
     }
     $perm = new Permissions;
     $perm->load_by_user($user->Index);
+    $inherited = MailGroup::inheritedPermissionSources((int)$user->Index);
+    $hasAny = $perm->hasAnyPermission() || count($inherited) > 0;
     $rows[] = array(
         'user' => $user,
         'perm' => $perm,
+        'inherited' => $inherited,
         'name' => $user->getName(),
-        'hasAny' => $perm->hasAnyPermission(),
+        'hasAny' => $hasAny,
     );
 }
 ?>
@@ -59,6 +62,7 @@ adminListPageBegin('System', 'Berechtigungen', array(
         </label>
       </div>
     </div>
+    <p class="admin-list-intro w3-small">Persönliche Rechte sind editierbar. Haken mit gestricheltem Rahmen kommen nur über eine Gruppe und lassen sich hier nicht entfernen.</p>
 
     <h3 class="profile-col-title">Rechte-Matrix</h3>
     <div class="perm-matrix-wrap">
@@ -99,22 +103,38 @@ adminListPageBegin('System', 'Berechtigungen', array(
               <?php echo htmlspecialchars($name); ?>
             </td>
 <?php foreach($permKeys as $key) {
-    $on = (bool)$entry['perm']->$key;
+    $personalOn = (bool)$entry['perm']->$key;
+    $groupNames = isset($entry['inherited'][$key]) ? $entry['inherited'][$key] : array();
+    $inheritedOnly = !$personalOn && count($groupNames) > 0;
+    $on = $personalOn || count($groupNames) > 0;
     $locked = ($uid === $sessionUserId && $key === 'perm_editPermissions');
-    $title = htmlspecialchars($permLabels[$key]['label'], ENT_QUOTES, 'UTF-8');
+    $title = $permLabels[$key]['label'];
+    if(count($groupNames)) {
+        $title .= ' — Gruppe: '.implode(', ', $groupNames);
+    }
+    $title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
     $gid = Permissions::groupIdForPermission($key);
     $gid = preg_replace('/[^a-z0-9_-]/i', '', (string)$gid);
     if($gid === '') {
         $gid = 'system';
     }
+    $cellExtra = $inheritedOnly ? ' perm-inherited' : '';
+    $disabled = $locked || $inheritedOnly;
+    $disabledTitle = '';
+    if($locked) {
+        $disabledTitle = ' title="Eigenes Recht „Berechtigungen bearbeiten“ kann nicht entfernt werden"';
+    }
+    elseif($inheritedOnly) {
+        $disabledTitle = ' title="'.htmlspecialchars('Nur über Gruppe: '.implode(', ', $groupNames), ENT_QUOTES, 'UTF-8').'"';
+    }
 ?>
-            <td class="perm-cell perm-group perm-group--<?php echo htmlspecialchars($gid, ENT_QUOTES, 'UTF-8'); ?> <?php echo $on ? 'perm-on' : 'perm-off'; ?>" title="<?php echo $title; ?>">
+            <td class="perm-cell perm-group perm-group--<?php echo htmlspecialchars($gid, ENT_QUOTES, 'UTF-8'); ?> <?php echo $on ? 'perm-on' : 'perm-off'; ?><?php echo $cellExtra; ?>" title="<?php echo $title; ?>">
               <input type="checkbox"
                      class="perm-toggle"
                      data-user="<?php echo $uid; ?>"
                      data-perm="<?php echo htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>"
                      <?php echo $on ? 'checked' : ''; ?>
-                     <?php echo $locked ? 'disabled title="Eigenes Recht „Berechtigungen bearbeiten“ kann nicht entfernt werden"' : ''; ?>>
+                     <?php echo $disabled ? 'disabled'.$disabledTitle : ''; ?>>
             </td>
 <?php } ?>
           </tr>
@@ -167,6 +187,27 @@ adminListPageBegin('System', 'Berechtigungen', array(
     row.setAttribute('data-has-perms', any ? '1' : '0');
   }
 
+  function applyInheritedState(cb, cell, data) {
+    var inherited = data && data.inherited;
+    var groups = (data && data.inheritedGroups) ? data.inheritedGroups : [];
+    if(inherited && !cb.checked) {
+      cb.checked = true;
+      cb.disabled = true;
+      cell.classList.add('perm-inherited');
+      cell.classList.add('perm-on');
+      cell.classList.remove('perm-off');
+      var tip = groups.length ? ('Nur über Gruppe: ' + groups.join(', ')) : 'Nur über Gruppe';
+      cb.setAttribute('title', tip);
+      cell.setAttribute('title', tip);
+    } else if(!inherited) {
+      cell.classList.remove('perm-inherited');
+      if(!(cb.disabled && cb.getAttribute('data-perm') === 'perm_editPermissions')) {
+        cb.disabled = false;
+        cb.removeAttribute('title');
+      }
+    }
+  }
+
   function saveToggle(cb) {
     var cell = cb.parentNode;
     var previous = !cb.checked;
@@ -180,8 +221,9 @@ adminListPageBegin('System', 'Berechtigungen', array(
       cell.classList.remove('perm-saving');
       var ok = false;
       var err = 'Speichern fehlgeschlagen';
+      var data = null;
       try {
-        var data = JSON.parse(xhr.responseText || '{}');
+        data = JSON.parse(xhr.responseText || '{}');
         ok = xhr.status >= 200 && xhr.status < 300 && data && data.ok;
         if(data && data.error === 'cannot_remove_own_edit') {
           err = 'Eigenes Recht „Berechtigungen bearbeiten“ kann nicht entfernt werden';
@@ -197,6 +239,7 @@ adminListPageBegin('System', 'Berechtigungen', array(
       }
       cell.classList.toggle('perm-on', cb.checked);
       cell.classList.toggle('perm-off', !cb.checked);
+      applyInheritedState(cb, cell, data);
       refreshRowHasPerms(cell.parentNode);
       applyFilter();
       setStatus('Gespeichert', true);

--- a/permissions.php
+++ b/permissions.php
@@ -62,7 +62,6 @@ adminListPageBegin('System', 'Berechtigungen', array(
         </label>
       </div>
     </div>
-    <p class="admin-list-intro w3-small">Persönliche Rechte sind editierbar. Haken mit gestricheltem Rahmen kommen nur über eine Gruppe und lassen sich hier nicht entfernen.</p>
 
     <h3 class="profile-col-title">Rechte-Matrix</h3>
     <div class="perm-matrix-wrap">

--- a/permissions.php
+++ b/permissions.php
@@ -33,7 +33,7 @@ while($row = mysqli_fetch_array($dbr)) {
     }
     $perm = new Permissions;
     $perm->load_by_user($user->Index);
-    $inherited = MailGroup::inheritedPermissionSources((int)$user->Index);
+    $inherited = Group::inheritedPermissionSources((int)$user->Index);
     $hasAny = $perm->hasAnyPermission() || count($inherited) > 0;
     $rows[] = array(
         'user' => $user,

--- a/register-types.php
+++ b/register-types.php
@@ -61,9 +61,7 @@ adminListPageBegin('Register', 'Register');
 <?php if($err) { ?><div class="w3-panel w3-red w3-padding"><?php echo htmlspecialchars($err); ?></div><?php } ?>
 
 <div class="admin-list-intro">
-  <p>Register steuern Gruppierung, Orchester-Sitzplan und Farben in der <a href="register.php">Registerübersicht</a>.</p>
-  <p><a href="instrument-types.php">Instrument-Typen verwalten</a></p>
-  <p class="w3-small"><b>Reihe</b> = Abstand vom Dirigenten (0 = Dirigent). <b>ArcMin/ArcMax</b> = Winkelbereich (0° links, 90° vorne, 180° rechts). Nach dem Speichern aktualisiert sich die Vorschau.</p>
+  <p><a href="register.php">Registerübersicht</a> · <a href="instrument-types.php">Instrument-Typen verwalten</a></p>
 </div>
 
 <div class="w3-center orchestra-svg-wrap">

--- a/savePermission.php
+++ b/savePermission.php
@@ -61,7 +61,7 @@ if($sessionUserId === $userId) {
     $_SESSION['admin'] = isAdmin() ? 1 : 0;
 }
 
-$inherited = MailGroup::inheritedPermissionSources($userId);
+$inherited = Group::inheritedPermissionSources($userId);
 $inheritedGroups = isset($inherited[$perm]) ? $inherited[$perm] : array();
 
 permJsonOut(array(

--- a/savePermission.php
+++ b/savePermission.php
@@ -54,16 +54,22 @@ $p = new Permissions;
 $p->load_by_user($userId);
 $p->$perm = $value;
 $p->save();
+Permissions::clearEffectiveCache($userId);
 
 if($sessionUserId === $userId) {
     $_SESSION['permissions'] = loadPermissions($userId);
     $_SESSION['admin'] = isAdmin() ? 1 : 0;
 }
 
+$inherited = MailGroup::inheritedPermissionSources($userId);
+$inheritedGroups = isset($inherited[$perm]) ? $inherited[$perm] : array();
+
 permJsonOut(array(
     'ok' => true,
     'user' => $userId,
     'perm' => $perm,
     'value' => $value,
+    'inherited' => count($inheritedGroups) > 0,
+    'inheritedGroups' => $inheritedGroups,
 ));
 ?>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1332,7 +1332,7 @@
   border-color: #7f9dc1;
 }
 
-.mail-recipient-chip--mailGroup {
+.mail-recipient-chip--namedGroup, .mail-recipient-chip--mailGroup {
   background: #e8f5e9;
   border-color: #66bb6a;
 }

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -548,6 +548,10 @@
   word-break: break-word;
 }
 
+.mail-list-primary .mail-list-perm-tiles {
+  margin-top: 0.35rem;
+}
+
 .mail-list-meta {
   grid-area: meta;
   font-size: 0.85em;
@@ -2265,6 +2269,12 @@ select.profile-control {
   line-height: 1.3;
   background: #eef1f4;
   color: #222;
+}
+
+.profile-perm-tile--inherited {
+  outline: 2px dashed rgba(0, 0, 0, 0.35);
+  outline-offset: 1px;
+  cursor: help;
 }
 
 .profile-perm-picker #profile-perm-chips {

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -247,6 +247,16 @@
 .perm-matrix td.perm-group--system.perm-off { background: #f7f9fa; }
 .perm-matrix td.perm-group--system.perm-on { background: #b0bec5; }
 
+.perm-matrix td.perm-inherited {
+  outline: 2px dashed rgba(0, 0, 0, 0.35);
+  outline-offset: -3px;
+}
+
+.perm-matrix td.perm-inherited input.perm-toggle {
+  opacity: 0.85;
+  cursor: help;
+}
+
 .perm-matrix tr:hover td.perm-off {
   filter: brightness(0.97);
 }

--- a/user-voice.php
+++ b/user-voice.php
@@ -70,7 +70,6 @@ include 'common/header.php';
 <div class="w3-panel w3-mobile w3-center w3-col s3 l4"></div>
 <div class="w3-card <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?> w3-mobile w3-center w3-border w3-padding w3-col s6 l4">
 <?php echo renderFlashHtml(); ?>
-  <p class="w3-small w3-left-align">Primäre Stimme und Fallbacks für das Notenarchiv (Stimmsatz). Priorität: zuerst Primär, dann Fallbacks in Reihenfolge.</p>
   <form method="POST" class="w3-left-align">
     <input type="hidden" name="save_voice" value="1">
     <h4>Primär</h4>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -160,8 +160,8 @@ $sections[] = array(
 '.(!empty($optionsDB['showMembers']) ? '<li><b>Mitgliederliste</b> – nur Vereinsmitglieder</li>' : '').'
 '.(!empty($optionsDB['showNonMembers']) ? '<li><b>Nicht-Mitgliederliste</b></li>' : '').'
 <li><b>Registerübersicht</b> – Orchester-/Registeransicht (Überschrift in Registerfarbe); Klick auf einen Sitz öffnet das User-Modal</li>
-'.(requirePermission('perm_editUsers') ? '<li><b>Musiker anlegen</b> – Person anlegen inkl. Benachrichtigungen, Haken <b>aktiv</b> (aus = Gastmusiker), Mitglied-Status, Instrument, Gruppen-Chips und Rechte; <b>Deaktivieren</b> setzt Gastmusiker; <b>Automatisch</b> zeigt die abgeleitete Zugehörigkeit</li>' : '').'
-'.(requirePermission('perm_editUsers') && !empty($optionsDB['urlNotenarchiv']) ? '<li><b>Stimme / Fallbacks</b> – primäre Stimme und Fallback-Instrumente für das Notenarchiv (Stimmsatz); im Profil verlinkt oder <code>user-voice.php</code></li>' : '').'
+'.(requirePermission('perm_editUsers') ? '<li><b>Musiker anlegen</b> – Person anlegen inkl. Benachrichtigungen, Haken <b>aktiv</b> (aus = Gastmusiker), Mitglied-Status, Instrument, Gruppen-Chips und Rechte (persönlich editierbar; über Gruppen vererbte Rechte erscheinen mit gestricheltem Rahmen und sind hier nicht entfernbar); <b>Deaktivieren</b> setzt Gastmusiker; <b>Automatisch</b> zeigt die abgeleitete Zugehörigkeit</li>' : '').'
+'.(requirePermission('perm_editUsers') && !empty($optionsDB['urlNotenarchiv']) ? '<li><b>Stimme / Fallbacks</b> – primäre Stimme und Fallback-Instrumente für das Notenarchiv (Stimmsatz); Priorität zuerst Primär, dann Fallbacks in Reihenfolge; im Profil verlinkt oder <code>user-voice.php</code></li>' : '').'
 </ul>
 '
 );
@@ -213,7 +213,7 @@ $sections[] = array(
     'visible' => isAdmin() && requirePermission('perm_sendEmail'),
     'body' => '
 <p>Unter Admin → <b>Email versenden</b> erstellst du Nachrichten an Verteiler oder einzelne Empfänger.</p>
-<p>Unter Admin → <b>Gruppen</b> legst du wiederverwendbare Gruppen an (Rollen, Register, Personen). Diese Gruppen kannst du beim Mailversand und bei der Termin-Sichtbarkeit als Chip auswählen. Zusätzlich kannst du einer Gruppe <b>Rechte vererben</b> (z.&nbsp;B. „Versteckte Termine“ für den Vorstand) – alle Mitglieder erhalten diese Rechte zusätzlich zu ihren persönlichen. Einzelne Personen kannst du den Gruppen auch direkt im Profil (Anlegen/Bearbeiten) zuordnen.</p>
+<p>Unter Admin → <b>Gruppen</b> legst du wiederverwendbare Gruppen an. <b>Mitglieder</b> sind die Union aus Rollen, Registern und einzelnen Personen (z.&nbsp;B. Posaunen + Schlagwerk + Klarinetten + einzelne Personen). Diese Gruppen kannst du beim Mailversand und bei der Termin-Sichtbarkeit als Chip auswählen. Unter <b>Vererbte Rechte</b> kannst du einer Gruppe Rechte setzen (z.&nbsp;B. „Versteckte Termine“ für den Vorstand) – alle Mitglieder erhalten diese zusätzlich zu ihren persönlichen. Einzelne Personen kannst du den Gruppen auch direkt im Profil (Anlegen/Bearbeiten) zuordnen.</p>
 <p>Beim Mailversand kannst du Chips für Rollen, Gruppen, Register, Personen und <b>Teilnehmer</b> (ja/vielleicht) zukünftiger Termine wählen. Über <b>Email an Teilnehmer</b> am Termin wird der passende Teilnehmer-Chip vorausgewählt. Mails werden in einer Warteschlange verarbeitet; den Versandstatus siehst du in der Admin-Ansicht. Bei versendeten Mails siehst du den gewählten <b>Verteiler</b> sowie die Liste der einzelnen Empfänger. Empfänger finden die Nachricht unter <b>Meine Nachrichten</b>.</p>
 <p>Falls Discord angebunden ist, kann der Versand optional auch dort veröffentlicht werden (nur bei konfiguriertem Webhook).</p>
 '
@@ -230,7 +230,7 @@ $sections[] = array(
 <li><b>Versicherung</b> – versicherte Stücke; Klick öffnet das Inventar-Modal; Spalten sortierbar; „Übersicht für Versicherung“ öffnet eine druck-/PDF-fähige Tabelle (Spalten per Checkbox wählen, dann kopieren oder als PDF speichern)</li>
 ' : '').'
 '.(requirePermission('perm_editInventories') ? '
-<li><b>Inventar-Typen</b> – Typen und Nummernkreise pflegen</li>
+<li><b>Inventar-Typen</b> – Prefix bestimmt den Nummernkreis (z.&nbsp;B. <code>MARSCH-001</code>, <code>INSTR-42</code>); die Beschriftung erscheint in Listen und Formularen</li>
 <li>Anlegen, Bearbeiten, Löschen und Ausleihen nur mit Schreibrechten; im Inventar-Modal unter <b>Leihen</b> neue Ausleihen eintragen, offene Leihen beenden oder einzelne Historie-Einträge löschen</li>
 ' : '').'
 </ul>
@@ -243,8 +243,8 @@ $sections[] = array(
     'visible' => isAdmin() && requirePermission('perm_editRegisters'),
     'body' => '
 <ul class="help-list">
-<li><b>Register</b> – Register anlegen, sortieren und einfärben (Sitzplan und Gruppenbildung)</li>
-<li><b>Instrument-Typen</b> – Instrumente den Registern zuordnen, sortieren und Spielbarkeit setzen</li>
+<li><b>Register</b> – anlegen, sortieren und einfärben (Sitzplan und Gruppenbildung). <b>Reihe</b> = Abstand vom Dirigenten (0 = Dirigent); <b>ArcMin/ArcMax</b> = Winkelbereich (0° links, 90° vorne, 180° rechts). Nach dem Speichern aktualisiert sich die Vorschau</li>
+<li><b>Instrument-Typen</b> – Instrumente (z.&nbsp;B. Flöte, Trompete) den Registern zuordnen, sortieren und Spielbarkeit setzen; Farbe in der Typen-Übersicht, Register-Farben steuern die Orchesterdarstellung</li>
 <li>Beide Seiten brauchen das Recht <b>Register bearbeiten</b></li>
 </ul>
 '
@@ -257,14 +257,14 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 '.(requirePermission('perm_editPermissions') ? '
-<li><b>Berechtigungen</b> – Matrix aller User (Autosave); Klick auf den Namen öffnet das User-Modal; Rechte aus Gruppen erscheinen als nicht editierbare Haken; Rechte auch beim Anlegen/Bearbeiten unter Musiker</li>
+<li><b>Berechtigungen</b> – Matrix aller User (Autosave); persönliche Rechte sind editierbar; Haken mit gestricheltem Rahmen kommen nur über eine Gruppe und lassen sich hier nicht entfernen; Klick auf den Namen öffnet das User-Modal; Rechte auch beim Anlegen/Bearbeiten unter Musiker</li>
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '
 <li><b>Konfiguration</b> – Farben, Texte, Feature-Schalter, Webhooks, …; Änderungen erscheinen im Log</li>
 <li><b>Plattform / SSO</b> – <code>ssoRedirectAllowlist</code>, <code>urlNotenarchiv</code> und <code>urlMitgliederverwaltung</code> für einmalige SSO-Tickets zu Schwester-Modulen (Nav-Links erscheinen bei gesetzter URL)</li>
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
-<li><b>Statistik</b> – Auswertungen mit Abschnittsnavigation; auf breiten Bildschirmen Diagramme und Tabellen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking und Inaktive (sortierbar)</li>
+<li><b>Statistik</b> – Auswertungen mit Abschnittsnavigation; auf breiten Bildschirmen Diagramme und Tabellen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking (Quote = Ja-Meldungen / Termine im Zeitraum; Spalten sortierbar) und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>)</li>
 <li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung)</li>
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -213,7 +213,7 @@ $sections[] = array(
     'visible' => isAdmin() && requirePermission('perm_sendEmail'),
     'body' => '
 <p>Unter Admin → <b>Email versenden</b> erstellst du Nachrichten an Verteiler oder einzelne Empfänger.</p>
-<p>Unter Admin → <b>Gruppen</b> legst du wiederverwendbare Gruppen an (Rollen, Register, Personen). Diese Gruppen kannst du beim Mailversand und bei der Termin-Sichtbarkeit als Chip auswählen. Einzelne Personen kannst du den Gruppen auch direkt im Profil (Anlegen/Bearbeiten) zuordnen.</p>
+<p>Unter Admin → <b>Gruppen</b> legst du wiederverwendbare Gruppen an (Rollen, Register, Personen). Diese Gruppen kannst du beim Mailversand und bei der Termin-Sichtbarkeit als Chip auswählen. Zusätzlich kannst du einer Gruppe <b>Rechte vererben</b> (z.&nbsp;B. „Versteckte Termine“ für den Vorstand) – alle Mitglieder erhalten diese Rechte zusätzlich zu ihren persönlichen. Einzelne Personen kannst du den Gruppen auch direkt im Profil (Anlegen/Bearbeiten) zuordnen.</p>
 <p>Beim Mailversand kannst du Chips für Rollen, Gruppen, Register, Personen und <b>Teilnehmer</b> (ja/vielleicht) zukünftiger Termine wählen. Über <b>Email an Teilnehmer</b> am Termin wird der passende Teilnehmer-Chip vorausgewählt. Mails werden in einer Warteschlange verarbeitet; den Versandstatus siehst du in der Admin-Ansicht. Bei versendeten Mails siehst du den gewählten <b>Verteiler</b> sowie die Liste der einzelnen Empfänger. Empfänger finden die Nachricht unter <b>Meine Nachrichten</b>.</p>
 <p>Falls Discord angebunden ist, kann der Versand optional auch dort veröffentlicht werden (nur bei konfiguriertem Webhook).</p>
 '
@@ -257,7 +257,7 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 '.(requirePermission('perm_editPermissions') ? '
-<li><b>Berechtigungen</b> – Matrix aller User (Autosave); Klick auf den Namen öffnet das User-Modal; Rechte auch beim Anlegen/Bearbeiten unter Musiker</li>
+<li><b>Berechtigungen</b> – Matrix aller User (Autosave); Klick auf den Namen öffnet das User-Modal; Rechte aus Gruppen erscheinen als nicht editierbare Haken; Rechte auch beim Anlegen/Bearbeiten unter Musiker</li>
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '
 <li><b>Konfiguration</b> – Farben, Texte, Feature-Schalter, Webhooks, …; Änderungen erscheinen im Log</li>

--- a/views/profile/fields_permissions.php
+++ b/views/profile/fields_permissions.php
@@ -14,8 +14,10 @@ if(!isset($inputBg)) {
 }
 $catalog = Permissions::permissionCatalog();
 $permObj = new Permissions;
+$inherited = array();
 if(!empty($fill) && isset($n) && (int)$n->Index > 0) {
     $permObj->load_by_user((int)$n->Index);
+    $inherited = Group::inheritedPermissionSources((int)$n->Index);
 }
 $sessionUserId = isset($_SESSION['userid']) ? (int)$_SESSION['userid'] : 0;
 $targetUserId = (!empty($fill) && isset($n)) ? (int)$n->Index : 0;
@@ -29,18 +31,16 @@ foreach($catalog as $item) {
     }
 }
 
-$catalogJson = json_encode(
-    array('permissions' => $catalog),
-    JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE
-);
-$selectedJson = json_encode(
-    array_values($selected),
-    JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE
-);
+$jsonFlags = JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE;
+$catalogJson = json_encode(array('permissions' => $catalog), $jsonFlags);
+$selectedJson = json_encode(array_values($selected), $jsonFlags);
+$inheritedJson = json_encode($inherited ? $inherited : new stdClass(), $jsonFlags);
 ?>
 <div class="profile-pref-group" id="profile-perms-wrap"
      data-perm-catalog="<?php echo htmlspecialchars((string)$catalogJson, ENT_QUOTES, 'UTF-8'); ?>"
      data-selected-perms="<?php echo htmlspecialchars((string)$selectedJson, ENT_QUOTES, 'UTF-8'); ?>"
+     data-inherited-perms="<?php echo htmlspecialchars((string)$inheritedJson, ENT_QUOTES, 'UTF-8'); ?>"
+     data-perm-input-name="userPermissions[]"
      data-locked-perm="<?php echo $lockEditPerms ? 'perm_editPermissions' : ''; ?>">
   <h3 class="profile-col-title">Rechte</h3>
   <input type="hidden" name="userPermissionsPosted" value="1">

--- a/views/profile/fields_person.php
+++ b/views/profile/fields_person.php
@@ -71,12 +71,12 @@ else {
 </div>
 <?php } ?>
 <?php
-$mailGroups = MailGroup::listAll();
+$namedGroups = Group::listAll();
 $userId = ($fill && (int)$n->Index > 0) ? (int)$n->Index : 0;
-if($adminUserEdit && count($mailGroups)) {
+if($adminUserEdit && count($namedGroups)) {
     $selectedGroupIds = array();
     $groupCatalog = array();
-    foreach($mailGroups as $g) {
+    foreach($namedGroups as $g) {
         $gid = (int)$g->Index;
         $groupCatalog[] = array(
             'id' => $gid,
@@ -87,7 +87,7 @@ if($adminUserEdit && count($mailGroups)) {
         }
     }
     $groupCatalogJson = json_encode(
-        array('mailGroups' => $groupCatalog),
+        array('namedGroups' => $groupCatalog),
         JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE
     );
     $selectedJson = json_encode(
@@ -99,7 +99,7 @@ if($adminUserEdit && count($mailGroups)) {
      data-group-catalog="<?php echo htmlspecialchars((string)$groupCatalogJson, ENT_QUOTES, 'UTF-8'); ?>"
      data-selected-groups="<?php echo htmlspecialchars((string)$selectedJson, ENT_QUOTES, 'UTF-8'); ?>">
   <span class="profile-label">Gruppen</span>
-  <input type="hidden" name="userMailGroupsPosted" value="1">
+  <input type="hidden" name="userNamedGroupsPosted" value="1">
   <div class="profile-group-picker w3-border <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>">
     <div id="profile-group-chips" class="mail-recipient-chips" aria-live="polite"></div>
     <input type="text" id="profile-group-input" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" placeholder="Gruppe tippen…" autocomplete="off">

--- a/views/profile/layout_c.php
+++ b/views/profile/layout_c.php
@@ -47,9 +47,6 @@ $mailHintLabel = count($mailHint) ? implode(' · ', $mailHint) : 'keine Kanäle'
     <section class="profile-c-edit" data-profile-c-edit hidden>
       <h3>Stammdaten</h3>
       <?php include __DIR__.'/fields_stammdaten.php'; ?>
-<?php if($fill && $edit != 2) { ?>
-      <p class="w3-small w3-text-gray">Admin-Aktionen stehen in der Leiste unter „speichern“.</p>
-<?php } ?>
       <button type="button" class="w3-btn w3-border w3-mobile" data-profile-c-toggle="edit">Schließen</button>
     </section>
   </form>

--- a/views/termin/detail_modal.php
+++ b/views/termin/detail_modal.php
@@ -224,7 +224,7 @@ if(!empty($GLOBALS['googlemapsapi']) && ($t->Ort1 || $t->Ort2)) {
         }
     }
     echo AudienceSpec::renderChipsHtml($visForChips, array(
-        'allowMailGroups' => true,
+        'allowNamedGroups' => true,
         'ariaLabel' => 'sichtbar für',
     ));
 ?>

--- a/views/user/modal.php
+++ b/views/user/modal.php
@@ -152,12 +152,17 @@ $btnEdit = $GLOBALS['optionsDB']['colorBtnEdit'];
       </div>
 <?php
 if($showUserDetails && !empty($permissions)) {
+    $inherited = Group::inheritedPermissionSources((int)$user->Index);
     $activePerms = array();
     foreach(Permissions::permissionCatalog() as $item) {
         $key = $item['key'];
-        if((int)$permissions->$key !== 1) {
+        $personal = ((int)$permissions->$key) === 1;
+        $groups = isset($inherited[$key]) ? $inherited[$key] : array();
+        if(!$personal && !count($groups)) {
             continue;
         }
+        $item['personal'] = $personal;
+        $item['groups'] = $groups;
         $activePerms[] = $item;
     }
     if(count($activePerms)) {
@@ -168,7 +173,19 @@ if($showUserDetails && !empty($permissions)) {
 <?php
         foreach($activePerms as $item) {
             $gid = preg_replace('/[^a-z0-9_-]/i', '', (string)$item['groupId']);
-            echo '<span class="profile-perm-tile profile-perm-tile--'.$gid.'">'
+            $inheritedOnly = empty($item['personal']) && count($item['groups']) > 0;
+            $cls = 'profile-perm-tile profile-perm-tile--'.$gid;
+            if($inheritedOnly) {
+                $cls .= ' profile-perm-tile--inherited';
+            }
+            $title = '';
+            if(count($item['groups'])) {
+                $title = ($inheritedOnly ? 'Nur über Gruppe: ' : 'Auch Gruppe: ')
+                    .implode(', ', $item['groups']);
+            }
+            echo '<span class="'.$cls.'"'
+                .($title !== '' ? ' title="'.htmlspecialchars($title, ENT_QUOTES, 'UTF-8').'"' : '')
+                .'>'
                 .htmlspecialchars($item['label'], ENT_QUOTES, 'UTF-8')
                 .'</span>';
         }


### PR DESCRIPTION
## Summary
- MailGroup → Group umbenannt; sichere Schema-Migration ohne Datenverlust
- Rechte-Vererbung über Gruppen (effektive Rechte = persönlich OR Gruppe)
- Vererbte Rechte in User-Verwaltung, User-Modal und Gruppenliste als Chips
- Didaktische Formular-Intros in die Hilfe verschoben

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-137

## Test plan
- [ ] Gruppen anlegen/bearbeiten mit Mitgliedern und vererbten Rechten
- [ ] User mit Gruppenmitgliedschaft: Rechte-Chips gestrichelt, nicht entfernbar
- [ ] Berechtigungs-Matrix zeigt Gruppen-Haken
- [ ] DB mit bestehender MailGroup: Repair/Update behält Daten
- [ ] Admin-Hero-Farben (MELD-138) weiter sichtbar nach Merge