### PR TITLE
MELD-145: Einheitliche Melde-Buttons und Kapazität links

### DIFF
--- a/libs/termin.php
+++ b/libs/termin.php
@@ -1824,6 +1824,7 @@ class Termin
             $str .= '</form>';
         }
 
+        $str .= $this->makeListMetaHtml($user);
         if(!$this->Shifts) {
             $str .= '<div class="melde-btns">';
             if($this->Capacity) {
@@ -1839,7 +1840,6 @@ class Termin
             }
             $str .= '</div>';
         }
-        $str .= $this->makeListMetaHtml($user);
         $str .= '</div>'; // melde-actions
         $str .= '</div>'; // melde-row-main
 
@@ -1892,6 +1892,9 @@ class Termin
                 }
                 $str .= '</div>';
                 $str .= '<div class="melde-actions">';
+                if($s->Bedarf) {
+                    $str .= '<div class="melde-meta"><i class="fas fa-user-friends" aria-hidden="true"></i> '.$h($s->getResponseString()).'</div>';
+                }
                 $str .= '<div class="melde-btns">';
                 if($s->Bedarf) {
                     if($s->Bedarf > $s->getMeldungenVal(1) || $m->Wert == 1 || requirePermission('perm_editResponse')) {
@@ -1905,9 +1908,6 @@ class Termin
                     $str .= $this->makeShiftButtonsUser(3, 0, $s->Index, $m->Wert, $user, true);
                 }
                 $str .= '</div>';
-                if($s->Bedarf) {
-                    $str .= '<div class="melde-meta"><i class="fas fa-user-friends" aria-hidden="true"></i> '.$h($s->getResponseString()).'</div>';
-                }
                 $str .= '</div>';
                 $str .= '</div>';
             }

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2791,20 +2791,25 @@ body.meld-cal-print {
 }
 
 .calendar-melde-modal .melde-btns--modal {
-  flex: 1 1 auto;
+  flex: 0 0 auto;
+  width: auto;
   max-width: none;
-  width: 100%;
   gap: 0.5rem;
+  justify-content: flex-start;
 }
 
 .calendar-melde-modal .melde-btns--modal .melde-btn {
+  width: 3.1rem;
+  min-width: 3.1rem;
   min-height: 2.75rem;
   font-size: 1.15rem;
-  padding: 0.45rem 0.55rem !important;
+  padding: 0.45rem 0.2rem !important;
 }
 
 @media (max-width: 600px) {
   .calendar-melde-modal .melde-btns--modal .melde-btn {
+    width: 3.25rem;
+    min-width: 3.25rem;
     min-height: 3rem;
   }
 }
@@ -3639,19 +3644,23 @@ select.profile-control {
 
 .melde-btns {
   display: flex;
-  flex: 1 1 8rem;
+  flex: 0 0 auto;
   flex-wrap: nowrap;
   align-items: stretch;
+  justify-content: flex-end;
   gap: 0.4rem;
   min-width: 0;
-  max-width: 16rem;
+  width: auto;
+  max-width: none;
 }
 
 .melde-btn {
-  flex: 1 1 0;
-  min-width: 2.6rem;
+  flex: 0 0 auto;
+  box-sizing: border-box;
+  width: 2.85rem;
+  min-width: 2.85rem;
   min-height: 2.6rem;
-  padding: 0.35rem 0.45rem !important;
+  padding: 0.35rem 0.2rem !important;
   margin: 0 !important;
   font-size: 1.05rem;
   line-height: 1;
@@ -3765,15 +3774,17 @@ select.profile-control {
 
   .melde-actions {
     grid-column: 1 / -1;
-    justify-content: stretch;
+    justify-content: flex-end;
   }
 
   .melde-btns {
-    flex: 1 1 100%;
-    max-width: none;
+    flex: 0 0 auto;
+    width: auto;
   }
 
   .melde-btn {
+    width: 3rem;
+    min-width: 3rem;
     min-height: 2.85rem;
   }
 }


### PR DESCRIPTION
## Summary
- Melde-Buttons haben feste Größe (Kapazität mit 2 Buttons wirkt wie normale Termine)
- Kapazitäts-/Bedarfsinfo steht links neben den Meldebuttons (Liste und Schichten)

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-145

## Test plan
- [ ] Termin mit Kapazität: Ja/Nein gleiche Buttonbreite wie bei normalen Terminen
- [ ] Kapazitätsanzeige (z. B. 3 / 10) links der Buttons
- [ ] Schicht mit Bedarf: Info ebenfalls links der Buttons
- [ ] Kalender-Melde-Modal: Buttons nicht gestreckt