### PR TITLE
MELD-139: Navigationsleiste links / unten + einheitliche Seitenköpfe

### DIFF
--- a/archiv.php
+++ b/archiv.php
@@ -12,7 +12,6 @@ $chunk = listChunkTermine('past', 'response', '', 50, (int)$_SESSION['userid']);
 adminListPageBegin('Meldungen', 'Archiv: Meldungen');
 adminListSearchField('Termine suchen (Titel, Ort, Datum, Beschreibung)…', array(
     'onkeyup' => 'filterTermine()',
-    'label' => 'Termine suchen',
 ));
 ?>
 <div id="Liste">

--- a/calendar.php
+++ b/calendar.php
@@ -27,11 +27,8 @@ include 'common/header.php';
 <script src="<?php echo assetUrl('js/changeInstrument.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/calendarMelde.js'); ?>"></script>
 
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-  <h2>Kalender</h2>
-</div>
-
 <?php
+adminListPageBegin('Termine', 'Kalender');
 $calYear = (int)$bounds['year'];
 $calMonth = (int)$bounds['month'];
 $monthNames = calendarMonthNames();
@@ -178,6 +175,7 @@ button.w3-button.meld-cal-nav-icon {
 include __DIR__.'/views/calendar/month.php';
 ?>
 </div>
+<?php adminListPageEnd(); ?>
 <?php
 if($showCalendarSubscribe) {
     $n = $calUser;

--- a/common/footer.php
+++ b/common/footer.php
@@ -1,3 +1,5 @@
+</div><!-- .app-main -->
+</div><!-- .app-shell -->
 <div id="ajaxModalHost" class="w3-modal" onclick="if(event.target===this)closeModal();">
   <div id="ajaxModalContent" class="w3-modal-content"></div>
 </div>

--- a/common/header.php
+++ b/common/header.php
@@ -26,6 +26,7 @@
       <link rel="stylesheet" href="<?php echo $cssUrl('styles/fontawesome-free-6.4.2-web/css/solid.css'); ?>">
       <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
       <?php echo renderConfigColorCss(); ?>
+      <?php echo renderPermissionGroupColorCss(); ?>
       <link rel="icon" href="<?php echo $GLOBALS['optionsDB']['favicon']; ?>" type="image/x-icon">
       <!-- successfully included php libraries -->
       <?php
@@ -56,7 +57,7 @@
       ?>
       <title><?php echo $optionsDB['WebSiteName']; ?></title>
   </head>
-  <body class="<?php echo $GLOBALS['optionsDB']['colorBackground']; ?>">
+  <body class="<?php echo $GLOBALS['optionsDB']['colorBackground']; ?> app-layout">
 <?php
 include "common/nav.php";
 $GLOBALS['mlHeaderRendered'] = true;

--- a/common/nav.php
+++ b/common/nav.php
@@ -1,21 +1,49 @@
-<div class="w3-container <?php echo $optionsDB['colorTitle']; ?>">
-  <h1 class="w3-hide-small" style="width: calc(100vw - 150px);"><?php echo $optionsDB['WebSiteName']; ?></h1>
-  <h1 class="w3-hide-large w3-hide-medium" style="width: calc(100vw - 150px);"><?php echo $optionsDB['WebSiteNameShort']; ?></h1>
+<?php
+$mailUnread = 0;
+if(isset($_SESSION['userid'])) {
+    $mailUnread = MailOutbox::countUnreadForUser((int)$_SESSION['userid']);
+}
+$mailUnreadLabel = $mailUnread > 99 ? '99+' : (string)$mailUnread;
+$navUser = new User;
+$navUser->load_by_id($_SESSION['userid']);
+$navHasInventories = $navUser->hasInventories();
+$ssoArchiv = !empty($optionsDB['urlNotenarchiv'])
+    ? 'sso.php?redirect='.rawurlencode(trim((string)$optionsDB['urlNotenarchiv']))
+    : '';
+$ssoMit = !empty($optionsDB['urlMitgliederverwaltung'])
+    ? 'sso.php?redirect='.rawurlencode(trim((string)$optionsDB['urlMitgliederverwaltung']))
+    : '';
+$isAdminNav = isAdmin();
+if($isAdminNav) {
+    $showPersonen = requirePermission('perm_showUsers');
+    $showTermine = requirePermission('perm_editAppmnts');
+    $showMeldungen = requirePermission('perm_showResponse');
+    $showKommunikation = requirePermission('perm_sendEmail');
+    $showInventar = requirePermission('perm_showInventories') || requirePermission('perm_editInventories');
+    $showRegister = requirePermission('perm_editRegisters');
+    $showSystem = requirePermission('perm_editConfig') || requirePermission('perm_showLog') || requirePermission('perm_editPermissions');
+}
+$navColor = htmlspecialchars((string)$optionsDB['colorNav'], ENT_QUOTES, 'UTF-8');
+$navAdminColor = htmlspecialchars((string)$optionsDB['colorNavAdmin'], ENT_QUOTES, 'UTF-8');
+?>
+<div class="app-titlebar <?php echo htmlspecialchars((string)$optionsDB['colorTitle'], ENT_QUOTES, 'UTF-8'); ?>">
+  <h1 class="app-titlebar-name w3-hide-small"><?php echo htmlspecialchars((string)$optionsDB['WebSiteName'], ENT_QUOTES, 'UTF-8'); ?></h1>
+  <h1 class="app-titlebar-name w3-hide-large w3-hide-medium"><?php echo htmlspecialchars((string)$optionsDB['WebSiteNameShort'], ENT_QUOTES, 'UTF-8'); ?></h1>
   <?php if(!empty($optionsDB['MasterPage'])) { ?>
-  <a href="<?php echo htmlspecialchars($optionsDB['MasterPage'], ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener noreferrer" title="Vereinshomepage" style="position: absolute; top: 10px; right: 10px;">
-    <img src="imgs/Logo.png" alt="Vereinshomepage" style="max-height:100px; max-width:100px; display:block;">
+  <a class="app-titlebar-logo" href="<?php echo htmlspecialchars($optionsDB['MasterPage'], ENT_QUOTES, 'UTF-8'); ?>" target="_blank" rel="noopener noreferrer" title="Vereinshomepage">
+    <img src="imgs/Logo.png" alt="Vereinshomepage">
   </a>
   <?php } else { ?>
-  <img src="imgs/Logo.png" alt="" style="max-height:100px; max-width:100px; position: absolute; top: 10px; right: 10px;">
+  <img class="app-titlebar-logo" src="imgs/Logo.png" alt="">
   <?php } ?>
-  <p><?php
-      echo $_SESSION['username'];
-      if(isAdmin()) echo " (Admin)";
-      ?></p>
+  <p class="app-titlebar-user"><?php
+      echo htmlspecialchars((string)$_SESSION['username'], ENT_QUOTES, 'UTF-8');
+      if(isAdmin()) echo ' (Admin)';
+  ?></p>
 </div>
-<?php if(getBranchName() != "master" || !empty($optionsDB['showBranchBannerAlways'])) { ?>
-<div class="w3-yellow w3-padding"><i class="fas fa-code-branch"></i>
-<?php echo "branch: <b>".htmlspecialchars(getBranchName(), ENT_QUOTES, 'UTF-8')."</b>"; ?>
+<?php if(getBranchName() != 'master' || !empty($optionsDB['showBranchBannerAlways'])) { ?>
+<div class="w3-yellow w3-padding app-banner"><i class="fas fa-code-branch"></i>
+<?php echo 'branch: <b>'.htmlspecialchars(getBranchName(), ENT_QUOTES, 'UTF-8').'</b>'; ?>
 </div>
 <?php } ?>
 <?php
@@ -25,7 +53,7 @@ if(requirePermission('perm_editConfig')) {
         if($schemaMgr->isSchemaOutdated()) {
             $inst = (int)$schemaMgr->getInstalledSchemaVersion();
             $exp = (int)$schemaMgr->getExpectedSchemaVersion();
-            echo '<div class="w3-orange w3-padding"><i class="fas fa-database"></i> '
+            echo '<div class="w3-orange w3-padding app-banner"><i class="fas fa-database"></i> '
                 .'Neue Datenbank-Version verfügbar (installiert: <b>'.$inst.'</b>, Soll: <b>'.$exp.'</b>). '
                 .'Bitte im <a href="updater.php"><b>Updater</b></a> „Datenbank reparieren“ ausführen '
                 .'oder „Update durchführen“ (aktualisiert die DB bei Bedarf mit).'
@@ -37,172 +65,203 @@ if(requirePermission('perm_editConfig')) {
     }
 }
 ?>
-<div class="w3-bar <?php echo $optionsDB['colorNav']; ?>">
-  <button onclick="showAll()" class="w3-bar-item w3-button w3-mobile w3-hide-large w3-hide-medium material-icons">menu</button>
-  <a title="Termine" alt="Termine" href="<?php echo $GLOBALS['optionsDB']['WebSiteURL']; ?>" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php getPage('home');?>"><i class="far fa-calendar-alt"></i></a>
-  <a title="Kalender" alt="Kalender" href="calendar.php" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php getPage('calendar');?>"><i class="fas fa-calendar"></i></a>
-  <?php
-  $mailUnread = 0;
-  if(isset($_SESSION['userid'])) {
-      $mailUnread = MailOutbox::countUnreadForUser((int)$_SESSION['userid']);
-  }
-  $mailUnreadLabel = $mailUnread > 99 ? '99+' : (string)$mailUnread;
-  ?>
-  <a title="Meine Nachrichten<?php echo $mailUnread > 0 ? ' ('.$mailUnreadLabel.' neu)' : ''; ?>" alt="Meine Nachrichten" href="meine-mails.php" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php getPage('meinemails');?>" style="position:relative;">
-    <i class="fas fa-envelope"></i><?php
-    if($mailUnread > 0) {
-        echo '<span class="w3-badge w3-tiny '.$GLOBALS['optionsDB']['colorLogEmail'].'" style="position:absolute;top:0;right:0;padding:1px 5px;font-size:10px;line-height:1.2;">'
-            .htmlspecialchars($mailUnreadLabel, ENT_QUOTES, 'UTF-8')
-            .'</span>';
-    }
-    ?></a>
-  <a title="Mein Register" alt="Mein Register" href="mein-register.php" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php getPage('meinregister');?>"><i class="fas fa-users"></i></a>
-<?php
-$u = new User;
-$u->load_by_id($_SESSION['userid']);
-if($u->hasInventories()) { ?>
-    <a title="Inventar" alt="Mein Inventar" href="myinventories.php" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php getPage('myinventories');?>"><i class="fas fa-shirt"></i></a>
+<div class="app-shell">
+<nav class="app-nav <?php echo $navColor; ?>" aria-label="Hauptnavigation">
+  <div class="app-nav-primary">
+    <a class="app-nav-item <?php getPage('home', 'termine'); ?>" href="<?php echo htmlspecialchars((string)$GLOBALS['optionsDB']['WebSiteURL'], ENT_QUOTES, 'UTF-8'); ?>" title="Termine">
+      <i class="far fa-calendar-alt" aria-hidden="true"></i><span class="nav-label">Termine</span>
+    </a>
+    <a class="app-nav-item <?php getPage('calendar', 'termine'); ?>" href="calendar.php" title="Kalender">
+      <i class="fas fa-calendar" aria-hidden="true"></i><span class="nav-label">Kalender</span>
+    </a>
+    <a class="app-nav-item app-nav-item--badge <?php getPage('meinemails', 'kommunikation'); ?>" href="meine-mails.php" title="Meine Nachrichten<?php echo $mailUnread > 0 ? ' ('.$mailUnreadLabel.' neu)' : ''; ?>">
+      <i class="fas fa-envelope" aria-hidden="true"></i><span class="nav-label">Nachrichten</span><?php
+      if($mailUnread > 0) {
+          echo '<span class="app-nav-badge w3-badge w3-tiny '.$GLOBALS['optionsDB']['colorLogEmail'].'">'
+              .htmlspecialchars($mailUnreadLabel, ENT_QUOTES, 'UTF-8')
+              .'</span>';
+      }
+      ?>
+    </a>
+    <a class="app-nav-item <?php getPage('meinregister', 'register'); ?>" href="mein-register.php" title="Mein Register">
+      <i class="fas fa-users" aria-hidden="true"></i>
+      <span class="nav-label"><span class="nav-label-long">Mein Register</span><span class="nav-label-short">Register</span></span>
+    </a>
+<?php if($navHasInventories) { ?>
+    <a class="app-nav-item app-nav-item--secondary <?php getPage('myinventories', 'inventar'); ?>" href="myinventories.php" title="Mein Inventar">
+      <i class="fas fa-shirt" aria-hidden="true"></i><span class="nav-label">Mein Inventar</span>
+    </a>
 <?php } ?>
-  <form action="new-musiker.php" method="POST">
-    <button title="Mein Profil" alt="Mein Profil" type="submit" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php getPage('me');?>">
-      <i class="fas fa-user"></i>
+    <form class="app-nav-form" action="new-musiker.php" method="POST">
+      <button class="app-nav-item <?php getPage('me', 'nutzer'); ?>" type="submit" title="Mein Profil">
+        <i class="fas fa-user" aria-hidden="true"></i>
+        <span class="nav-label"><span class="nav-label-long">Mein Profil</span><span class="nav-label-short">Profil</span></span>
+      </button>
+      <input type="hidden" name="id" value="<?php echo (int)$_SESSION['userid']; ?>">
+      <input type="hidden" name="mode" value="useredit">
+    </form>
+    <a class="app-nav-item app-nav-item--secondary <?php getPage('media', 'system'); ?>" href="media.php" title="Medien">
+      <i class="fas fa-photo-film" aria-hidden="true"></i><span class="nav-label">Medien</span>
+    </a>
+<?php if($ssoArchiv !== '') { ?>
+    <a class="app-nav-item app-nav-item--secondary <?php echo htmlspecialchars(navGroupClass('system'), ENT_QUOTES, 'UTF-8'); ?>" href="<?php echo htmlspecialchars($ssoArchiv, ENT_QUOTES, 'UTF-8'); ?>" title="Notenarchiv">
+      <i class="fas fa-book" aria-hidden="true"></i><span class="nav-label">Notenarchiv</span>
+    </a>
+<?php } ?>
+<?php if($ssoMit !== '') { ?>
+    <a class="app-nav-item app-nav-item--secondary <?php echo htmlspecialchars(navGroupClass('nutzer'), ENT_QUOTES, 'UTF-8'); ?>" href="<?php echo htmlspecialchars($ssoMit, ENT_QUOTES, 'UTF-8'); ?>" title="Mitgliederverwaltung">
+      <i class="fas fa-id-card" aria-hidden="true"></i><span class="nav-label">Mitgliederverw.</span>
+    </a>
+<?php } ?>
+    <a class="app-nav-item app-nav-item--secondary <?php getPage('help', 'system'); ?>" href="help.php" title="Hilfe">
+      <i class="fas fa-circle-question" aria-hidden="true"></i><span class="nav-label">Hilfe</span>
+    </a>
+  </div>
+
+  <div class="app-nav-more-wrap">
+    <button type="button" class="app-nav-item app-nav-more-toggle <?php echo htmlspecialchars(navGroupClass('system'), ENT_QUOTES, 'UTF-8'); ?>" id="appNavMoreToggle" aria-expanded="false" aria-controls="appNavMorePanel" title="Mehr">
+      <i class="fas fa-ellipsis-h" aria-hidden="true"></i><span class="nav-label">Mehr</span>
     </button>
-    <input type="hidden" name="id" value="<?php echo $_SESSION['userid']; ?>" />
-    <input type="hidden" name="mode" value="useredit" />
-  </form>
-  <a title="Medien" alt="Medien" href="media.php" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php echo $optionsDB['colorNav']; ?>"><i class="fas fa-photo-film"></i></a>
-<?php
-if(!empty($optionsDB['urlNotenarchiv'])) {
-    $ssoArchiv = 'sso.php?redirect='.rawurlencode(trim((string)$optionsDB['urlNotenarchiv']));
-?>
-  <a title="Notenarchiv" href="<?php echo htmlspecialchars($ssoArchiv, ENT_QUOTES, 'UTF-8'); ?>" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php echo $optionsDB['colorNav']; ?>"><i class="fas fa-book"></i></a>
-<?php }
-if(!empty($optionsDB['urlMitgliederverwaltung'])) {
-    $ssoMit = 'sso.php?redirect='.rawurlencode(trim((string)$optionsDB['urlMitgliederverwaltung']));
-?>
-  <a title="Mitgliederverwaltung" href="<?php echo htmlspecialchars($ssoMit, ENT_QUOTES, 'UTF-8'); ?>" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php echo $optionsDB['colorNav']; ?>"><i class="fas fa-id-card"></i></a>
+    <div class="app-nav-more-backdrop" id="appNavMoreBackdrop" hidden></div>
+    <div class="app-nav-more-panel <?php echo $navColor; ?>" id="appNavMorePanel" role="dialog" aria-label="Weitere Navigation">
+      <div class="app-nav-more-head">
+        <span>Mehr</span>
+        <button type="button" class="app-nav-more-close" id="appNavMoreClose" aria-label="Schließen">&times;</button>
+      </div>
+      <div class="app-nav-more-body">
+<?php if($navHasInventories) { ?>
+        <a class="app-nav-item app-nav-more-only-mobile <?php getPage('myinventories', 'inventar'); ?>" href="myinventories.php" title="Mein Inventar">
+          <i class="fas fa-shirt" aria-hidden="true"></i><span class="nav-label">Mein Inventar</span>
+        </a>
 <?php } ?>
-  <a title="Hilfe" alt="Hilfe" href="help.php" class="stdhide w3-hide-small w3-bar-item w3-button w3-mobile <?php getPage('help');?>"><i class="fas fa-circle-question"></i></a>
-  <?php if(isAdmin()) {
-    $showPersonen = requirePermission("perm_showUsers");
-    $showTermine = requirePermission("perm_editAppmnts");
-    $showMeldungen = requirePermission("perm_showResponse");
-    $showKommunikation = requirePermission("perm_sendEmail");
-    $showInventar = requirePermission("perm_showInventories") || requirePermission("perm_editInventories");
-    $showRegister = requirePermission("perm_editRegisters");
-    $showSystem = requirePermission("perm_editConfig") || requirePermission("perm_showLog") || requirePermission("perm_editPermissions");
-  ?>
-  <div class="stdhide w3-hide-small w3-dropdown-hover w3-mobile admin-nav">
-    <button title="Admin" alt="Admin" class="w3-button w3-mobile w3-hide-small <?php getAdminPage($_SESSION['page']); ?>"><i class="fas fa-wrench"></i></button>
-    <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $optionsDB['colorNavAdmin']; ?> w3-mobile">
-      <?php if($showPersonen) { ?>
-      <div class="w3-dropdown-hover w3-mobile admin-nav-group">
-        <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_showUsers'); ?>">Personen <i class="fas fa-caret-right admin-nav-caret"></i></button>
-        <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $optionsDB['colorNavAdmin']; ?> w3-mobile">
-          <a title="Musikerliste" alt="Musikerliste" href="musiker.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('musiker', 'perm_showUsers'); ?>"><i class="fas fa-users"></i> Musikerliste</a>
-          <a title="Gastmusiker" alt="Gastmusiker" href="gastmusiker.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('gastmusiker', 'perm_showUsers'); ?>"><i class="fas fa-user-clock"></i> Gastmusiker</a>
-          <a title="Userliste" alt="Userliste" href="users.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('users', 'perm_showUsers'); ?>"><i class="fas fa-users"></i> Userliste</a>
-          <?php if($GLOBALS['optionsDB']['showMembers']) { ?>
-          <a title="Mitgliederliste" alt="Mitgliederliste" href="mitglied.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('mitglied', 'perm_showUsers'); ?>"><i class="fas fa-users"></i> Mitgliederliste</a>
-          <?php } ?>
-          <?php if($GLOBALS['optionsDB']['showNonMembers']) { ?>
-          <a title="Nicht-Mitgliederliste" alt="Nicht-Mitgliederliste" href="no-mitglied.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('nomitglied', 'perm_showUsers'); ?>"><i class="fas fa-users"></i> Nicht-Mitgliederliste</a>
-          <?php } ?>
-          <a title="Registerübersicht" alt="Registerübersicht" href="register.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('register', 'perm_showUsers'); ?>"><i class="fas fa-list"></i> Registerübersicht</a>
-          <?php if(requirePermission("perm_editUsers")) { ?>
-          <a title="neuen Musiker anlegen" alt="neuen Musiker anlegen" href="new-musiker.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('newmusiker', 'perm_editUsers'); ?>"><i class="fas fa-plus-circle"></i> Musiker anlegen</a>
-          <?php } ?>
+        <a class="app-nav-item app-nav-more-only-mobile <?php getPage('media', 'system'); ?>" href="media.php" title="Medien">
+          <i class="fas fa-photo-film" aria-hidden="true"></i><span class="nav-label">Medien</span>
+        </a>
+<?php if($ssoArchiv !== '') { ?>
+        <a class="app-nav-item app-nav-more-only-mobile <?php echo htmlspecialchars(navGroupClass('system'), ENT_QUOTES, 'UTF-8'); ?>" href="<?php echo htmlspecialchars($ssoArchiv, ENT_QUOTES, 'UTF-8'); ?>" title="Notenarchiv">
+          <i class="fas fa-book" aria-hidden="true"></i><span class="nav-label">Notenarchiv</span>
+        </a>
+<?php } ?>
+<?php if($ssoMit !== '') { ?>
+        <a class="app-nav-item app-nav-more-only-mobile <?php echo htmlspecialchars(navGroupClass('nutzer'), ENT_QUOTES, 'UTF-8'); ?>" href="<?php echo htmlspecialchars($ssoMit, ENT_QUOTES, 'UTF-8'); ?>" title="Mitgliederverwaltung">
+          <i class="fas fa-id-card" aria-hidden="true"></i><span class="nav-label">Mitgliederverw.</span>
+        </a>
+<?php } ?>
+        <a class="app-nav-item app-nav-more-only-mobile <?php getPage('help', 'system'); ?>" href="help.php" title="Hilfe">
+          <i class="fas fa-circle-question" aria-hidden="true"></i><span class="nav-label">Hilfe</span>
+        </a>
+<?php if($isAdminNav) { ?>
+        <div class="admin-nav app-nav-admin">
+          <div class="app-nav-admin-title"><i class="fas fa-wrench" aria-hidden="true"></i><span class="nav-label">Admin</span></div>
+          <div class="w3-bar-block <?php echo $navAdminColor; ?>">
+<?php if($showPersonen) { ?>
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+              <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_showUsers'); ?>">Personen <i class="fas fa-caret-right admin-nav-caret"></i></button>
+              <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
+                <a title="Musikerliste" href="musiker.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('musiker', 'perm_showUsers'); ?>"><i class="fas fa-users"></i> Musikerliste</a>
+                <a title="Gastmusiker" href="gastmusiker.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('gastmusiker', 'perm_showUsers'); ?>"><i class="fas fa-user-clock"></i> Gastmusiker</a>
+                <a title="Userliste" href="users.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('users', 'perm_showUsers'); ?>"><i class="fas fa-users"></i> Userliste</a>
+<?php if(!empty($GLOBALS['optionsDB']['showMembers'])) { ?>
+                <a title="Mitgliederliste" href="mitglied.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('mitglied', 'perm_showUsers'); ?>"><i class="fas fa-users"></i> Mitgliederliste</a>
+<?php } ?>
+<?php if(!empty($GLOBALS['optionsDB']['showNonMembers'])) { ?>
+                <a title="Nicht-Mitgliederliste" href="no-mitglied.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('nomitglied', 'perm_showUsers'); ?>"><i class="fas fa-users"></i> Nicht-Mitgliederliste</a>
+<?php } ?>
+                <a title="Registerübersicht" href="register.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('register', 'perm_showUsers'); ?>"><i class="fas fa-list"></i> Registerübersicht</a>
+<?php if(requirePermission('perm_editUsers')) { ?>
+                <a title="Musiker anlegen" href="new-musiker.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('newmusiker', 'perm_editUsers'); ?>"><i class="fas fa-plus-circle"></i> Musiker anlegen</a>
+<?php } ?>
+              </div>
+            </div>
+<?php } ?>
+<?php if($showTermine) { ?>
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+              <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_editAppmnts'); ?>">Termine <i class="fas fa-caret-right admin-nav-caret"></i></button>
+              <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
+                <a title="Termin erstellen" href="new-termin.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('newtermin', 'perm_editAppmnts'); ?>"><i class="fas fa-plus-circle"></i> Termin erstellen</a>
+                <a title="Archiv: Termine" href="termine-archiv.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('termine-archiv', 'perm_editAppmnts'); ?>"><i class="fas fa-history"></i> Archiv: Termine</a>
+              </div>
+            </div>
+<?php } ?>
+<?php if($showMeldungen) { ?>
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+              <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_showResponse'); ?>">Meldungen <i class="fas fa-caret-right admin-nav-caret"></i></button>
+              <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
+                <a title="Meldungen" href="meldungen.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('meldungen', 'perm_showResponse'); ?>"><i class="fas fa-comment-dots"></i> Meldungen</a>
+                <a title="Archiv: Meldungen" href="archiv.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('archiv', 'perm_showResponse'); ?>"><i class="fas fa-history"></i> Archiv: Meldungen</a>
+<?php if(requirePermission('perm_editResponse')) { ?>
+                <a title="im Auftrag melden" href="public-entry.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('public-entry', 'perm_editResponse'); ?>"><i class="fas fa-comments"></i> im Auftrag melden</a>
+<?php } ?>
+              </div>
+            </div>
+<?php } ?>
+<?php if($showKommunikation) { ?>
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+              <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_sendEmail'); ?>">Kommunikation <i class="fas fa-caret-right admin-nav-caret"></i></button>
+              <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
+                <a title="Email versenden" href="mail.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('mail', 'perm_sendEmail'); ?>"><i class="fas fa-envelope-open-text"></i> Email versenden</a>
+                <a title="Gruppen" href="groups.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('groups', 'perm_sendEmail'); ?>"><i class="fas fa-users"></i> Gruppen</a>
+              </div>
+            </div>
+<?php } ?>
+<?php if($showInventar) { ?>
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+              <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_showInventories'); ?>">Inventar <i class="fas fa-caret-right admin-nav-caret"></i></button>
+              <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
+<?php if(requirePermission('perm_showInventories')) { ?>
+                <a title="Inventar" href="inventories.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('inventories', 'perm_showInventories'); ?>"><i class="fas fa-shirt"></i> Inventar</a>
+                <a title="Versicherung" href="insurance.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('insurance', 'perm_showInventories'); ?>"><i class="fas fa-file-invoice-dollar"></i> Versicherung</a>
+<?php } ?>
+<?php if(requirePermission('perm_editInventories')) { ?>
+                <a title="Inventar-Typen" href="inventory-types.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('inventory-types', 'perm_editInventories'); ?>"><i class="fas fa-tags"></i> Inventar-Typen</a>
+<?php } ?>
+              </div>
+            </div>
+<?php } ?>
+<?php if($showRegister) { ?>
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+              <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_editRegisters'); ?>">Register <i class="fas fa-caret-right admin-nav-caret"></i></button>
+              <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
+                <a title="Register" href="register-types.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('register-types', 'perm_editRegisters'); ?>"><i class="fas fa-layer-group"></i> Register</a>
+                <a title="Instrument-Typen" href="instrument-types.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('instrument-types', 'perm_editRegisters'); ?>"><i class="fas fa-guitar"></i> Instrument-Typen</a>
+              </div>
+            </div>
+<?php } ?>
+<?php if($showSystem) { ?>
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+              <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_editConfig'); ?>">System <i class="fas fa-caret-right admin-nav-caret"></i></button>
+              <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
+<?php if(requirePermission('perm_editPermissions')) { ?>
+                <a title="Berechtigungen" href="permissions.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('permissions', 'perm_editPermissions'); ?>"><i class="fas fa-lock"></i> Berechtigungen</a>
+<?php } ?>
+<?php if(requirePermission('perm_editConfig')) { ?>
+                <a title="Konfiguration" href="config-menu.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('config', 'perm_editConfig'); ?>"><i class="fas fa-cogs"></i> Konfiguration</a>
+<?php } ?>
+<?php if(requirePermission('perm_showLog')) { ?>
+                <a title="Statistik" href="evaluate.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('evaluate', 'perm_showLog'); ?>"><i class="fas fa-chart-pie"></i> Statistik</a>
+                <a title="Log" href="log.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('log', 'perm_showLog'); ?>"><i class="fas fa-poll"></i> Log</a>
+<?php } ?>
+<?php if(requirePermission('perm_editConfig')) { ?>
+                <a title="Backup" href="backup.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('backup', 'perm_editConfig'); ?>"><i class="fas fa-database"></i> Backup</a>
+                <a title="Updater" href="updater.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('updater', 'perm_editConfig'); ?>"><i class="fas fa-code-branch"></i> Updater</a>
+<?php } ?>
+              </div>
+            </div>
+<?php } ?>
+          </div>
         </div>
+<?php } ?>
+        <a class="app-nav-item <?php echo htmlspecialchars(navGroupClass('system'), ENT_QUOTES, 'UTF-8'); ?>" href="logout.php" title="Ausloggen">
+          <i class="fas fa-sign-out-alt" aria-hidden="true"></i><span class="nav-label">Ausloggen</span>
+        </a>
       </div>
-      <?php } ?>
-
-      <?php if($showTermine) { ?>
-      <div class="w3-dropdown-hover w3-mobile admin-nav-group">
-        <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_editAppmnts'); ?>">Termine <i class="fas fa-caret-right admin-nav-caret"></i></button>
-        <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $optionsDB['colorNavAdmin']; ?> w3-mobile">
-          <a title="neuen Termin erstellen" alt="neuen Termin erstellen" href="new-termin.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('newtermin', 'perm_editAppmnts'); ?>"><i class="fas fa-plus-circle"></i> Termin erstellen</a>
-          <a title="Termine - Archiv" alt="termine archiv" href="termine-archiv.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('termine-archiv', 'perm_editAppmnts'); ?>"><i class="fas fa-history"></i> Archiv: Termine</a>
-        </div>
-      </div>
-      <?php } ?>
-
-      <?php if($showMeldungen) { ?>
-      <div class="w3-dropdown-hover w3-mobile admin-nav-group">
-        <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_showResponse'); ?>">Meldungen <i class="fas fa-caret-right admin-nav-caret"></i></button>
-        <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $optionsDB['colorNavAdmin']; ?> w3-mobile">
-          <a title="Meldungen" alt="Meldungen" href="meldungen.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('meldungen', 'perm_showResponse'); ?>"><i class="fas fa-comment-dots"></i> Meldungen</a>
-          <a title="Meldungen - Archiv" alt="archiv" href="archiv.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('archiv', 'perm_showResponse'); ?>"><i class="fas fa-history"></i> Archiv: Meldungen</a>
-          <?php if(requirePermission("perm_editResponse")) { ?>
-          <a title="im Auftrag melden" alt="im Auftrag melden" href="public-entry.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('public-entry', 'perm_editResponse'); ?>"><i class="fas fa-comments"></i> im Auftrag melden</a>
-          <?php } ?>
-        </div>
-      </div>
-      <?php } ?>
-
-      <?php if($showKommunikation) { ?>
-      <div class="w3-dropdown-hover w3-mobile admin-nav-group">
-        <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_sendEmail'); ?>">Kommunikation <i class="fas fa-caret-right admin-nav-caret"></i></button>
-        <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $optionsDB['colorNavAdmin']; ?> w3-mobile">
-          <a title="Email versenden" alt="Email versenden" href="mail.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('mail', 'perm_sendEmail'); ?>"><i class="fas fa-envelope-open-text"></i> Email versenden</a>
-          <a title="Gruppen" alt="Gruppen" href="groups.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('groups', 'perm_sendEmail'); ?>"><i class="fas fa-users"></i> Gruppen</a>
-        </div>
-      </div>
-      <?php } ?>
-
-      <?php if($showInventar) { ?>
-      <div class="w3-dropdown-hover w3-mobile admin-nav-group">
-        <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_showInventories'); ?>">Inventar <i class="fas fa-caret-right admin-nav-caret"></i></button>
-        <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $optionsDB['colorNavAdmin']; ?> w3-mobile">
-          <?php if(requirePermission("perm_showInventories")) { ?>
-          <a title="Inventar" alt="Inventar" href="inventories.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('inventories', 'perm_showInventories'); ?>"><i class="fas fa-shirt"></i> Inventar</a>
-          <a title="Versicherung" alt="Versicherung" href="insurance.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('insurance', 'perm_showInventories'); ?>"><i class="fas fa-file-invoice-dollar"></i> Versicherung</a>
-          <?php } ?>
-          <?php if(requirePermission("perm_editInventories")) { ?>
-          <a title="Inventar-Typen" alt="Inventar-Typen" href="inventory-types.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('inventory-types', 'perm_editInventories'); ?>"><i class="fas fa-tags"></i> Inventar-Typen</a>
-          <?php } ?>
-        </div>
-      </div>
-      <?php } ?>
-
-      <?php if($showRegister) { ?>
-      <div class="w3-dropdown-hover w3-mobile admin-nav-group">
-        <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_editRegisters'); ?>">Register <i class="fas fa-caret-right admin-nav-caret"></i></button>
-        <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $optionsDB['colorNavAdmin']; ?> w3-mobile">
-          <a title="Register" alt="Register" href="register-types.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('register-types', 'perm_editRegisters'); ?>"><i class="fas fa-layer-group"></i> Register</a>
-          <a title="Instrument-Typen" alt="Instrument-Typen" href="instrument-types.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('instrument-types', 'perm_editRegisters'); ?>"><i class="fas fa-guitar"></i> Instrument-Typen</a>
-        </div>
-      </div>
-      <?php } ?>
-
-      <?php if($showSystem) { ?>
-      <div class="w3-dropdown-hover w3-mobile admin-nav-group">
-        <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_editConfig'); ?>">System <i class="fas fa-caret-right admin-nav-caret"></i></button>
-        <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $optionsDB['colorNavAdmin']; ?> w3-mobile">
-          <?php if(requirePermission("perm_editPermissions")) { ?>
-          <a title="Berechtigungen" alt="Berechtigungen" href="permissions.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('permissions', 'perm_editPermissions'); ?>"><i class="fas fa-lock"></i> Berechtigungen</a>
-          <?php } ?>
-          <?php if(requirePermission("perm_editConfig")) { ?>
-          <a title="Konfiguration" alt="Konfiguration" href="config-menu.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('config', 'perm_editConfig'); ?>"><i class="fas fa-cogs"></i> Konfiguration</a>
-          <?php } ?>
-          <?php if(requirePermission("perm_showLog")) { ?>
-          <a title="Statistik" alt="Statistik" href="evaluate.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('evaluate', 'perm_showLog'); ?>"><i class="fas fa-chart-pie"></i> Statistik</a>
-          <a title="Logfile anschauen" alt="Logfile anschauen" href="log.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('log', 'perm_showLog'); ?>"><i class="fas fa-poll"></i> Log</a>
-          <?php } ?>
-          <?php if(requirePermission("perm_editConfig")) { ?>
-          <a title="Backup" alt="Backup" href="backup.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('backup', 'perm_editConfig'); ?>"><i class="fas fa-database"></i> Backup</a>
-          <a title="Updater" alt="Updater" href="updater.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('updater', 'perm_editConfig'); ?>"><i class="fas fa-code-branch"></i> Updater</a>
-          <?php } ?>
-        </div>
-      </div>
-      <?php } ?>
     </div>
   </div>
-  <?php } ?>
-  <a title="Ausloggen" alt="Ausloggen" href="logout.php" class="stdhide w3-hide-small w3-bar-item w3-button <?php echo $optionsDB['colorNav']; ?> w3-mobile"><i class="fas fa-sign-out-alt"></i></a>
-</div>
+</nav>
+<div class="app-main">
 <?php
- if($optionsDB['showMessageOfTheDay']) {
- ?>
+if(!empty($optionsDB['showMessageOfTheDay'])) {
+?>
 <div class="w3-container w3-card w3-padding <?php echo $GLOBALS['optionsDB']['colorWarning']; ?>">
   <div class="w3-col l3 m3 s2 w3-center">
     <i class="fas fa-exclamation-triangle"></i>
@@ -210,7 +269,6 @@ if(!empty($optionsDB['urlMitgliederverwaltung'])) {
   <div class="w3-col l6 m6 s8 w3-center">
     <?php echo $optionsDB['MessageOfTheDayShort']; ?>
   </div>
-
   <div class="w3-col l3 m3 s2 w3-center">
     <i class="fas fa-exclamation-triangle"></i>
   </div>
@@ -225,53 +283,11 @@ if(!empty($optionsDB['urlMitgliederverwaltung'])) {
   </div>
 </div>
 <?php
- }
- ?>
-<script type="text/javascript">
-  function resetAdminNavGroups() {
-    var groups = document.querySelectorAll('.admin-nav-group.admin-nav-open');
-    for(var i = 0; i < groups.length; i++) {
-      groups[i].classList.remove('admin-nav-open');
-    }
-  }
-
-  function showAll() {
-    var x = document.getElementsByClassName('stdhide');
-    var closing = false;
-    for(var i = 0; i < x.length; i++) {
-      if(x[i].className.indexOf("w3-show") == -1) {
-        x[i].className = x[i].className.replace("w3-hide-small", "w3-show");
-      }
-      else {
-        x[i].className = x[i].className.replace("w3-show", "w3-hide-small");
-        closing = true;
-      }
-    }
-    if(closing) {
-      resetAdminNavGroups();
-    }
-  }
-
-  document.addEventListener('click', function(ev) {
-    if(window.matchMedia && !window.matchMedia('(max-width: 600px)').matches) {
-      return;
-    }
-    var btn = ev.target.closest ? ev.target.closest('.admin-nav-group > .w3-button') : null;
-    if(!btn) return;
-    var group = btn.parentNode;
-    if(!group || !group.classList || !group.classList.contains('admin-nav-group')) return;
-    ev.preventDefault();
-    ev.stopPropagation();
-    var open = group.classList.contains('admin-nav-open');
-    resetAdminNavGroups();
-    if(!open) {
-      group.classList.add('admin-nav-open');
-    }
-  });
-
-  <?php if(!isset($_SESSION['MessageOfTheDay'])){
-    $_SESSION['MessageOfTheDay']=true;
-  ?>
-  document.getElementById('MessageOfTheDay').style.display='block';
-  <?php } ?>
-</script>
+}
+?>
+<script src="<?php echo assetUrl('js/app-nav.js'); ?>"></script>
+<?php if(!empty($optionsDB['showMessageOfTheDay']) && !isset($_SESSION['MessageOfTheDay'])) {
+    $_SESSION['MessageOfTheDay'] = true;
+?>
+<script>document.getElementById('MessageOfTheDay').style.display='block';</script>
+<?php } ?>

--- a/help.php
+++ b/help.php
@@ -7,11 +7,8 @@ include "common/header.php";
 
 $helpUser = new User;
 $helpUser->load_by_id((int)$_SESSION['userid']);
+adminListPageBegin('Hilfe', 'Hilfe & Info');
 ?>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-  <h2>Hilfe &amp; Info</h2>
-</div>
-
 <div class="w3-row help-layout">
   <div class="w3-col l7 m12 s12 help-col-guide">
     <div class="w3-container w3-margin-top">
@@ -28,7 +25,7 @@ $helpUser->load_by_id((int)$_SESSION['userid']);
     </div>
   </div>
 </div>
-
 <?php
+adminListPageEnd();
 include "common/footer.php";
 ?>

--- a/index.php
+++ b/index.php
@@ -47,29 +47,22 @@ include "common/header.php";
 
 <?php echo renderFlashHtml(); ?>
 <?php
-if(isset($_POST['proxy'])) {
-?>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorLogWarning']; ?>">
-    <h2>Bevorstehende Termine <?php echo $proxy->getName();?></h2>
-</div>
-<?php
-} else {
-?>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-    <h2>Bevorstehende Termine</h2>
-</div>
-<?php
+$homeTitle = 'Bevorstehende Termine';
+if(isset($_POST['proxy']) && isset($proxy) && $proxy) {
+    $homeTitle .= ' '.$proxy->getName();
 }
+adminListPageBegin('Termine', $homeTitle);
+adminListSearchField('Termine suchen (Titel, Ort, Datum, Beschreibung)…', array(
+    'onkeyup' => 'filterTermine()',
+));
 $chunkUser = isset($user) ? (int)$user : (int)$_SESSION['userid'];
 $chunk = listChunkTermine('future', 'basic', '', 50, $chunkUser);
 ?>
-<div class="w3-container w3-padding-16" style="clear:both;">
-<input class="w3-input w3-border w3-padding" type="text" placeholder="Termine suchen (Titel, Ort, Datum, Beschreibung)…" id="filterString" onkeyup="filterTermine()">
-</div>
 <div id="Liste">
 <?php echo $chunk['html']; ?>
 <?php echo listChunkRenderSentinel('termine', $chunk['nextCursor'], $chunk['hasMore'], 'filterTermine', ' data-extra="user='.$chunkUser.'"'); ?>
 </div>
+<?php adminListPageEnd(); ?>
 <script src="<?php echo assetUrl('js/filterTermine.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/infiniteScroll.js'); ?>"></script>
 <?php

--- a/js/app-nav.js
+++ b/js/app-nav.js
@@ -1,0 +1,88 @@
+(function () {
+  function resetAdminNavGroups() {
+    var groups = document.querySelectorAll('.admin-nav-group.admin-nav-open');
+    for (var i = 0; i < groups.length; i++) {
+      groups[i].classList.remove('admin-nav-open');
+    }
+  }
+
+  function isNarrow() {
+    return window.matchMedia && window.matchMedia('(max-width: 600px)').matches;
+  }
+
+  function setMoreOpen(open) {
+    var panel = document.getElementById('appNavMorePanel');
+    var backdrop = document.getElementById('appNavMoreBackdrop');
+    var toggle = document.getElementById('appNavMoreToggle');
+    if (!panel || !toggle) return;
+    if (!isNarrow()) {
+      open = false;
+    }
+    panel.classList.toggle('is-open', !!open);
+    if (backdrop) {
+      if (open) {
+        backdrop.hidden = false;
+      } else {
+        backdrop.hidden = true;
+      }
+    }
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    document.body.classList.toggle('app-nav-more-open', !!open);
+    if (!open) {
+      resetAdminNavGroups();
+    }
+  }
+
+  function initMore() {
+    var toggle = document.getElementById('appNavMoreToggle');
+    var closeBtn = document.getElementById('appNavMoreClose');
+    var backdrop = document.getElementById('appNavMoreBackdrop');
+    if (toggle) {
+      toggle.addEventListener('click', function (e) {
+        e.preventDefault();
+        var open = toggle.getAttribute('aria-expanded') === 'true';
+        setMoreOpen(!open);
+      });
+    }
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function () {
+        setMoreOpen(false);
+      });
+    }
+    if (backdrop) {
+      backdrop.addEventListener('click', function () {
+        setMoreOpen(false);
+      });
+    }
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        setMoreOpen(false);
+      }
+    });
+    window.addEventListener('resize', function () {
+      if (!isNarrow()) {
+        setMoreOpen(false);
+      }
+    });
+  }
+
+  document.addEventListener('click', function (ev) {
+    var btn = ev.target.closest ? ev.target.closest('.admin-nav-group > .w3-button') : null;
+    if (!btn) return;
+    var group = btn.parentNode;
+    if (!group || !group.classList || !group.classList.contains('admin-nav-group')) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    var open = group.classList.contains('admin-nav-open');
+    resetAdminNavGroups();
+    if (!open) {
+      group.classList.add('admin-nav-open');
+    }
+  });
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initMore);
+  } else {
+    initMore();
+  }
+})();

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -190,17 +190,26 @@ function getAdminPagePerm($page, $permKey) {
 }
 
 /**
+ * CSS-Klassen für Nav anhand der Rechte-Farbgruppe (wie Admin-Nav / Chips).
+ * @param string $groupId nutzer|termine|register|inventar|kommunikation|system
+ * @return string
+ */
+function navGroupClass($groupId) {
+    $gid = preg_replace('/[^a-z0-9_-]/i', '', (string)$groupId);
+    if($gid === '') {
+        $gid = 'system';
+    }
+    return 'admin-nav-perm admin-nav-perm--'.$gid;
+}
+
+/**
  * CSS-Klassen für Admin-Nav anhand der Rechte-Farbgruppe (wie Profil-Chips).
  * @param string $permKey
  * @return string
  */
 function adminNavPermClass($permKey) {
     $gid = Permissions::groupIdForPermission($permKey);
-    $gid = preg_replace('/[^a-z0-9_-]/i', '', (string)$gid);
-    if($gid === '') {
-        $gid = 'system';
-    }
-    return 'admin-nav-perm admin-nav-perm--'.$gid;
+    return navGroupClass($gid);
 }
 
 /**
@@ -217,6 +226,11 @@ function adminListSectionGroupId($kicker) {
         'Inventar' => 'inventar',
         'Register' => 'register',
         'System' => 'system',
+        // Nutzer-Seiten (gleicher Hero wie Admin-Listen)
+        'Hilfe' => 'system',
+        'Medien' => 'system',
+        'Anwesenheit' => 'termine',
+        'Stimme' => 'nutzer',
         // Admin-Formulare (nicht Listen)
         'Neuer Termin' => 'termine',
         'Termin bearbeiten' => 'termine',
@@ -278,8 +292,9 @@ function adminListPageBegin($kicker, $title, $options = array()) {
         $heroOpts['permKey'] = $options['permKey'];
     }
     $heroCls = adminHeroClass($heroOpts);
-    echo '<div class="w3-container w3-margin-bottom profile-page">'."\n";
+    echo '<div class="profile-page">'."\n";
     echo '  <div class="'.htmlspecialchars($shellCls, ENT_QUOTES, 'UTF-8').'">'."\n";
+    echo '    <div class="app-page-chrome">'."\n";
     echo '    <header class="'.htmlspecialchars($heroCls, ENT_QUOTES, 'UTF-8').'">'."\n";
     echo '      <div class="profile-hero-text">'."\n";
     echo '        <p class="profile-kicker">'.htmlspecialchars((string)$kicker, ENT_QUOTES, 'UTF-8').'</p>'."\n";
@@ -289,43 +304,69 @@ function adminListPageBegin($kicker, $title, $options = array()) {
         echo '      <div class="profile-hero-actions">'.$actionsHtml.'</div>'."\n";
     }
     echo '    </header>'."\n";
+    $GLOBALS['mlAdminListChrome'] = 'open';
+}
+
+/**
+ * Close open app-page-chrome and open scrollable body (after search or before other content).
+ */
+function adminListChromeClose() {
+    if(!empty($GLOBALS['mlAdminListChrome']) && $GLOBALS['mlAdminListChrome'] === 'open') {
+        echo '    </div><!-- .app-page-chrome -->'."\n";
+        echo '    <div class="admin-list-body">'."\n";
+        $GLOBALS['mlAdminListChrome'] = 'closed';
+        $GLOBALS['mlAdminListBody'] = 'open';
+        return;
+    }
 }
 
 /** Close adminListPageBegin(). */
 function adminListPageEnd() {
+    if(!empty($GLOBALS['mlAdminListChrome']) && $GLOBALS['mlAdminListChrome'] === 'open') {
+        /* Kein Search/ChromeClose: Inhalt liegt im Chrome — nur Chrome schließen */
+        echo '    </div><!-- .app-page-chrome -->'."\n";
+        $GLOBALS['mlAdminListChrome'] = 'closed';
+    }
+    elseif(!empty($GLOBALS['mlAdminListBody']) && $GLOBALS['mlAdminListBody'] === 'open') {
+        echo '    </div><!-- .admin-list-body -->'."\n";
+        $GLOBALS['mlAdminListBody'] = 'closed';
+    }
     echo '  </div>'."\n";
     echo '</div>'."\n";
 }
 
 /**
  * Search field styled like profile controls (keeps #filterString for existing JS).
+ * Kein sichtbares Label — nur Placeholder (+ aria-label). Siehe .cursor/rules/short-ui-labels.mdc
  * @param string $placeholder
- * @param array $options id, onkeyup, label, extraHtml
+ * @param array $options id, onkeyup, extraHtml (label wird ignoriert / nur für aria)
  */
 function adminListSearchField($placeholder, $options = array()) {
     $id = isset($options['id']) ? (string)$options['id'] : 'filterString';
     $onkeyup = isset($options['onkeyup']) ? (string)$options['onkeyup'] : '';
-    $label = isset($options['label']) ? (string)$options['label'] : 'Suchen';
     $extra = isset($options['extraHtml']) ? (string)$options['extraHtml'] : '';
     $inputBg = isset($GLOBALS['optionsDB']['colorInputBackground'])
         ? (string)$GLOBALS['optionsDB']['colorInputBackground'] : '';
-    echo '<div class="admin-list-toolbar">'."\n";
-    echo '  <div class="profile-field admin-list-search">'."\n";
-    echo '    <label class="profile-label" for="'.htmlspecialchars($id, ENT_QUOTES, 'UTF-8').'">'
-        .htmlspecialchars($label, ENT_QUOTES, 'UTF-8').'</label>'."\n";
-    echo '    <input type="search" id="'.htmlspecialchars($id, ENT_QUOTES, 'UTF-8').'"'
+    $aria = isset($options['ariaLabel']) && (string)$options['ariaLabel'] !== ''
+        ? (string)$options['ariaLabel']
+        : (string)$placeholder;
+    echo '    <div class="admin-list-toolbar">'."\n";
+    echo '      <div class="profile-field admin-list-search">'."\n";
+    echo '        <input type="search" id="'.htmlspecialchars($id, ENT_QUOTES, 'UTF-8').'"'
         .' class="w3-input w3-border profile-control '.htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8').'"'
         .' placeholder="'.htmlspecialchars((string)$placeholder, ENT_QUOTES, 'UTF-8').'"'
+        .' aria-label="'.htmlspecialchars($aria, ENT_QUOTES, 'UTF-8').'"'
         .' autocomplete="off"';
     if($onkeyup !== '') {
         echo ' onkeyup="'.htmlspecialchars($onkeyup, ENT_QUOTES, 'UTF-8').'"';
     }
     echo '>'."\n";
-    echo '  </div>'."\n";
+    echo '      </div>'."\n";
     if($extra !== '') {
-        echo '  <div class="admin-list-toolbar-extra">'.$extra.'</div>'."\n";
+        echo '      <div class="admin-list-toolbar-extra">'.$extra.'</div>'."\n";
     }
-    echo '</div>'."\n";
+    echo '    </div>'."\n";
+    adminListChromeClose();
 }
 
 function getNextRegInventoryNumber($inventoryTypeId = 0) {
@@ -349,13 +390,16 @@ function getOwner($index) {
     return $user->getName();
 }
 
-function getPage($string) {
+function getPage($string, $groupId = '') {
     if($string == $_SESSION['page']) {
         echo $GLOBALS['optionsDB']['colorTitleBar'];
+        return;
     }
-    else {
-        echo $GLOBALS['optionsDB']['colorNav'];
+    if($groupId !== '') {
+        echo navGroupClass($groupId);
+        return;
     }
+    echo $GLOBALS['optionsDB']['colorNav'];
 }
 
 function getShort($Vorname, $Nachname) {
@@ -459,6 +503,123 @@ function normalizeHexColor($value) {
         return '#'.$value[1].$value[1].$value[2].$value[2].$value[3].$value[3];
     }
     return $value;
+}
+
+/**
+ * Mix two hex colors. $t=0 → $hexA, $t=1 → $hexB.
+ * @param string $hexA
+ * @param string $hexB
+ * @param float $t
+ * @return string
+ */
+function hexMix($hexA, $hexB, $t) {
+    $hexA = normalizeHexColor($hexA);
+    $hexB = normalizeHexColor($hexB);
+    if($hexA === '') return $hexB !== '' ? $hexB : '#808080';
+    if($hexB === '') return $hexA;
+    $t = max(0.0, min(1.0, (float)$t));
+    $ar = hexdec(substr($hexA, 1, 2));
+    $ag = hexdec(substr($hexA, 3, 2));
+    $ab = hexdec(substr($hexA, 5, 2));
+    $br = hexdec(substr($hexB, 1, 2));
+    $bg = hexdec(substr($hexB, 3, 2));
+    $bb = hexdec(substr($hexB, 5, 2));
+    $r = (int)round($ar + ($br - $ar) * $t);
+    $g = (int)round($ag + ($bg - $ag) * $t);
+    $b = (int)round($ab + ($bb - $ab) * $t);
+    return sprintf('#%02X%02X%02X', $r, $g, $b);
+}
+
+/**
+ * Soft / accent / strong / softOff from a group accent color.
+ * @param string $accentHex
+ * @return array{accent:string,soft:string,strong:string,softOff:string,fg:string}
+ */
+function permissionGroupTonePalette($accentHex) {
+    $accent = normalizeHexColor($accentHex);
+    if($accent === '') {
+        $accent = '#78909C';
+    }
+    return array(
+        'accent' => $accent,
+        'soft' => hexMix($accent, '#FFFFFF', 0.82),
+        'strong' => hexMix($accent, '#FFFFFF', 0.38),
+        'softOff' => hexMix($accent, '#FFFFFF', 0.92),
+        'fg' => '#222222',
+    );
+}
+
+/**
+ * Palette for all permission groups (id → tones).
+ * @return array<string,array{accent:string,soft:string,strong:string,softOff:string,fg:string}>
+ */
+function permissionGroupPalettes() {
+    static $cache = null;
+    if($cache !== null) {
+        return $cache;
+    }
+    $cache = array();
+    if(!class_exists('Permissions')) {
+        return $cache;
+    }
+    foreach(Permissions::permissionGroups() as $group) {
+        $id = isset($group['id']) ? preg_replace('/[^a-z0-9_-]/i', '', (string)$group['id']) : '';
+        if($id === '') {
+            continue;
+        }
+        $accent = isset($group['color']) ? (string)$group['color'] : Permissions::groupColor($id);
+        $cache[$id] = permissionGroupTonePalette($accent);
+    }
+    return $cache;
+}
+
+/**
+ * CSS for Nav / Chips / Heroes / Rechte-Matrix from permission group colors.
+ * @param bool $wrapStyleTag
+ * @return string
+ */
+function renderPermissionGroupColorCss($wrapStyleTag = true) {
+    $palettes = permissionGroupPalettes();
+    if(!$palettes) {
+        return '';
+    }
+    $css = '';
+    foreach($palettes as $id => $tone) {
+        $soft = $tone['soft'];
+        $accent = $tone['accent'];
+        $strong = $tone['strong'];
+        $softOff = $tone['softOff'];
+        $fg = $tone['fg'];
+
+        $css .= '.app-nav .admin-nav-perm--'.$id
+            .',.profile-perm-tile--'.$id
+            .'{background:'.$soft.' !important;border-color:'.$accent.';color:'.$fg.' !important;}';
+
+        $css .= '.profile-shell .profile-hero.admin-list-hero--'.$id
+            .',.w3-container.admin-list-hero--'.$id
+            .'{background:'.$strong.';border-left-color:'.$accent.';}';
+
+        $css .= '.perm-matrix thead th.perm-group--'.$id
+            .'{background:'.$soft.';box-shadow:inset 0 -3px 0 '.$accent.';}';
+
+        $css .= '.perm-matrix td.perm-group--'.$id.'.perm-off{background:'.$softOff.';}';
+        $css .= '.perm-matrix td.perm-group--'.$id.'.perm-on{background:'.$strong.';}';
+    }
+
+    $css .= '@media (max-width:600px){';
+    foreach($palettes as $id => $tone) {
+        $accent = $tone['accent'];
+        $css .= '.app-nav>.app-nav-primary>.app-nav-item.admin-nav-perm--'.$id
+            .',.app-nav>.app-nav-primary>.app-nav-form>.app-nav-item.admin-nav-perm--'.$id
+            .',.app-nav>.app-nav-more-wrap>.app-nav-more-toggle.admin-nav-perm--'.$id
+            .'{border-top-color:'.$accent.';}';
+    }
+    $css .= '}';
+
+    if($css === '') {
+        return '';
+    }
+    return $wrapStyleTag ? '<style type="text/css" id="perm-group-colors">'.$css.'</style>' : $css;
 }
 
 function hexContrastText($hex) {

--- a/libs/permissions.php
+++ b/libs/permissions.php
@@ -305,19 +305,22 @@ class Permissions
     }
 
     /**
-     * Logical groups: order + color id for chips (titles not shown in UI).
-     * @return array<int,array{id:string,title:string,keys:string[]}>
+     * Logical groups: order + color id for chips/nav/heroes.
+     * `color` = Akzentfarbe; Soft/Strong werden daraus abgeleitet (kein Hardcode in CSS).
+     * @return array<int,array{id:string,title:string,color:string,keys:string[]}>
      */
     public static function permissionGroups() {
         return array(
             array(
                 'id' => 'nutzer',
                 'title' => 'Nutzer',
+                'color' => '#42A5F5',
                 'keys' => array('perm_showUsers', 'perm_editUsers', 'perm_editPermissions'),
             ),
             array(
                 'id' => 'termine',
                 'title' => 'Termine',
+                'color' => '#66BB6A',
                 'keys' => array(
                     'perm_showHiddenAppmnts',
                     'perm_editAppmnts',
@@ -328,24 +331,43 @@ class Permissions
             array(
                 'id' => 'register',
                 'title' => 'Register',
+                'color' => '#FFA726',
                 'keys' => array('perm_editRegisters'),
             ),
             array(
                 'id' => 'inventar',
                 'title' => 'Inventar',
+                'color' => '#AB47BC',
                 'keys' => array('perm_showInventories', 'perm_editInventories'),
             ),
             array(
                 'id' => 'kommunikation',
                 'title' => 'Kommunikation',
+                'color' => '#26C6DA',
                 'keys' => array('perm_sendEmail'),
             ),
             array(
                 'id' => 'system',
                 'title' => 'System',
+                'color' => '#78909C',
                 'keys' => array('perm_showLog', 'perm_editConfig'),
             ),
         );
+    }
+
+    /**
+     * Accent hex for a group id (from permissionGroups).
+     * @param string $groupId
+     * @return string
+     */
+    public static function groupColor($groupId) {
+        $groupId = (string)$groupId;
+        foreach(self::permissionGroups() as $group) {
+            if(isset($group['id']) && (string)$group['id'] === $groupId) {
+                return isset($group['color']) ? (string)$group['color'] : '#78909C';
+            }
+        }
+        return '#78909C';
     }
 
     /**

--- a/log.php
+++ b/log.php
@@ -18,7 +18,7 @@ if($leak !== false && $leak !== '') {
 ?>
 <?php
 adminListPageBegin('System', 'Log');
-adminListSearchField('Log durchsuchen…', array('onkeyup' => 'filterLog()', 'label' => 'Log durchsuchen'));
+adminListSearchField('Log durchsuchen…', array('onkeyup' => 'filterLog()'));
 ?>
 <div id="Liste" style="clear:both;">
 <?php echo $chunk['html']; ?>

--- a/media.php
+++ b/media.php
@@ -51,13 +51,8 @@ foreach($mediaLinks as $link) {
         $visibleLinks[] = $link;
     }
 }
+adminListPageBegin('Medien', 'Medien');
 ?>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-<h2>Medien</h2>
-</div>
-<div class="w3-container">
-<h3>Hier findest du Konzertaufnahmen, Fotos und weitere Medien für den internen Gebrauch</h3>
-</div>
 <?php if($visibleLinks) { ?>
   <div class="w3-container w3-row-padding">
 <?php foreach($visibleLinks as $link) { ?>
@@ -72,5 +67,6 @@ foreach($mediaLinks as $link) {
 </div>
 <?php } ?>
 <?php
+adminListPageEnd();
 include "common/footer.php";
 ?>

--- a/mein-register.php
+++ b/mein-register.php
@@ -12,16 +12,11 @@ if(isset($_POST['proxy'])) {
 else {
     $user = $_SESSION['userid'];
 }
+adminListPageBegin('Register', 'Mein Register');
+adminListSearchField('Termine suchen (Titel, Ort, Datum, Beschreibung)…', array(
+    'onkeyup' => 'filterTermine()',
+));
 ?>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-<h2>Mein Register</h2>
-</div>
-      <div class="w3-row">
-               <div class="w3-panel w3-col l3 w3-left"></div>
-                        <div class="w3-col l6 s12 m12">
-<div class="w3-container w3-padding-16" style="clear:both;">
-<input class="w3-input w3-border w3-padding" type="text" placeholder="Termine suchen (Titel, Ort, Datum, Beschreibung)…" id="filterString" onkeyup="filterTermine()">
-</div>
 <div id="Liste">
 <?php
 $now = date("Y-m-d");
@@ -41,9 +36,7 @@ while($row = mysqli_fetch_array($dbr)) {
 }
 ?>
 </div>
-</div>
-<div class="w3-col l3"></div>
-</div>
+<?php adminListPageEnd(); ?>
 <script src="js/filterTermine.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <?php
 include "common/footer.php";

--- a/meine-mails.php
+++ b/meine-mails.php
@@ -73,11 +73,8 @@ $resolveSender = function($senderId) use (&$userNameCache) {
     }
     return $userNameCache[$senderId];
 };
+adminListPageBegin('Kommunikation', 'Meine Nachrichten');
 ?>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-  <h2>Meine Nachrichten</h2>
-</div>
-
 <?php if($viewMail) {
     $subj = htmlspecialchars((string)$viewMail->Subject, ENT_QUOTES, 'UTF-8');
     $body = formatMailBodyForDisplay((string)$viewMail->BodyText);
@@ -147,5 +144,6 @@ else {
   </div>
 </div>
 <?php
+adminListPageEnd();
 include "common/footer.php";
 ?>

--- a/meldungen.php
+++ b/meldungen.php
@@ -12,7 +12,6 @@ $chunk = listChunkTermine('future', 'response', '', 50, (int)$_SESSION['userid']
 adminListPageBegin('Meldungen', 'Rückmeldungen');
 adminListSearchField('Termine suchen (Titel, Ort, Datum, Beschreibung)…', array(
     'onkeyup' => 'filterTermine()',
-    'label' => 'Termine suchen',
 ));
 ?>
 <div id="Liste">

--- a/musiker.php
+++ b/musiker.php
@@ -37,14 +37,12 @@ $nMusiker = $row['Count'];
 ?>
 <?php echo renderFlashHtml(); ?>
 <?php adminListPageBegin('Personen', 'Musiker ('.$nMusiker.')'); ?>
-
+<?php adminListSearchField('Nach Musiker suchen…', array('onkeyup' => 'filterMusiker()')); ?>
 <?php if($GLOBALS['optionsDB']['showOrchestraView']) { ?>
 <div class="w3-center orchestra-svg-wrap">
 <?php echo printOrchestra(0); ?>
 </div>
 <?php } ?>
-
-<?php adminListSearchField('Nach Musiker suchen…', array('onkeyup' => 'filterMusiker()')); ?>
 <div id="listHeader" class="list-header w3-row w3-hide-small">
   <div class="w3-col l3 m6 s12 w3-container list-sort" data-sort="nachname" data-type="string">Name</div>
   <div class="w3-col l2 m6 s12 w3-container list-sort" data-sort="instrument" data-type="string">Instrument</div>

--- a/myinventories.php
+++ b/myinventories.php
@@ -14,11 +14,8 @@ if(handleInventoriesMutations()) {
 }
 
 include "common/header.php";
+adminListPageBegin('Inventar', 'Mein Inventar');
 ?>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-  <h2>Mein Inventar</h2>
-</div>
-
 <div class="w3-row w3-padding w3-border-bottom w3-border-black w3-hide-small w3-hide-medium">
   <div class="w3-col l1 m1 s1 w3-center w3-border-right"><b>Inventarnummer</b></div>
   <div class="w3-col l2 m2 s2 w3-center w3-border-right"><b>Typ</b></div>
@@ -60,5 +57,6 @@ for($i=0; $i < count($loans); $i++) {
     echo $inventory->printTableLine(false);
 }
 
+adminListPageEnd();
 include "common/footer.php";
 ?>

--- a/permissions.php
+++ b/permissions.php
@@ -52,8 +52,7 @@ adminListPageBegin('System', 'Berechtigungen', array(
 ?>
     <div class="perm-toolbar">
       <div class="profile-field perm-toolbar-search">
-        <label class="profile-label" for="permFilter">Name filtern</label>
-        <input type="search" id="permFilter" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" placeholder="Name tippen…" autocomplete="off">
+        <input type="search" id="permFilter" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" placeholder="Name tippen…" aria-label="Name tippen…" autocomplete="off">
       </div>
       <div class="profile-field perm-toolbar-filter">
         <label class="profile-pref" for="permOnlyActive">
@@ -62,8 +61,8 @@ adminListPageBegin('System', 'Berechtigungen', array(
         </label>
       </div>
     </div>
+<?php adminListChromeClose(); ?>
 
-    <h3 class="profile-col-title">Rechte-Matrix</h3>
     <div class="perm-matrix-wrap">
       <table class="perm-matrix" id="permMatrix">
         <thead>

--- a/register-types.php
+++ b/register-types.php
@@ -56,6 +56,7 @@ if(isset($_POST['delete'])) {
 
 $inputCls = $GLOBALS['optionsDB']['colorInputBackground'];
 adminListPageBegin('Register', 'Register');
+adminListChromeClose();
 ?>
 <?php if($msg) { ?><div class="w3-panel w3-green w3-padding"><?php echo htmlspecialchars($msg); ?></div><?php } ?>
 <?php if($err) { ?><div class="w3-panel w3-red w3-padding"><?php echo htmlspecialchars($err); ?></div><?php } ?>

--- a/register.php
+++ b/register.php
@@ -9,6 +9,7 @@ if(!requirePermission("perm_showUsers")) {
 }
 
 adminListPageBegin('Personen', 'Registerübersicht');
+adminListSearchField('Nach Musiker suchen…', array('onkeyup' => 'filterMusiker()'));
 ?>
 
 <?php if($GLOBALS['optionsDB']['showOrchestraView']) { ?>
@@ -17,6 +18,7 @@ adminListPageBegin('Personen', 'Registerübersicht');
 </div>
 <?php } ?>
 
+<div id="Liste">
 <?php
     $sql = sprintf('SELECT `Index` FROM `%sRegister` WHERE `Name` != "keins" ORDER BY `Sortierung`;',
         $GLOBALS['dbprefix']
@@ -28,6 +30,12 @@ while($row = mysqli_fetch_array($dbr)) {
     $M->load_by_id($row['Index']);
     $M->memberTable();
 }
+?>
+</div>
+<?php
 adminListPageEnd();
+?>
+<script src="js/filterMusiker.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<?php
 include "common/footer.php";
 ?>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2,16 +2,679 @@
   color: #111;
 }
 
+/* —— App navigation (MELD-139): sidebar ≥601px, bottom bar ≤600px —— */
+html {
+  height: 100%;
+}
+
+body.app-layout {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-height: 100dvh;
+  margin: 0;
+  overflow: hidden;
+}
+
+.app-titlebar {
+  position: relative;
+  z-index: 1100;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 0.15rem;
+  padding: 0.5rem 4.5rem 0.5rem 1rem;
+  min-height: 0;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+/* w3-container-Clearfix darf hier kein Flex-Item erzeugen */
+.app-titlebar::before,
+.app-titlebar::after {
+  content: none;
+  display: none;
+}
+
+.app-titlebar-name {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
+  font-size: 1.75rem;
+  font-weight: 650;
+  line-height: 1.25;
+  text-align: left;
+}
+
+.app-titlebar-logo {
+  position: absolute;
+  top: 50%;
+  right: 0.65rem;
+  transform: translateY(-50%);
+  height: 2.75rem;
+  width: auto;
+  max-height: 2.75rem;
+  max-width: 3.5rem;
+  display: block;
+  object-fit: contain;
+}
+
+a.app-titlebar-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.app-titlebar-logo img {
+  height: 2.75rem;
+  width: auto;
+  max-height: 2.75rem;
+  max-width: 3.5rem;
+  display: block;
+  object-fit: contain;
+}
+
+.app-titlebar-user {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
+  font-size: 0.95rem;
+  line-height: 1.3;
+  text-align: left;
+}
+
+@media (max-width: 600px) {
+  .app-titlebar {
+    padding-right: 3.75rem;
+  }
+
+  .app-titlebar-name {
+    font-size: 1.4rem;
+  }
+
+  .app-titlebar-logo,
+  .app-titlebar-logo img {
+    height: 2.25rem;
+    max-height: 2.25rem;
+    max-width: 2.75rem;
+  }
+}
+
+.app-banner {
+  flex-shrink: 0;
+}
+
+.app-shell {
+  display: flex;
+  align-items: stretch;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.app-nav {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1000;
+  overflow-x: visible;
+  overflow-y: auto;
+}
+
+.app-nav-primary,
+.app-nav-more-body {
+  display: flex;
+  flex-direction: column;
+}
+
+.app-nav-form {
+  margin: 0;
+  padding: 0;
+  display: block;
+}
+
+.app-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.65rem 0.9rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  font: inherit;
+  position: relative;
+}
+
+.app-nav-item:hover {
+  filter: brightness(0.95);
+}
+
+.app-nav-item .nav-label {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.app-nav-item .nav-label-short {
+  display: none;
+}
+
+.app-nav-item--badge {
+  padding-right: 1.75rem;
+}
+
+.app-nav-badge {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.4rem;
+  padding: 1px 5px;
+  font-size: 10px;
+  line-height: 1.2;
+}
+
+.app-nav-more-wrap {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  z-index: 1;
+  overflow: visible;
+}
+
+.app-nav-more-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.9rem;
+  font-weight: 700;
+}
+
+.app-nav-more-close {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 0.25rem;
+}
+
+.app-nav-admin-title {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.65rem 0.9rem;
+  font-weight: 700;
+}
+
+.app-main {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  position: relative;
+  z-index: 1;
+  margin: 0.65rem 0.75rem 0.75rem;
+  padding: 0 1.25rem 1.25rem;
+  box-sizing: border-box;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 10px;
+  background: #fff;
+  color: #111;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --app-page-head-h: 0px;
+  --app-page-toolbar-h: 0px;
+}
+
+.app-main:has(.profile-hero) {
+  --app-page-head-h: 4.75rem;
+}
+
+.app-main:has(.admin-list-toolbar),
+.app-main:has(.perm-toolbar) {
+  --app-page-toolbar-h: 2.35rem;
+}
+
+/* Flash / MOTD oben etwas Abstand (kein padding-top auf der Karte) */
+.app-main > .w3-panel:first-child,
+.app-main > .w3-container.w3-card:first-of-type {
+  margin-top: 1rem;
+}
+
+/* Admin/Profil-Seiten: keine zweite Karte im gleichen Rahmen */
+.app-main > .profile-page,
+.app-main > .termin-page {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  max-width: none;
+}
+
+.app-main > .profile-page > .profile-shell,
+.app-main > .termin-page > .profile-shell,
+.app-main > .w3-container > .profile-shell,
+.app-main > .profile-shell {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  background: transparent;
+}
+
+/* Admin-Listen: Hero bündig am Kartenrand (wie Hilfe), Inhalt eingerückt */
+.app-main:has(.admin-list-shell) {
+  padding-top: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-bottom: 0.75rem;
+}
+
+.admin-list-shell > .app-page-chrome > .admin-list-toolbar,
+.admin-list-shell > .app-page-chrome > .perm-toolbar {
+  margin-left: 1.25rem;
+  margin-right: 1.25rem;
+}
+
+/* Seiten ohne Body (Hilfe, …): Chrome padded, Hero negativ zurück auf Kanten */
+.admin-list-shell:not(:has(.admin-list-body)) > .app-page-chrome {
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+}
+
+.admin-list-shell:not(:has(.admin-list-body)) > .app-page-chrome > .profile-hero.admin-list-hero {
+  margin-left: -1.25rem;
+  margin-right: -1.25rem;
+}
+
+/* Listen mit Chrome+Body: Titel(+Suche) fest, nur .admin-list-body scrollt */
+.app-main:has(.admin-list-body) {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.app-main:has(.admin-list-body) > .w3-panel,
+.app-main:has(.admin-list-body) > .w3-container.w3-card,
+.app-main:has(.admin-list-body) > .app-banner {
+  flex-shrink: 0;
+  margin-left: 1.25rem;
+  margin-right: 1.25rem;
+}
+
+.app-main:has(.admin-list-body) > .profile-page {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.admin-list-shell:has(.admin-list-body) {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  --app-chrome-fade-h: 0.75rem;
+}
+
+.admin-list-shell > .app-page-chrome {
+  flex-shrink: 0;
+  position: relative;
+  z-index: 6;
+  padding-bottom: 0;
+}
+
+/* Inhalt scrollt unter die Suche und fadet aus (schmale Zone) */
+.admin-list-shell > .app-page-chrome::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  height: var(--app-chrome-fade-h);
+  pointer-events: none;
+  background: linear-gradient(
+    to bottom,
+    #fff 0%,
+    rgba(255, 255, 255, 0.65) 45%,
+    rgba(255, 255, 255, 0) 100%
+  );
+}
+
+.admin-list-shell > .admin-list-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  /* ungescrollt: Inhalt erst unter / am Ende der Fade-Zone */
+  padding-top: var(--app-chrome-fade-h);
+  padding-left: 1.25rem;
+  padding-right: 1.25rem;
+  box-sizing: border-box;
+  overflow-x: hidden;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Seiten ohne Body-Wrapper (Hilfe, Formulare): Hero sticky im app-main-Scroll */
+.app-main .profile-shell:not(.admin-list-shell) > .profile-hero,
+.app-main .profile-form > .profile-hero,
+.app-main .admin-list-shell:not(:has(.admin-list-body)) .profile-hero {
+  position: sticky;
+  top: 0;
+  z-index: 6;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
+}
+
+.app-main .profile-shell > .profile-hero:not(.admin-list-hero),
+.app-main .profile-form > .profile-hero:not(.admin-list-hero) {
+  background: #fff;
+}
+
+@media (min-width: 601px) {
+  .app-nav {
+    width: 13.5rem;
+    align-self: stretch;
+    overflow-x: visible;
+    overflow-y: auto;
+  }
+
+  .app-nav-more-toggle,
+  .app-nav-more-backdrop,
+  .app-nav-more-head,
+  .app-nav-more-only-mobile {
+    display: none !important;
+  }
+
+  .app-nav-more-panel {
+    display: block;
+    position: static;
+    box-shadow: none;
+    border-top: 1px solid rgba(0, 0, 0, 0.12);
+    overflow: visible;
+  }
+}
+
+@media (max-width: 600px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .app-nav {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    flex-direction: row;
+    align-items: stretch;
+    width: 100%;
+    max-width: none;
+    min-height: 3.75rem;
+    box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.15);
+    padding-bottom: env(safe-area-inset-bottom, 0);
+  }
+
+  .app-nav-primary {
+    /* 5 Kern-Buttons: gleiche Zellenbreite wie „Mehr“ (1) */
+    flex: 5 1 0;
+    flex-direction: row;
+    align-items: stretch;
+    min-width: 0;
+    overflow: visible;
+  }
+
+  .app-nav-form {
+    display: flex;
+    flex: 1 1 0;
+    min-width: 0;
+    height: 100%;
+  }
+
+  .app-nav-item--secondary {
+    display: none !important;
+  }
+
+  .app-nav-more-wrap {
+    margin-top: 0;
+    flex: 1 1 0;
+    flex-direction: column;
+    align-items: stretch;
+    min-width: 0;
+    height: 100%;
+  }
+
+  .app-nav-primary > .app-nav-item,
+  .app-nav-form > .app-nav-item,
+  .app-nav-more-wrap > .app-nav-more-toggle {
+    flex: 1 1 0;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 0;
+    padding: 0.45rem 0.2rem;
+    margin: 0;
+    min-width: 0;
+    width: 100%;
+    height: 100%;
+    min-height: 3.75rem;
+    box-sizing: border-box;
+    text-align: center;
+    font-size: 0.7rem;
+    font-weight: 600;
+    line-height: 1.15;
+  }
+
+  .app-nav-item > i,
+  .app-nav-more-toggle > i {
+    font-size: 1.45rem;
+    line-height: 1;
+  }
+
+  /* Bottom-Bar: nur Icons, Labels im Mehr-Sheet */
+  .app-nav-primary > .app-nav-item .nav-label,
+  .app-nav-form > .app-nav-item .nav-label,
+  .app-nav-more-toggle .nav-label {
+    display: none;
+  }
+
+  .app-nav-item--badge {
+    padding-right: 0.2rem;
+  }
+
+  .app-nav-badge {
+    top: 0.2rem;
+    right: 0.15rem;
+    font-size: 0.65rem;
+  }
+
+  .app-nav-more-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.35);
+    z-index: 45;
+  }
+
+  .app-nav-more-panel {
+    display: none;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    max-height: min(75vh, 32rem);
+    overflow: auto;
+    z-index: 50;
+    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.2);
+    padding-bottom: calc(4rem + env(safe-area-inset-bottom, 0));
+    border-radius: 0.75rem 0.75rem 0 0;
+  }
+
+  .app-nav-more-panel.is-open {
+    display: block;
+  }
+
+  .app-nav-more-head {
+    font-size: 1.05rem;
+    padding: 0.75rem 1rem;
+  }
+
+  .app-nav-more-body .app-nav-item {
+    flex: none;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    text-align: left;
+    width: 100%;
+    min-width: 0;
+    min-height: 3rem;
+    height: auto;
+    font-size: 1.05rem;
+    font-weight: 600;
+    gap: 0.75rem;
+    padding: 0.85rem 1rem;
+  }
+
+  .app-nav-more-body .app-nav-item > i {
+    font-size: 1.25rem;
+    width: 1.5rem;
+    text-align: center;
+  }
+
+  .app-nav-more-body .app-nav-item .nav-label {
+    display: inline;
+    flex: 1;
+    font-size: 1.05rem;
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+  }
+
+  .app-nav-more-body .app-nav-item .nav-label-long {
+    display: inline;
+  }
+
+  .app-nav-more-body .app-nav-item .nav-label-short {
+    display: none;
+  }
+
+  .app-main {
+    margin: 0.5rem 0.5rem calc(4.5rem + env(safe-area-inset-bottom, 0));
+    padding: 0 1rem 1rem;
+  }
+
+  .app-main:has(.admin-list-shell) {
+    padding-top: 0;
+    padding-left: 0;
+    padding-right: 0;
+    padding-bottom: 0.75rem;
+  }
+
+  .admin-list-shell > .app-page-chrome > .admin-list-toolbar,
+  .admin-list-shell > .app-page-chrome > .perm-toolbar {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+
+  .admin-list-shell > .admin-list-body {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .admin-list-shell:not(:has(.admin-list-body)) > .app-page-chrome {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .admin-list-shell:not(:has(.admin-list-body)) > .app-page-chrome > .profile-hero.admin-list-hero {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+
+  .app-main:has(.admin-list-body) > .w3-panel,
+  .app-main:has(.admin-list-body) > .w3-container.w3-card,
+  .app-main:has(.admin-list-body) > .app-banner {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+
+  .app-main:has(.profile-hero) {
+    --app-page-head-h: 5.25rem;
+  }
+
+  .app-main:has(.admin-list-toolbar),
+  .app-main:has(.perm-toolbar) {
+    --app-page-toolbar-h: 2.45rem;
+  }
+
+  .profile-shell .profile-hero.admin-list-hero,
+  .w3-container.admin-list-hero {
+    margin-bottom: 0.5rem;
+    padding: 0.65rem 1rem;
+  }
+
+  .app-main:has(.admin-list-shell) .admin-list-shell .profile-hero.admin-list-hero {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .app-main:has(.admin-list-shell) .admin-list-shell:not(:has(.admin-list-body)) > .app-page-chrome > .profile-hero.admin-list-hero {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+
+  body.app-nav-more-open {
+    overflow: hidden;
+  }
+}
+
+/* —— end app navigation —— */
+
 /* Hero tinted by Admin-Rechte group (same palette as Nav / Chips / Matrix).
    Descendant (not only >) so Form-Seiten mit .profile-form > header auch treffen. */
 .profile-shell .profile-hero.admin-list-hero,
 .w3-container.admin-list-hero {
-  margin: -1px -1px 1.15rem;
-  padding: 0.65rem 1rem;
+  margin: 0 -1.25rem 0.5rem;
+  padding: 0.65rem 1.25rem;
   border-bottom: 0;
   border-radius: 10px 10px 0 0;
   border-left: 6px solid transparent;
   color: #222;
+}
+
+/* Admin-Listen-Karten ohne seitliches app-main-Padding: Hero ohne Negativ-Margin */
+.app-main:has(.admin-list-shell) .admin-list-shell .profile-hero.admin-list-hero {
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: 0.5rem;
+}
+
+/* Hilfe & Co.: Chrome hat seitliches Padding → Hero wieder auf Kartenkante */
+.app-main:has(.admin-list-shell) .admin-list-shell:not(:has(.admin-list-body)) > .app-page-chrome > .profile-hero.admin-list-hero {
+  margin-left: -1.25rem;
+  margin-right: -1.25rem;
+}
+
+.app-main > div.profile-page:first-of-type > .profile-shell > .profile-hero.admin-list-hero:first-child,
+.app-main > div.profile-page:first-of-type > .profile-shell > .app-page-chrome > .profile-hero.admin-list-hero:first-child,
+.app-main > div.termin-page:first-of-type > .profile-shell > .profile-hero.admin-list-hero:first-child,
+.app-main > div.termin-page:first-of-type > .profile-shell > .app-page-chrome > .profile-hero.admin-list-hero:first-child,
+.app-main .profile-form > .profile-hero.admin-list-hero:first-child,
+.app-main > div.w3-container.admin-list-hero:first-of-type {
+  border-radius: 10px 10px 0 0;
 }
 
 .profile-shell .profile-hero.admin-list-hero .profile-kicker {
@@ -22,6 +685,7 @@
 .profile-shell .profile-hero.admin-list-hero .profile-title {
   color: inherit;
   font-weight: 700;
+  font-size: clamp(1.65rem, 2.8vw, 2.05rem);
 }
 
 .profile-shell .profile-hero.admin-list-hero .profile-hero-actions .w3-button,
@@ -29,54 +693,32 @@
   color: inherit;
 }
 
-.profile-shell .profile-hero.admin-list-hero--nutzer,
-.w3-container.admin-list-hero--nutzer {
-  background: #90caf9;
-  border-left-color: #42a5f5;
-}
+/* Gruppenfarben (Nav/Hero/Matrix): siehe renderPermissionGroupColorCss() */
 
-.profile-shell .profile-hero.admin-list-hero--termine,
-.w3-container.admin-list-hero--termine {
-  background: #a5d6a7;
-  border-left-color: #66bb6a;
-}
-
-.profile-shell .profile-hero.admin-list-hero--register,
-.w3-container.admin-list-hero--register {
-  background: #ffcc80;
-  border-left-color: #ffa726;
-}
-
-.profile-shell .profile-hero.admin-list-hero--inventar,
-.w3-container.admin-list-hero--inventar {
-  background: #ce93d8;
-  border-left-color: #ab47bc;
-}
-
-.profile-shell .profile-hero.admin-list-hero--kommunikation,
-.w3-container.admin-list-hero--kommunikation {
-  background: #80deea;
-  border-left-color: #26c6da;
-}
-
-.profile-shell .profile-hero.admin-list-hero--system,
-.w3-container.admin-list-hero--system {
-  background: #b0bec5;
-  border-left-color: #78909c;
-}
-
-.admin-list-toolbar {
+.admin-list-toolbar,
+.perm-toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem 1rem;
-  align-items: flex-end;
-  margin-bottom: 0.85rem;
+  gap: 0.35rem 0.75rem;
+  align-items: stretch;
+  margin: 0;
+  padding: 0.15rem 0 0;
+  background: #fff;
 }
 
-.admin-list-search {
+.admin-list-search,
+.perm-toolbar-search,
+.admin-list-toolbar .profile-field,
+.perm-toolbar .profile-field {
   flex: 1 1 16rem;
   min-width: 12rem;
-  margin-bottom: 0;
+  margin: 0 !important;
+  padding: 0;
+}
+
+.admin-list-toolbar .profile-control,
+.perm-toolbar .profile-control {
+  margin: 0 !important;
 }
 
 .admin-list-toolbar-extra {
@@ -85,7 +727,43 @@
   flex-wrap: wrap;
   gap: 0.5rem;
   align-items: center;
-  padding-bottom: 0.15rem;
+  margin: 0;
+  padding: 0;
+}
+
+.admin-list-shell > #Liste,
+.admin-list-shell > .list-header,
+.admin-list-shell > #listHeader,
+.profile-shell > #Liste,
+.profile-shell > .list-header,
+.profile-shell > #listHeader {
+  margin-top: 0;
+}
+
+/* Abstand Suche → Liste: weicher Fade unter .app-page-chrome */
+.admin-list-body > #Liste > :first-child,
+.admin-list-shell > #Liste > :first-child {
+  margin-top: 0 !important;
+}
+
+.admin-list-body > .list-header,
+.admin-list-body > #listHeader,
+.admin-list-shell > .list-header,
+.admin-list-shell > #listHeader {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.admin-list-body > .list-header + #Liste > :first-child,
+.admin-list-body > #listHeader + #Liste > :first-child,
+.admin-list-shell > .list-header + #Liste > :first-child,
+.admin-list-shell > #listHeader + #Liste > :first-child {
+  margin-top: 0 !important;
+}
+
+.perm-toolbar-filter {
+  flex: 0 1 auto;
+  margin: 0 !important;
 }
 
 .admin-list-shell .list-header,
@@ -138,25 +816,6 @@
   color: #111;
 }
 
-.perm-toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem 1.5rem;
-  align-items: flex-end;
-  margin-bottom: 1rem;
-}
-
-.perm-toolbar-search {
-  flex: 1 1 16rem;
-  min-width: 12rem;
-  margin-bottom: 0;
-}
-
-.perm-toolbar-filter {
-  flex: 0 1 auto;
-  margin-bottom: 0.35rem;
-}
-
 .perm-save-status {
   margin: 0;
   min-height: 1.2em;
@@ -179,11 +838,16 @@
   max-width: 100%;
   min-width: 0;
   box-sizing: border-box;
-  max-height: calc(100dvh - 16rem);
   border: 1px solid rgba(0, 0, 0, 0.12);
   border-radius: 8px;
   background: #fff;
   -webkit-overflow-scrolling: touch;
+}
+
+/* Ohne Body-Scroll (Fallback): begrenzte Höhe */
+.admin-list-shell:not(:has(.admin-list-body)) > .perm-matrix-wrap,
+.profile-shell:not(.admin-list-shell) > .perm-matrix-wrap {
+  max-height: calc(100dvh - 16rem);
 }
 
 .perm-matrix {
@@ -207,7 +871,7 @@
   overflow: hidden;
 }
 
-.perm-matrix thead th {
+.perm-matrix-wrap .perm-matrix thead th {
   position: sticky;
   top: 0;
   z-index: 2;
@@ -298,44 +962,7 @@
   }
 }
 
-/* Group colors (same palette as Admin-Nav / Rechte-Chips) */
-.perm-matrix thead th.perm-group--nutzer {
-  background: #e3f2fd;
-  box-shadow: inset 0 -3px 0 #64b5f6;
-}
-.perm-matrix thead th.perm-group--termine {
-  background: #e8f5e9;
-  box-shadow: inset 0 -3px 0 #66bb6a;
-}
-.perm-matrix thead th.perm-group--register {
-  background: #fff3e0;
-  box-shadow: inset 0 -3px 0 #ffb74d;
-}
-.perm-matrix thead th.perm-group--inventar {
-  background: #f3e5f5;
-  box-shadow: inset 0 -3px 0 #ba68c8;
-}
-.perm-matrix thead th.perm-group--kommunikation {
-  background: #e0f7fa;
-  box-shadow: inset 0 -3px 0 #4dd0e1;
-}
-.perm-matrix thead th.perm-group--system {
-  background: #eceff1;
-  box-shadow: inset 0 -3px 0 #90a4ae;
-}
-
-.perm-matrix td.perm-group--nutzer.perm-off { background: #f5fafd; }
-.perm-matrix td.perm-group--nutzer.perm-on { background: #90caf9; }
-.perm-matrix td.perm-group--termine.perm-off { background: #f4faf5; }
-.perm-matrix td.perm-group--termine.perm-on { background: #a5d6a7; }
-.perm-matrix td.perm-group--register.perm-off { background: #fffaf3; }
-.perm-matrix td.perm-group--register.perm-on { background: #ffcc80; }
-.perm-matrix td.perm-group--inventar.perm-off { background: #faf5fc; }
-.perm-matrix td.perm-group--inventar.perm-on { background: #ce93d8; }
-.perm-matrix td.perm-group--kommunikation.perm-off { background: #f2fcfd; }
-.perm-matrix td.perm-group--kommunikation.perm-on { background: #80deea; }
-.perm-matrix td.perm-group--system.perm-off { background: #f7f9fa; }
-.perm-matrix td.perm-group--system.perm-on { background: #b0bec5; }
+/* Group colors: renderPermissionGroupColorCss() */
 
 .perm-matrix td.perm-inherited {
   outline: 2px dashed rgba(0, 0, 0, 0.35);
@@ -386,20 +1013,64 @@
   align-items: stretch;
 }
 
-/* Admin nested dropdowns (MELD-58) */
+/* Admin nested dropdowns (MELD-58 / MELD-139 sidebar) */
+.admin-nav {
+  position: relative;
+  z-index: 2;
+  overflow: visible;
+}
+
 .admin-nav > .w3-dropdown-content {
   min-width: 0;
   width: max-content;
   max-width: min(90vw, 16rem);
-  z-index: 10;
+  z-index: 1100;
 }
 
-/* w3.css opens ALL nested .w3-dropdown-content on parent hover — reset that */
-.admin-nav:hover .w3-dropdown-content {
-  display: none;
+/* w3.css opens ALL nested .w3-dropdown-content on ancestor hover — reset that.
+   Desktop (MELD-139): Akkordeon nach unten in der Sidebar, nicht als Flyout über dem Content. */
+@media (min-width: 601px) {
+  .admin-nav:hover .admin-nav-group > .w3-dropdown-content,
+  .admin-nav .admin-nav-group:hover > .w3-dropdown-content {
+    display: none;
+  }
+
+  .admin-nav .admin-nav-group > .w3-dropdown-content {
+    position: static !important;
+    left: auto;
+    top: auto;
+    display: none !important;
+    width: 100%;
+    max-width: none;
+    min-width: 0 !important;
+    z-index: auto;
+    box-shadow: none;
+  }
+
+  .admin-nav .admin-nav-group.admin-nav-open > .w3-dropdown-content {
+    display: block !important;
+  }
+
+  .admin-nav-group.admin-nav-open > .w3-button .admin-nav-caret {
+    transform: rotate(90deg);
+  }
+
+  .admin-nav-group > .w3-button {
+    font-weight: 600;
+    cursor: pointer;
+    white-space: normal;
+  }
+
+  .admin-nav-group > .w3-dropdown-content .w3-bar-item {
+    white-space: normal;
+    padding-left: 1.25rem;
+  }
 }
-.admin-nav:hover > .w3-dropdown-content {
-  display: block;
+
+@media (max-width: 600px) {
+  .admin-nav:hover .admin-nav-group > .w3-dropdown-content {
+    display: none;
+  }
 }
 
 /*
@@ -431,55 +1102,29 @@
   background-color: transparent;
 }
 
-/* Same palette as profile permission chips */
-.admin-nav .admin-nav-perm,
+/* Gruppenfarben Nav/Chips: renderPermissionGroupColorCss() */
+.app-nav .admin-nav-perm,
 .profile-perm-tile {
   color: #222 !important;
 }
 
-.admin-nav .admin-nav-perm {
+.app-nav .admin-nav-perm {
   border-left: 4px solid transparent;
 }
 
-.admin-nav .admin-nav-perm--nutzer,
-.profile-perm-tile--nutzer {
-  background: #e3f2fd !important;
-  border-color: #64b5f6;
-}
-
-.admin-nav .admin-nav-perm--termine,
-.profile-perm-tile--termine {
-  background: #e8f5e9 !important;
-  border-color: #66bb6a;
-}
-
-.admin-nav .admin-nav-perm--register,
-.profile-perm-tile--register {
-  background: #fff3e0 !important;
-  border-color: #ffb74d;
-}
-
-.admin-nav .admin-nav-perm--inventar,
-.profile-perm-tile--inventar {
-  background: #f3e5f5 !important;
-  border-color: #ba68c8;
-}
-
-.admin-nav .admin-nav-perm--kommunikation,
-.profile-perm-tile--kommunikation {
-  background: #e0f7fa !important;
-  border-color: #4dd0e1;
-}
-
-.admin-nav .admin-nav-perm--system,
-.profile-perm-tile--system {
-  background: #eceff1 !important;
-  border-color: #90a4ae;
-}
-
-.admin-nav .admin-nav-group > .w3-button.admin-nav-perm:hover,
-.admin-nav .w3-bar-item.admin-nav-perm:hover {
+.app-nav .admin-nav-group > .w3-button.admin-nav-perm:hover,
+.app-nav .w3-bar-item.admin-nav-perm:hover,
+.app-nav .app-nav-item.admin-nav-perm:hover {
   filter: brightness(0.96);
+}
+
+@media (max-width: 600px) {
+  .app-nav > .app-nav-primary > .app-nav-item.admin-nav-perm,
+  .app-nav > .app-nav-primary > .app-nav-form > .app-nav-item.admin-nav-perm,
+  .app-nav > .app-nav-more-wrap > .app-nav-more-toggle.admin-nav-perm {
+    border-left: 0;
+    border-top: 3px solid transparent;
+  }
 }
 
 .admin-nav-caret {
@@ -490,20 +1135,15 @@
 
 .admin-nav-group > .w3-dropdown-content {
   position: absolute !important;
-  /* slight overlap so the pointer can reach the flyout without leaving :hover */
   left: calc(100% - 2px);
   top: 0;
-  /* override .w3-bar-block … min-width:100% */
   min-width: 0 !important;
   width: max-content;
   max-width: min(90vw, 16rem);
-  z-index: 12;
+  z-index: 1100;
   margin: 0;
   padding: 0;
-}
-
-.admin-nav-group:hover > .w3-dropdown-content {
-  display: block;
+  display: none;
 }
 
 .admin-nav-group > .w3-dropdown-content .w3-bar-item {
@@ -511,28 +1151,13 @@
 }
 
 @media (max-width: 600px) {
-  /* Top-level admin panel: full width when hamburger opens admin-nav */
-  .admin-nav.w3-show > .w3-dropdown-content,
-  .admin-nav.w3-show:hover > .w3-dropdown-content {
-    display: block;
-    position: static !important;
-    width: 100%;
-    max-width: none;
-    min-width: 100% !important;
-    box-shadow: none;
-  }
-
-  .admin-nav > .w3-dropdown-content,
-  .admin-nav .admin-nav-group > .w3-dropdown-content {
-    width: 100%;
-    max-width: none;
-    min-width: 100% !important;
-  }
-
-  /* Subgroups collapsed by default (accordion) */
+  /* Admin accordion inside Mehr-Sheet */
   .admin-nav .admin-nav-group > .w3-dropdown-content {
     position: static !important;
     display: none !important;
+    width: 100%;
+    max-width: none;
+    min-width: 100% !important;
     box-shadow: none;
   }
 
@@ -541,7 +1166,6 @@
     display: block !important;
   }
 
-  /* No hover-open on touch devices */
   .admin-nav:hover .admin-nav-group > .w3-dropdown-content {
     display: none !important;
   }
@@ -565,11 +1189,6 @@
   .admin-nav-group > .w3-dropdown-content .w3-bar-item {
     white-space: normal;
     padding-left: 1.5em;
-  }
-
-  /* Wrench stays hidden; groups are the mobile entry */
-  .admin-nav > .w3-button.w3-hide-small {
-    display: none !important;
   }
 }
 
@@ -1821,7 +2440,7 @@ body.meld-cal-print {
   flex-wrap: wrap;
   gap: 0.5rem;
   position: sticky;
-  top: 0;
+  top: calc(var(--app-page-head-h, 0px) + var(--app-page-toolbar-h, 0px));
   z-index: 5;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
@@ -1889,11 +2508,25 @@ body.meld-cal-print {
 }
 
 /* Sortierbare Listenköpfe (MELD-96): Format + sticky beim Scrollen
-   z-index unter Nav/Admin-Dropdowns (admin-nav: 10/12), damit Menüs nicht verdeckt werden */
+   z-index unter Nav/Admin-Dropdowns (app-nav: 1000), damit Menüs nicht verdeckt werden */
+/* Listenköpfe: im Body-Scroll unter festem Chrome bei top:0 kleben */
+.admin-list-body > #listHeader,
+.admin-list-body > .list-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.admin-list-shell > #listHeader,
+.admin-list-shell > .list-header {
+  position: static;
+  top: auto;
+}
+
 #listHeader,
 .list-header {
   position: sticky;
-  top: 0;
+  top: calc(var(--app-page-head-h, 0px) + var(--app-page-toolbar-h, 0px));
   z-index: 2;
   margin: 0;
   background: #009688;
@@ -2217,6 +2850,13 @@ body.meld-cal-print {
   margin-bottom: 1.15rem;
   padding-bottom: 0.85rem;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  text-align: left;
+}
+
+.profile-hero-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: left;
 }
 
 .profile-kicker {
@@ -2225,13 +2865,15 @@ body.meld-cal-print {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   opacity: 0.65;
+  text-align: left;
 }
 
 .profile-title {
   margin: 0;
-  font-size: clamp(1.35rem, 2vw, 1.7rem);
-  font-weight: 650;
+  font-size: clamp(1.65rem, 2.8vw, 2.05rem);
+  font-weight: 700;
   line-height: 1.2;
+  text-align: left;
 }
 
 .profile-hero-actions {

--- a/termine-archiv.php
+++ b/termine-archiv.php
@@ -53,7 +53,6 @@ adminListPageBegin('Termine', $title);
 $chunk = listChunkTermine('past', 'basic', '', 50, isset($user) ? (int)$user : (int)$_SESSION['userid']);
 adminListSearchField('Termine suchen (Titel, Ort, Datum, Beschreibung)…', array(
     'onkeyup' => 'filterTermine()',
-    'label' => 'Termine suchen',
 ));
 ?>
 <div id="Liste">

--- a/tracking.php
+++ b/tracking.php
@@ -14,12 +14,9 @@ $termin->load_by_id($_POST['termin']);
 <script src="<?php echo assetUrl('js/getStatus.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/track.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/meldeshift.js'); ?>"></script>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-         <h2>Anwesenheitsliste - <?php echo $termin->Name." (".germanDate($termin->Datum, 1).")"; ?></h2>
-</div>
 <?php
+adminListPageBegin('Anwesenheit', 'Anwesenheitsliste — '.$termin->Name.' ('.germanDate($termin->Datum, 1).')');
 echo $termin->TrackingTable();
-?>
-<?php
+adminListPageEnd();
 include "common/footer.php";
 ?>

--- a/user-voice.php
+++ b/user-voice.php
@@ -63,10 +63,8 @@ foreach($voices as $uv) {
 }
 
 include 'common/header.php';
+adminListPageBegin('Stimme', 'Stimme / Fallbacks — '.$target->Vorname.' '.$target->Nachname);
 ?>
-<div class="w3-container <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-  <h2>Stimme / Fallbacks — <?php echo htmlspecialchars($target->Vorname.' '.$target->Nachname, ENT_QUOTES, 'UTF-8'); ?></h2>
-</div>
 <div class="w3-panel w3-mobile w3-center w3-col s3 l4"></div>
 <div class="w3-card <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?> w3-mobile w3-center w3-border w3-padding w3-col s6 l4">
 <?php echo renderFlashHtml(); ?>
@@ -119,4 +117,7 @@ function addFallbackRow() {
   container.appendChild(clone);
 }
 </script>
-<?php include 'common/footer.php'; ?>
+<?php
+adminListPageEnd();
+include 'common/footer.php';
+?>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -30,7 +30,7 @@ $sections[] = array(
     'title' => 'Einführung',
     'body' => '
 <p>Die Meldeliste ist die zentrale Plattform für Termine, Rückmeldungen und (je nach Rechten) Verwaltung im Verein.</p>
-<p>Oben in der Navigation erreichst du die Bereiche, die für dich freigeschaltet sind. Diese Hilfe zeigt nur Abschnitte, die zu deinen aktuellen Rechten passen.</p>
+<p>Über die Navigation erreichst du die Bereiche, die für dich freigeschaltet sind: auf breiten Bildschirmen links mit Text, auf dem Smartphone unten als Leiste (weitere Einträge und Admin unter <b>Mehr</b>). Diese Hilfe zeigt nur Abschnitte, die zu deinen aktuellen Rechten passen.</p>
 <p>Bitte melde dich möglichst vollständig zu Terminen an (ja / nein / vielleicht) – das erleichtert die Planung enorm.</p>
 '
 );
@@ -39,6 +39,7 @@ $sections[] = array(
     'id' => 'navigation',
     'title' => 'Navigation',
     'body' => '
+<p>Auf dem Desktop steht die Navigation links (Icons mit Beschriftung). Auf dem Smartphone unten; unter <b>Mehr</b> findest du weitere Einträge, Admin und Ausloggen.</p>
 <ul class="help-list">
 <li><i class="far fa-calendar-alt"></i> <b>Termine</b> – bevorstehende Termine und schnelles Melden</li>
 <li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details); Info-Button für Abo-Link, Drucken für alle kommenden Termine als Tabelle</li>
@@ -49,7 +50,7 @@ $sections[] = array(
 <li><i class="fas fa-photo-film"></i> <b>Medien</b> – Links zu Aufnahmen und Social Media (konfigurierbar)</li>
 <li>Logo oben rechts – öffnet die <b>Vereinshomepage</b> in einem neuen Tab</li>
 <li><i class="fas fa-circle-question"></i> <b>Hilfe</b> – diese Seite inkl. Changelog</li>
-'.(isAdmin() ? '<li><i class="fas fa-wrench"></i> <b>Admin</b> – Verwaltungsmenü in der Reihenfolge Personen → Termine → Meldungen → Kommunikation → Inventar → Register → System; Einträge sind in denselben Farben wie die Rechte-Chips eingefärbt</li>' : '').'
+'.(isAdmin() ? '<li><i class="fas fa-wrench"></i> <b>Admin</b> – Verwaltungsmenü in der Reihenfolge Personen → Termine → Meldungen → Kommunikation → Inventar → Register → System; Einträge sind in denselben Farben wie die Rechte-Chips eingefärbt (Desktop links unten, mobil unter Mehr)</li>' : '').'
 <li><i class="fas fa-sign-out-alt"></i> <b>Ausloggen</b> – Sitzung beenden</li>
 </ul>
 '

--- a/views/profile/layout_a.php
+++ b/views/profile/layout_a.php
@@ -17,9 +17,10 @@ elseif(!$fill) {
 else {
     $profileKicker = 'Nutzer bearbeiten';
 }
-$profileHeroClass = !empty($_SESSION['adminpage'])
-    ? adminHeroClass(array('kicker' => $profileKicker, 'permKey' => 'perm_editUsers'))
-    : 'profile-hero';
+$profileHeroClass = adminHeroClass(array(
+    'kicker' => $profileKicker,
+    'permKey' => 'perm_editUsers',
+));
 ?>
 <div class="profile-shell profile-layout-a">
   <form class="profile-form" action="<?php echo htmlspecialchars($formAction, ENT_QUOTES, 'UTF-8'); ?>" method="POST">


### PR DESCRIPTION
## Summary
- App-Navigation: Sidebar ab Desktop, Bottom-Nav mobil (Icons, Mehr-Sheet)
- Listen-Chrome: Titel (+ Suche) fest; Inhalt scrollt mit kurzem Fade darunter
- Hero/Nav-Farben aus Rechte-Gruppen; User-Seiten auf `adminListPageBegin`
- Suche ohne sichtbare Labels; Orchester unter der Suchleiste

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-139

## Test plan
- [ ] Desktop: linke Nav mit Gruppenfarben, aktiver Eintrag
- [ ] Mobil: untere Nav gleich große Zellen, Mehr-Sheet mit Labels
- [ ] Termine: Hero bündig wie Hilfe; Suche fest; Liste scrollt mit Fade
- [ ] Musiker/Register: Suche unter Titel, Orchester darunter
- [ ] Hilfe ohne Suche: Hero-Stil wie Termine


Made with [Cursor](https://cursor.com)