### PR TITLE
MELD-147: Kalender-Abo-Modal und Meldezeilen-Opazität

### DIFF
--- a/config/ConfigDefaults.php
+++ b/config/ConfigDefaults.php
@@ -231,7 +231,7 @@ function getConfigDefaults() {
             'Parameter' => 'meldeRowResponseOpacity',
             'Value' => '0.55',
             'Type' => 'string',
-            'Description' => 'Opazit&auml;t der Meldezeilen-Hintergrundfarbe bei vorhandener Meldung (0–1; 1 = volle Farbe)',
+            'Description' => 'Opazit&auml;t der Meldezeilen-Hintergrundfarbe (0–1; auch ohne Meldung; 1 = volle Farbe)',
         ),
         array(
             'Parameter' => 'showOrchestraView',

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -1692,17 +1692,6 @@ class Termin
         $str=$str.$admStatusDiv->print();
         return $str;
     }
-    protected function hasMeldeResponseTint() {
-        if($this->globalShiftColor()) {
-            return true;
-        }
-        if(!$this->Shifts) {
-            $w = (int)$this->Wert;
-            return ($w === 1 || $w === 2 || $w === 3);
-        }
-        return false;
-    }
-
     /**
      * Resolve hex for a config color CSS class (cfg-hex-… or legacy w3-*).
      * @param string $colorClass
@@ -1737,6 +1726,26 @@ class Termin
         return max(0.0, min(1.0, $opacity));
     }
 
+    /**
+     * Soft response tint via CSS vars (meldeRowResponseOpacity), or empty if full opacity / unknown color.
+     * @return array{0:string,1:string} [extraClass, styleAttrIncludingLeadingSpace]
+     */
+    protected function meldeSoftTintAttrs($colorClass) {
+        $opacity = $this->meldeRowResponseOpacity();
+        if($opacity >= 0.999) {
+            return array('', '');
+        }
+        $hex = $this->resolveMeldeColorHex($colorClass);
+        if($hex === '') {
+            return array('', '');
+        }
+        $fg = hexContrastTextOnFill($hex, $opacity);
+        $style = ' style="--melde-response-opacity:'.$opacity
+            .';--melde-response-bg:'.$hex
+            .';--melde-response-fg:'.$fg.'"';
+        return array('melde-row--responded', $style);
+    }
+
     public function getLineColor($val) {
         $c="";
         switch($val) {
@@ -1759,11 +1768,9 @@ class Termin
             return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
         };
 
+        $isShifts = (bool)$this->Shifts;
         $classes = array('melde-row', 'w3-card-4', 'w3-margin');
         $mainColor = $this->mainColor();
-        if($mainColor) {
-            $classes[] = $mainColor;
-        }
         $mainHover = $this->mainHover();
         if($mainHover) {
             $classes[] = $mainHover;
@@ -1772,18 +1779,29 @@ class Termin
             $classes[] = $GLOBALS['optionsDB']['styleAppmntUnpublished'];
         }
 
+        /*
+         * Soft tint must REPLACE the solid color class: cfg-hex-* uses
+         * background !important and would sit under the 0.55 overlay (= wrong opacity).
+         * Schichten: tint only header + shift lines, never the whole card.
+         */
         $styleAttr = '';
-        if($this->hasMeldeResponseTint()) {
-            $opacity = $this->meldeRowResponseOpacity();
-            if($opacity < 0.999) {
-                $hex = $this->resolveMeldeColorHex($mainColor);
-                if($hex !== '') {
-                    $classes[] = 'melde-row--responded';
-                    $fg = hexContrastTextOnFill($hex, $opacity);
-                    $styleAttr = ' style="--melde-response-opacity:'.$opacity
-                        .';--melde-response-bg:'.$hex
-                        .';--melde-response-fg:'.$fg.'"';
-                }
+        $mainSoftClass = '';
+        $mainSoftStyle = '';
+        if(!$isShifts) {
+            list($tintClass, $tintStyle) = $this->meldeSoftTintAttrs($mainColor);
+            if($tintClass !== '') {
+                $classes[] = $tintClass;
+                $styleAttr = $tintStyle;
+            }
+            elseif($mainColor) {
+                $classes[] = $mainColor;
+            }
+        }
+        else {
+            list($mainSoftClass, $mainSoftStyle) = $this->meldeSoftTintAttrs($mainColor);
+            if($mainSoftClass === '' && $mainColor) {
+                $mainSoftClass = $mainColor;
+                $mainSoftStyle = '';
             }
         }
 
@@ -1792,13 +1810,12 @@ class Termin
         if($lineHover) {
             $rowClasses[] = $lineHover;
         }
-        $shiftColor = $this->globalShiftColor();
-        if($shiftColor) {
-            $rowClasses[] = $shiftColor;
+        if($isShifts && $mainSoftClass !== '') {
+            $rowClasses[] = $mainSoftClass;
         }
 
         $str = '<div id="entry'.$tid.'_user'.$user.'" class="'.implode(' ', $classes).'"'.$styleAttr.' data-termin-id="'.$tid.'" '.$this->getSearchDataAttr().'>';
-        $str .= '<div class="'.implode(' ', $rowClasses).'">';
+        $str .= '<div class="'.implode(' ', $rowClasses).'"'.$mainSoftStyle.'>';
         $str .= '<div class="melde-date-col">'.$this->makeListDateInfo().'</div>';
         $str .= '<div class="melde-date-rail" aria-hidden="true"></div>';
 
@@ -1880,11 +1897,19 @@ class Termin
 
                 $shiftClasses = array('melde-shift');
                 $shiftClasses[] = $GLOBALS['optionsDB']['HoverEffect'];
+                $shiftStyleAttr = '';
                 $lc = $this->getLineColor($m->Wert);
                 if($lc) {
-                    $shiftClasses[] = $lc;
+                    list($tintClass, $tintStyle) = $this->meldeSoftTintAttrs($lc);
+                    if($tintClass !== '') {
+                        $shiftClasses[] = $tintClass;
+                        $shiftStyleAttr = $tintStyle;
+                    }
+                    else {
+                        $shiftClasses[] = $lc;
+                    }
                 }
-                $str .= '<div class="'.implode(' ', array_filter($shiftClasses)).'" data-melde-stop>';
+                $str .= '<div class="'.implode(' ', array_filter($shiftClasses)).'"'.$shiftStyleAttr.' data-melde-stop>';
                 $str .= '<div class="melde-shift-info">';
                 $str .= '<div class="melde-shift-name">'.$h($s->Name).'</div>';
                 if($s->Start != $s->End) {

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -3093,20 +3093,80 @@ body.meld-cal-print {
   z-index: 2000;
 }
 
-/* MELD-147: Kalender-Abo-Modal (rendered outside .app-main via footer) */
-#calSubscribeModal .w3-modal-content {
-  max-width: 36rem;
+/* Page-local profile-shell modals (outside .app-main): same chrome as #ajaxModalContent */
+#calSubscribeModal .w3-modal-content,
+#delmodal .w3-modal-content {
+  background: transparent;
+  box-shadow: none;
+  width: auto !important;
+  max-width: min(36rem, calc(100vw - 1.5rem));
   margin: 4vh auto;
 }
 
-#calSubscribeModal .calendar-subscribe-modal {
-  margin: 0.75rem;
+#delmodal .w3-modal-content {
+  max-width: min(32rem, calc(100vw - 1.5rem));
+  margin: 8vh auto;
 }
 
-/* Confirm-delete modals (Termin etc.) */
-#delmodal .w3-modal-content {
-  max-width: 32rem;
-  margin: 8vh auto;
+#calSubscribeModal .calendar-subscribe-modal,
+#delmodal .confirm-delete-modal {
+  margin: 0.75rem;
+  background: #fff;
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+}
+
+.calendar-subscribe-block .profile-field {
+  margin-bottom: 0.85rem;
+}
+
+.calendar-subscribe-url {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  font-size: 0.88rem;
+  line-height: 1.35;
+  word-break: break-all;
+}
+
+.calendar-subscribe-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 0.5rem;
+  margin: 0.35rem 0 0.25rem;
+}
+
+.calendar-subscribe-actions .profile-actions-primary {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: min(100%, 11rem);
+  margin: 0;
+}
+
+.calendar-subscribe-actions .profile-actions-primary .w3-btn,
+.calendar-subscribe-actions > .w3-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 2.6rem;
+  margin: 0 !important;
+  padding: 0.5rem 0.9rem;
+  font-size: 0.95rem;
+  line-height: 1.25;
+  box-sizing: border-box;
+  white-space: nowrap;
+}
+
+.calendar-subscribe-actions > .w3-btn {
+  flex: 1 1 auto;
+  min-width: min(100%, 11rem);
+}
+
+.calendar-subscribe-block .profile-inline-link {
+  margin-top: 0.65rem;
+  margin-bottom: 0;
 }
 
 .confirm-delete-modal .profile-actions--confirm {
@@ -3119,6 +3179,19 @@ body.meld-cal-print {
 
 .confirm-delete-modal .profile-actions--confirm .profile-actions-primary {
   margin: 0;
+}
+
+@media (max-width: 600px) {
+  #calSubscribeModal .calendar-subscribe-modal,
+  #delmodal .confirm-delete-modal {
+    margin: 0.35rem 0.5rem;
+  }
+
+  .calendar-subscribe-actions .profile-actions-primary,
+  .calendar-subscribe-actions > .w3-btn {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
 }
 
 /* Keep modal content in the safe viewport (notches + breathing room) */
@@ -3514,14 +3587,21 @@ select.profile-control {
   position: relative;
 }
 
-/* Soften response tint (config: meldeRowResponseOpacity) without fading buttons/text */
-.melde-row.melde-row--responded {
+/* Soften tint (config: meldeRowResponseOpacity) without fading buttons/text.
+   Beat cfg-hex-* background !important — solid color class must not be combined. */
+.melde-row.melde-row--responded,
+.melde-row-main.melde-row--responded,
+.melde-shift.melde-row--responded {
+  background: transparent !important;
   background-color: transparent !important;
   color: var(--melde-response-fg, inherit) !important;
   isolation: isolate;
+  position: relative;
 }
 
-.melde-row.melde-row--responded::before {
+.melde-row.melde-row--responded::before,
+.melde-row-main.melde-row--responded::before,
+.melde-shift.melde-row--responded::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -3532,7 +3612,9 @@ select.profile-control {
   opacity: var(--melde-response-opacity, 1);
 }
 
-.melde-row.melde-row--responded > * {
+.melde-row.melde-row--responded > *,
+.melde-row-main.melde-row--responded > *,
+.melde-shift.melde-row--responded > * {
   position: relative;
   z-index: 1;
 }
@@ -3776,6 +3858,8 @@ select.profile-control {
   padding: 0.65rem 1rem;
   border-top: 1px solid rgba(255, 255, 255, 0.65);
   cursor: default;
+  position: relative;
+  overflow: hidden;
 }
 
 .melde-shift-info {

--- a/views/calendar/subscribe.php
+++ b/views/calendar/subscribe.php
@@ -20,12 +20,17 @@ if($calendarHttps === '') {
     return;
 }
 $uid = isset($calendarSubscribeUid) ? (string)$calendarSubscribeUid : 'cal-sub';
+$uidEsc = htmlspecialchars($uid, ENT_QUOTES, 'UTF-8');
 $inModal = !empty($calendarSubscribeInModal);
 $quiet = !empty($calendarSubscribeQuiet) || $inModal;
+$inputBg = htmlspecialchars($GLOBALS['optionsDB']['colorInputBackground'], ENT_QUOTES, 'UTF-8');
+$btnSubmit = htmlspecialchars($GLOBALS['optionsDB']['colorBtnSubmit'], ENT_QUOTES, 'UTF-8');
 if(!$inModal) {
 ?>
-<div class="w3-panel w3-border w3-padding w3-margin-top <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorInputBackground'], ENT_QUOTES, 'UTF-8'); ?>">
+<div class="w3-panel w3-border w3-padding w3-margin-top calendar-subscribe-block <?php echo $inputBg; ?>">
   <h3><i class="fas fa-calendar-plus" aria-hidden="true"></i> Persönlichen Kalender abonnieren</h3>
+<?php } else { ?>
+<div class="calendar-subscribe-block calendar-subscribe-block--modal">
 <?php } ?>
 <?php if(!$quiet) { ?>
   <p class="w3-small">
@@ -34,22 +39,32 @@ if(!$inModal) {
     Zu- und Absagen weiterhin hier in der Meldeliste.
   </p>
 <?php } ?>
-  <p class="w3-small w3-break">
-    <label for="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-https"><b>HTTPS</b></label><br>
-    <input id="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-https" class="w3-input w3-border" type="text" readonly value="<?php echo htmlspecialchars($calendarHttps, ENT_QUOTES, 'UTF-8'); ?>">
-  </p>
-  <p class="w3-small w3-break">
-    <label for="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-webcal"><b>webcal</b></label><br>
-    <input id="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-webcal" class="w3-input w3-border" type="text" readonly value="<?php echo htmlspecialchars($calendarWebcal, ENT_QUOTES, 'UTF-8'); ?>">
-  </p>
-  <p class="w3-margin-top">
-    <button type="button" class="w3-button w3-border <?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnSubmit'], ENT_QUOTES, 'UTF-8'); ?>" data-copy-target="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-https">HTTPS kopieren</button>
-    <button type="button" class="w3-button w3-border" data-copy-target="<?php echo htmlspecialchars($uid, ENT_QUOTES, 'UTF-8'); ?>-webcal">webcal kopieren</button>
-  </p>
-  <p class="w3-small"><a href="help.php#help-kalender-abo">Hilfe: Kalender</a></p>
-<?php if(!$inModal) { ?>
+  <div class="profile-field">
+    <label class="profile-label" for="<?php echo $uidEsc; ?>-https">HTTPS</label>
+    <input id="<?php echo $uidEsc; ?>-https"
+           class="w3-input w3-border profile-control calendar-subscribe-url <?php echo $inputBg; ?>"
+           type="text" readonly
+           value="<?php echo htmlspecialchars($calendarHttps, ENT_QUOTES, 'UTF-8'); ?>">
+  </div>
+  <div class="profile-field">
+    <label class="profile-label" for="<?php echo $uidEsc; ?>-webcal">webcal</label>
+    <input id="<?php echo $uidEsc; ?>-webcal"
+           class="w3-input w3-border profile-control calendar-subscribe-url <?php echo $inputBg; ?>"
+           type="text" readonly
+           value="<?php echo htmlspecialchars($calendarWebcal, ENT_QUOTES, 'UTF-8'); ?>">
+  </div>
+  <div class="profile-actions calendar-subscribe-actions">
+    <div class="profile-actions-primary">
+      <button type="button"
+              class="w3-btn profile-btn-primary <?php echo $btnSubmit; ?> w3-border"
+              data-copy-target="<?php echo $uidEsc; ?>-https">HTTPS kopieren</button>
+    </div>
+    <button type="button"
+            class="w3-btn w3-border"
+            data-copy-target="<?php echo $uidEsc; ?>-webcal">webcal kopieren</button>
+  </div>
+  <p class="profile-inline-link"><a href="help.php#help-kalender-abo">Hilfe: Kalender</a></p>
 </div>
-<?php } ?>
 <script>
 (function () {
   document.querySelectorAll('[data-copy-target]').forEach(function (btn) {


### PR DESCRIPTION
## Summary
- Kalender-Abo-Modal: abgerundete Shell, Profile-Felder und abgestimmte Copy-Buttons
- Meldezeilen-Opazität auch ohne Meldung und bei Schichten; Soft-Tint ersetzt Solid-`cfg-hex` (keine Doppeldeckung)

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-147

## Test plan
- [ ] Kalender → Info: Modal mit Ecken, URL-Felder und Buttons einheitlich
- [ ] index.php: Zeilen ohne Meldung mit konfigurierter Opazität
- [ ] Schicht-Termine: Header und Schichtzeilen korrekt transparent, nicht doppelt
- [ ] Ja/Nein/Vielleicht weiterhin korrekte Soft-Tint-Farbe