### PR TITLE
MELD-147: Overlay-Kollisionen und Termin-Löschen-Modal

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -111,10 +111,6 @@ button.w3-button.meld-cal-nav-icon {
   padding-left: 0;
   padding-right: 0;
 }
-#calSubscribeModal .w3-modal-content {
-  max-width: 36rem;
-  margin: 4vh auto;
-}
 </style>
 
 <div class="meld-cal-page">
@@ -181,16 +177,27 @@ if($showCalendarSubscribe) {
     $n = $calUser;
     $calendarSubscribeUid = 'page-cal';
     $calendarSubscribeInModal = true;
+    ob_start();
 ?>
 <div id="calSubscribeModal" class="w3-modal" role="dialog" aria-modal="true" aria-labelledby="calSubscribeModalTitle" style="display:none;"
      onclick="if(event.target===this){ this.style.display='none'; }">
-  <div class="w3-modal-content w3-card">
-    <header class="w3-container <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorTitleBar'], ENT_QUOTES, 'UTF-8'); ?>">
-      <button type="button" class="w3-button w3-display-topright" id="calSubscribeClose" aria-label="Schließen">&times;</button>
-      <h2 id="calSubscribeModalTitle"><i class="fas fa-calendar-plus" aria-hidden="true"></i> Persönlichen Kalender abonnieren</h2>
-    </header>
-    <div class="w3-container w3-padding">
+  <div class="w3-modal-content">
+    <div class="profile-shell modal-shell calendar-subscribe-modal">
+      <header class="profile-hero">
+        <div class="profile-hero-text">
+          <p class="profile-kicker">Kalender</p>
+          <h2 class="profile-title" id="calSubscribeModalTitle">Persönlichen Kalender abonnieren</h2>
+        </div>
+        <div class="profile-hero-actions">
+          <button type="button" class="modal-close w3-button" id="calSubscribeClose" aria-label="Schließen">&times;</button>
+        </div>
+      </header>
+      <div class="termin-grid">
+        <section class="profile-col" aria-labelledby="cal-subscribe-links">
+          <h3 id="cal-subscribe-links" class="profile-col-title">Abo-Link</h3>
 <?php include __DIR__.'/views/calendar/subscribe.php'; ?>
+        </section>
+      </div>
     </div>
   </div>
 </div>
@@ -210,6 +217,7 @@ if($showCalendarSubscribe) {
 })();
 </script>
 <?php
+    deferPageModalHtml(ob_get_clean());
 }
 
 include 'common/footer.php';

--- a/common/footer.php
+++ b/common/footer.php
@@ -1,5 +1,12 @@
 </div><!-- .app-main -->
 </div><!-- .app-shell -->
+<?php
+/* Page-local modals must live outside .app-main (overflow/z-index stacking). */
+if(!empty($GLOBALS['mlDeferredPageModals'])) {
+    echo $GLOBALS['mlDeferredPageModals'];
+    unset($GLOBALS['mlDeferredPageModals']);
+}
+?>
 <div id="ajaxModalHost" class="w3-modal" onclick="if(event.target===this)closeModal();">
   <div id="ajaxModalContent" class="w3-modal-content"></div>
 </div>

--- a/common/nav.php
+++ b/common/nav.php
@@ -281,6 +281,9 @@ if(!empty($optionsDB['showMessageOfTheDay'])) {
     <i class="fas fa-exclamation-triangle"></i>
   </div>
 </div>
+<?php
+    ob_start();
+?>
 <div id="MessageOfTheDay" class="w3-modal">
   <div class="w3-modal-content">
     <div class="w3-container">
@@ -291,11 +294,13 @@ if(!empty($optionsDB['showMessageOfTheDay'])) {
   </div>
 </div>
 <?php
+    if(!isset($_SESSION['MessageOfTheDay'])) {
+        $_SESSION['MessageOfTheDay'] = true;
+?>
+<script>document.getElementById('MessageOfTheDay').style.display='block';</script>
+<?php
+    }
+    deferPageModalHtml(ob_get_clean());
 }
 ?>
 <script src="<?php echo assetUrl('js/app-nav.js'); ?>"></script>
-<?php if(!empty($optionsDB['showMessageOfTheDay']) && !isset($_SESSION['MessageOfTheDay'])) {
-    $_SESSION['MessageOfTheDay'] = true;
-?>
-<script>document.getElementById('MessageOfTheDay').style.display='block';</script>
-<?php } ?>

--- a/js/modal.js
+++ b/js/modal.js
@@ -474,13 +474,8 @@ function ensureOrchestraSeatSheet() {
         +   '<button type="button" class="w3-btn w3-border w3-border-black w3-center orchestra-seat-sheet-btn" data-wert="3" title="unsicher"><b>?</b></button>'
         + '</div>';
 
-    var host = document.getElementById('ajaxModalHost');
-    if(host) {
-        host.appendChild(sheet);
-    }
-    else {
-        document.body.appendChild(sheet);
-    }
+    // Always on body: ajaxModalHost is position:fixed + overflow and would clip/trap the sheet.
+    document.body.appendChild(sheet);
 
     function onClose(ev) {
         ev.preventDefault();
@@ -726,3 +721,26 @@ document.addEventListener('contextmenu', function(ev) {
         ev.preventDefault();
     }
 });
+
+/**
+ * MELD-147: .app-main is a stacking/overflow context (z-index:1).
+ * Page-local .w3-modal nodes must sit outside it (with ajaxModalHost) or they collide with chrome.
+ */
+function liftPageModalsOutOfAppMain() {
+    var main = document.querySelector('.app-main');
+    if(!main) return;
+    var modals = main.querySelectorAll('.w3-modal');
+    if(!modals.length) return;
+    var anchor = document.getElementById('ajaxModalHost');
+    var parent = (anchor && anchor.parentNode) ? anchor.parentNode : document.body;
+    for(var i = 0; i < modals.length; i++) {
+        if(anchor) {
+            parent.insertBefore(modals[i], anchor);
+        }
+        else {
+            parent.appendChild(modals[i]);
+        }
+    }
+}
+
+liftPageModalsOutOfAppMain();

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -302,6 +302,21 @@ function adminHeroClass($options = array()) {
  * @param string $title Page title (plain text)
  * @param array $options actionsHtml (string), shellClass (string), permKey (string), groupId (string)
  */
+/**
+ * Queue modal HTML to render outside .app-main (MELD-147).
+ * Footer echoes $GLOBALS['mlDeferredPageModals'] after .app-shell closes.
+ */
+function deferPageModalHtml($html) {
+    $html = (string)$html;
+    if($html === '') {
+        return;
+    }
+    if(!isset($GLOBALS['mlDeferredPageModals'])) {
+        $GLOBALS['mlDeferredPageModals'] = '';
+    }
+    $GLOBALS['mlDeferredPageModals'] .= $html;
+}
+
 function adminListPageBegin($kicker, $title, $options = array()) {
     $actionsHtml = isset($options['actionsHtml']) ? (string)$options['actionsHtml'] : '';
     $shellClass = isset($options['shellClass']) ? trim((string)$options['shellClass']) : '';

--- a/new-termin.php
+++ b/new-termin.php
@@ -272,33 +272,60 @@ if($fill && $n && (int)$n->Index > 0 && !empty($GLOBALS['googlemapsapi']) && ($n
 </div>
 </div>
 
-<?php if($fill && $n && (int)$n->Index > 0) { ?>
-<div id="delmodal" class="w3-modal">
-  <div class="w3-modal-content w3-card">
-    <header class="w3-container w3-row <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
-      <span onclick="document.getElementById('delmodal').style.display='none'"
-      class="w3-button w3-display-topright">&times;</span>
-      <h2>L&ouml;schen best&auml;tigen</h2>
-    </header>
-    <div class="w3-container w3-row w3-center w3-padding w3-margin w3-card <?php echo $GLOBALS['optionsDB']['colorWarning']; ?>">Sind Sie sicher, dass sie <b><?php echo htmlspecialchars($n->Name.' ('.germanDate($n->Datum,1).')', ENT_QUOTES, 'UTF-8'); ?></b> l&ouml;schen wollen?</div>
-    <div class="w3-container w3-mobile">
-      <form action="index.php" method="POST">
-        <input type="hidden" name="Index" value="<?php echo (int)$n->Index; ?>">
-        <div class="w3-row">
-          <div class="w3-col l4 m4 s2 w3-center">&nbsp;</div>
-          <button class="w3-btn w3-col l4 m4 s8 w3-center <?php echo htmlspecialchars($btnSubmit, ENT_QUOTES, 'UTF-8'); ?> w3-border w3-margin-bottom w3-mobile" type="submit" name="delete" value="delete">ja</button>
-          <div class="w3-col l4 m4 s2 w3-center">&nbsp;</div>
+<?php if($fill && $n && (int)$n->Index > 0) {
+    $delName = htmlspecialchars($n->Name.' ('.germanDate($n->Datum, 1).')', ENT_QUOTES, 'UTF-8');
+    ob_start();
+?>
+<div id="delmodal" class="w3-modal" role="dialog" aria-modal="true" aria-labelledby="delmodalTitle" style="display:none;"
+     onclick="if(event.target===this){ this.style.display='none'; }">
+  <div class="w3-modal-content">
+    <div class="profile-shell modal-shell confirm-delete-modal">
+      <header class="profile-hero">
+        <div class="profile-hero-text">
+          <p class="profile-kicker">Termin</p>
+          <h2 class="profile-title" id="delmodalTitle">Löschen bestätigen</h2>
         </div>
-      </form>
-      <div class="w3-row">
-        <div class="w3-col l4 m4 s2 w3-center">&nbsp;</div>
-        <button class="w3-btn w3-col l4 m4 s8 w3-center <?php echo htmlspecialchars($btnSubmit, ENT_QUOTES, 'UTF-8'); ?> w3-border w3-margin-bottom w3-mobile" onclick="document.getElementById('delmodal').style.display='none'">nein</button>
-        <div class="w3-col l4 m4 s2 w3-center">&nbsp;</div>
+        <div class="profile-hero-actions">
+          <button type="button" class="modal-close w3-button" id="delmodalClose" aria-label="Schließen">&times;</button>
+        </div>
+      </header>
+      <div class="termin-grid">
+        <section class="profile-col" aria-labelledby="delmodal-body">
+          <h3 id="delmodal-body" class="profile-col-title">Bestätigung</h3>
+          <p class="profile-value">
+            Soll <b><?php echo $delName; ?></b> wirklich gelöscht werden?
+          </p>
+          <div class="profile-actions profile-actions--confirm">
+            <div class="profile-actions-primary">
+              <form action="index.php" method="POST">
+                <input type="hidden" name="Index" value="<?php echo (int)$n->Index; ?>">
+                <button class="w3-btn profile-btn-primary <?php echo htmlspecialchars($btnDelete, ENT_QUOTES, 'UTF-8'); ?> w3-border w3-mobile" type="submit" name="delete" value="delete">Löschen</button>
+              </form>
+            </div>
+            <button type="button" class="w3-btn w3-border w3-mobile" id="delmodalCancel">Abbrechen</button>
+          </div>
+        </section>
       </div>
     </div>
   </div>
 </div>
-<?php } ?>
+<script>
+(function() {
+  var modal = document.getElementById('delmodal');
+  if(!modal) return;
+  function closeDel() { modal.style.display = 'none'; }
+  var closeBtn = document.getElementById('delmodalClose');
+  var cancelBtn = document.getElementById('delmodalCancel');
+  if(closeBtn) closeBtn.addEventListener('click', closeDel);
+  if(cancelBtn) cancelBtn.addEventListener('click', closeDel);
+  document.addEventListener('keydown', function(e) {
+    if(e.key === 'Escape' && modal.style.display === 'block') closeDel();
+  });
+})();
+</script>
+<?php
+    deferPageModalHtml(ob_get_clean());
+} ?>
 
 <script type="text/javascript">
 function endToggle() {

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -3093,6 +3093,34 @@ body.meld-cal-print {
   z-index: 2000;
 }
 
+/* MELD-147: Kalender-Abo-Modal (rendered outside .app-main via footer) */
+#calSubscribeModal .w3-modal-content {
+  max-width: 36rem;
+  margin: 4vh auto;
+}
+
+#calSubscribeModal .calendar-subscribe-modal {
+  margin: 0.75rem;
+}
+
+/* Confirm-delete modals (Termin etc.) */
+#delmodal .w3-modal-content {
+  max-width: 32rem;
+  margin: 8vh auto;
+}
+
+.confirm-delete-modal .profile-actions--confirm {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: 1rem;
+}
+
+.confirm-delete-modal .profile-actions--confirm .profile-actions-primary {
+  margin: 0;
+}
+
 /* Keep modal content in the safe viewport (notches + breathing room) */
 @media (max-width: 600px) {
   .w3-modal {


### PR DESCRIPTION
## Summary
- Seiten-lokale Modals außerhalb von `.app-main` (`deferPageModalHtml`, Footer)
- Message of the Day und Kalender-Abo deferred; Safety-Net `liftPageModalsOutOfAppMain`
- Orchester-Sitz-Sheet an `document.body`
- Termin-Löschen im Profile-Shell-Modal-Design

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-147

## Test plan
- [ ] Kalender → Info: Abo-Overlay deckt Seite/Nav sauber ab
- [ ] MOTD (falls aktiv): Overlay nicht in der Seitenkarte geklemmt
- [ ] Termin bearbeiten → Löschen: modernes Modal, Abbrechen/Löschen
- [ ] Musiker/Schicht-Löschen-Dialoge (Lift) ohne Kollision
- [ ] Termin-Modal Orchester-Longpress Sheet über allem