### PR TITLE
MELD-147: Kalender-Abo Desktop-Layout und Admin-Menü offen halten

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -192,11 +192,9 @@ if($showCalendarSubscribe) {
           <button type="button" class="modal-close w3-button" id="calSubscribeClose" aria-label="Schließen">&times;</button>
         </div>
       </header>
-      <div class="termin-grid">
-        <section class="profile-col" aria-labelledby="cal-subscribe-links">
-          <h3 id="cal-subscribe-links" class="profile-col-title">Abo-Link</h3>
+      <div class="calendar-subscribe-body">
+        <h3 class="profile-col-title">Abo-Link</h3>
 <?php include __DIR__.'/views/calendar/subscribe.php'; ?>
-        </section>
       </div>
     </div>
   </div>

--- a/common/nav.php
+++ b/common/nav.php
@@ -163,7 +163,7 @@ if(requirePermission('perm_editConfig')) {
           <div class="app-nav-admin-title"><i class="fas fa-wrench" aria-hidden="true"></i><span class="nav-label">Admin</span></div>
           <div class="w3-bar-block <?php echo $navAdminColor; ?>">
 <?php if($showPersonen) { ?>
-            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group<?php echo adminNavGroupActiveClass(array('musiker', 'gastmusiker', 'users', 'mitglied', 'nomitglied', 'register', 'newmusiker')); ?>">
               <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_showUsers'); ?>">Personen <i class="fas fa-caret-right admin-nav-caret"></i></button>
               <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
                 <a title="Musikerliste" href="musiker.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('musiker', 'perm_showUsers'); ?>"><i class="fas fa-users"></i> Musikerliste</a>
@@ -183,7 +183,7 @@ if(requirePermission('perm_editConfig')) {
             </div>
 <?php } ?>
 <?php if($showTermine) { ?>
-            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group<?php echo adminNavGroupActiveClass(array('newtermin', 'termine-archiv', 'shifts')); ?>">
               <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_editAppmnts'); ?>">Termine <i class="fas fa-caret-right admin-nav-caret"></i></button>
               <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
                 <a title="Termin erstellen" href="new-termin.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('newtermin', 'perm_editAppmnts'); ?>"><i class="fas fa-plus-circle"></i> Termin erstellen</a>
@@ -192,7 +192,7 @@ if(requirePermission('perm_editConfig')) {
             </div>
 <?php } ?>
 <?php if($showMeldungen) { ?>
-            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group<?php echo adminNavGroupActiveClass(array('meldungen', 'archiv', 'public-entry')); ?>">
               <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_showResponse'); ?>">Meldungen <i class="fas fa-caret-right admin-nav-caret"></i></button>
               <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
                 <a title="Meldungen" href="meldungen.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('meldungen', 'perm_showResponse'); ?>"><i class="fas fa-comment-dots"></i> Meldungen</a>
@@ -204,7 +204,7 @@ if(requirePermission('perm_editConfig')) {
             </div>
 <?php } ?>
 <?php if($showKommunikation) { ?>
-            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group<?php echo adminNavGroupActiveClass(array('mail', 'groups')); ?>">
               <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_sendEmail'); ?>">Kommunikation <i class="fas fa-caret-right admin-nav-caret"></i></button>
               <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
                 <a title="Email versenden" href="mail.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('mail', 'perm_sendEmail'); ?>"><i class="fas fa-envelope-open-text"></i> Email versenden</a>
@@ -213,7 +213,7 @@ if(requirePermission('perm_editConfig')) {
             </div>
 <?php } ?>
 <?php if($showInventar) { ?>
-            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group<?php echo adminNavGroupActiveClass(array('inventories', 'newinventory', 'inventory-types')); ?>">
               <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_showInventories'); ?>">Inventar <i class="fas fa-caret-right admin-nav-caret"></i></button>
               <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
 <?php if(requirePermission('perm_showInventories')) { ?>
@@ -227,7 +227,7 @@ if(requirePermission('perm_editConfig')) {
             </div>
 <?php } ?>
 <?php if($showRegister) { ?>
-            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group<?php echo adminNavGroupActiveClass(array('register-types', 'instrument-types')); ?>">
               <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_editRegisters'); ?>">Register <i class="fas fa-caret-right admin-nav-caret"></i></button>
               <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
                 <a title="Register" href="register-types.php" class="w3-bar-item w3-button w3-mobile <?php getAdminPagePerm('register-types', 'perm_editRegisters'); ?>"><i class="fas fa-layer-group"></i> Register</a>
@@ -236,7 +236,7 @@ if(requirePermission('perm_editConfig')) {
             </div>
 <?php } ?>
 <?php if($showSystem) { ?>
-            <div class="w3-dropdown-hover w3-mobile admin-nav-group">
+            <div class="w3-dropdown-hover w3-mobile admin-nav-group<?php echo adminNavGroupActiveClass(array('permissions', 'config', 'evaluate', 'log', 'backup', 'updater')); ?>">
               <button type="button" class="w3-button w3-mobile w3-block w3-left-align <?php echo adminNavPermClass('perm_editConfig'); ?>">System <i class="fas fa-caret-right admin-nav-caret"></i></button>
               <div class="w3-dropdown-content w3-bar-block w3-card-4 <?php echo $navAdminColor; ?> w3-mobile">
 <?php if(requirePermission('perm_editPermissions')) { ?>

--- a/js/app-nav.js
+++ b/js/app-nav.js
@@ -1,13 +1,26 @@
 (function () {
+  function isNarrow() {
+    return window.matchMedia && window.matchMedia('(max-width: 600px)').matches;
+  }
+
+  /** Close open admin accordion groups; on desktop keep the active-page section open. */
   function resetAdminNavGroups() {
     var groups = document.querySelectorAll('.admin-nav-group.admin-nav-open');
     for (var i = 0; i < groups.length; i++) {
-      groups[i].classList.remove('admin-nav-open');
+      var g = groups[i];
+      if (!isNarrow() && g.classList.contains('admin-nav-current-group')) {
+        continue;
+      }
+      g.classList.remove('admin-nav-open');
     }
   }
 
-  function isNarrow() {
-    return window.matchMedia && window.matchMedia('(max-width: 600px)').matches;
+  function ensureCurrentAdminNavOpen() {
+    if (isNarrow()) return;
+    var cur = document.querySelector('.admin-nav-group.admin-nav-current-group');
+    if (cur) {
+      cur.classList.add('admin-nav-open');
+    }
   }
 
   function setMoreOpen(open) {
@@ -20,16 +33,13 @@
     }
     panel.classList.toggle('is-open', !!open);
     if (backdrop) {
-      if (open) {
-        backdrop.hidden = false;
-      } else {
-        backdrop.hidden = true;
-      }
+      backdrop.hidden = !open;
     }
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
     document.body.classList.toggle('app-nav-more-open', !!open);
     if (!open) {
       resetAdminNavGroups();
+      ensureCurrentAdminNavOpen();
     }
   }
 
@@ -62,8 +72,10 @@
     window.addEventListener('resize', function () {
       if (!isNarrow()) {
         setMoreOpen(false);
+        ensureCurrentAdminNavOpen();
       }
     });
+    ensureCurrentAdminNavOpen();
   }
 
   document.addEventListener('click', function (ev) {
@@ -73,10 +85,19 @@
     if (!group || !group.classList || !group.classList.contains('admin-nav-group')) return;
     ev.preventDefault();
     ev.stopPropagation();
-    var open = group.classList.contains('admin-nav-open');
-    resetAdminNavGroups();
-    if (!open) {
+
+    var willOpen = !group.classList.contains('admin-nav-open');
+    var others = document.querySelectorAll('.admin-nav-group.admin-nav-open');
+    for (var i = 0; i < others.length; i++) {
+      var g = others[i];
+      if (g === group) continue;
+      if (!isNarrow() && g.classList.contains('admin-nav-current-group')) continue;
+      g.classList.remove('admin-nav-open');
+    }
+    if (willOpen) {
       group.classList.add('admin-nav-open');
+    } else {
+      group.classList.remove('admin-nav-open');
     }
   });
 

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -212,6 +212,27 @@ function getAdminPagePerm($page, $permKey) {
 }
 
 /**
+ * Desktop sidebar: keep the admin accordion section open when one of its pages is active.
+ * @param string|string[] $pages $_SESSION['page'] values belonging to this group
+ * @return string CSS classes (leading space) or ''
+ */
+function adminNavGroupActiveClass($pages) {
+    if(empty($_SESSION['adminpage'])) {
+        return '';
+    }
+    $current = isset($_SESSION['page']) ? (string)$_SESSION['page'] : '';
+    if($current === '') {
+        return '';
+    }
+    foreach((array)$pages as $p) {
+        if((string)$p === $current) {
+            return ' admin-nav-open admin-nav-current-group';
+        }
+    }
+    return '';
+}
+
+/**
  * CSS-Klassen für Nav anhand der Rechte-Farbgruppe (wie Admin-Nav / Chips).
  * @param string $groupId nutzer|termine|register|inventar|kommunikation|system
  * @return string

--- a/new-termin.php
+++ b/new-termin.php
@@ -289,22 +289,19 @@ if($fill && $n && (int)$n->Index > 0 && !empty($GLOBALS['googlemapsapi']) && ($n
           <button type="button" class="modal-close w3-button" id="delmodalClose" aria-label="Schließen">&times;</button>
         </div>
       </header>
-      <div class="termin-grid">
-        <section class="profile-col" aria-labelledby="delmodal-body">
-          <h3 id="delmodal-body" class="profile-col-title">Bestätigung</h3>
-          <p class="profile-value">
-            Soll <b><?php echo $delName; ?></b> wirklich gelöscht werden?
-          </p>
-          <div class="profile-actions profile-actions--confirm">
-            <div class="profile-actions-primary">
-              <form action="index.php" method="POST">
-                <input type="hidden" name="Index" value="<?php echo (int)$n->Index; ?>">
-                <button class="w3-btn profile-btn-primary <?php echo htmlspecialchars($btnDelete, ENT_QUOTES, 'UTF-8'); ?> w3-border w3-mobile" type="submit" name="delete" value="delete">Löschen</button>
-              </form>
-            </div>
-            <button type="button" class="w3-btn w3-border w3-mobile" id="delmodalCancel">Abbrechen</button>
+      <div class="confirm-delete-body">
+        <p class="profile-value">
+          Soll <b><?php echo $delName; ?></b> wirklich gelöscht werden?
+        </p>
+        <div class="profile-actions profile-actions--confirm">
+          <div class="profile-actions-primary">
+            <form action="index.php" method="POST">
+              <input type="hidden" name="Index" value="<?php echo (int)$n->Index; ?>">
+              <button class="w3-btn profile-btn-primary <?php echo htmlspecialchars($btnDelete, ENT_QUOTES, 'UTF-8'); ?> w3-border w3-mobile" type="submit" name="delete" value="delete">Löschen</button>
+            </form>
           </div>
-        </section>
+          <button type="button" class="w3-btn w3-border w3-mobile" id="delmodalCancel">Abbrechen</button>
+        </div>
       </div>
     </div>
   </div>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -3113,60 +3113,101 @@ body.meld-cal-print {
   margin: 0.75rem;
   background: #fff;
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
+  width: auto;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
-.calendar-subscribe-block .profile-field {
-  margin-bottom: 0.85rem;
-}
-
-.calendar-subscribe-url {
+.calendar-subscribe-body,
+.confirm-delete-body {
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
-  font-size: 0.88rem;
+}
+
+.calendar-subscribe-block {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.calendar-subscribe-block .profile-field {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: 0.85rem;
+  box-sizing: border-box;
+}
+
+.calendar-subscribe-block .profile-label {
+  display: block;
+}
+
+.calendar-subscribe-url {
+  display: block;
+  width: 100% !important;
+  max-width: 100%;
+  box-sizing: border-box;
+  font-size: 0.9rem;
   line-height: 1.35;
-  word-break: break-all;
 }
 
 .calendar-subscribe-actions {
   display: flex;
   flex-wrap: wrap;
   align-items: stretch;
-  gap: 0.5rem;
+  gap: 0.55rem;
   margin: 0.35rem 0 0.25rem;
+  width: 100%;
 }
 
 .calendar-subscribe-actions .profile-actions-primary {
   display: flex;
-  flex: 1 1 auto;
-  min-width: min(100%, 11rem);
+  flex: 1 1 12rem;
+  min-width: 0;
   margin: 0;
 }
 
+.calendar-subscribe-actions .profile-actions-primary form {
+  display: flex;
+  width: 100%;
+}
+
+/* Override .modal-shell … width:auto !important so copy buttons fill the row */
+.modal-shell .calendar-subscribe-actions .profile-actions-primary .w3-btn,
+.modal-shell .calendar-subscribe-actions > .w3-btn,
 .calendar-subscribe-actions .profile-actions-primary .w3-btn,
 .calendar-subscribe-actions > .w3-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex: 1 1 auto;
-  width: 100%;
-  min-height: 2.6rem;
+  width: 100% !important;
+  min-width: 0;
+  min-height: 2.65rem;
   margin: 0 !important;
-  padding: 0.5rem 0.9rem;
+  padding: 0.55rem 1rem;
   font-size: 0.95rem;
   line-height: 1.25;
   box-sizing: border-box;
   white-space: nowrap;
+  overflow: visible;
 }
 
 .calendar-subscribe-actions > .w3-btn {
-  flex: 1 1 auto;
-  min-width: min(100%, 11rem);
+  flex: 1 1 12rem;
 }
 
 .calendar-subscribe-block .profile-inline-link {
-  margin-top: 0.65rem;
+  display: block;
+  margin-top: 0.75rem;
   margin-bottom: 0;
+  white-space: normal;
+}
+
+.calendar-subscribe-block .profile-inline-link a {
+  display: inline;
+  white-space: nowrap;
 }
 
 .confirm-delete-modal .profile-actions--confirm {
@@ -3190,7 +3231,6 @@ body.meld-cal-print {
   .calendar-subscribe-actions .profile-actions-primary,
   .calendar-subscribe-actions > .w3-btn {
     flex: 1 1 100%;
-    min-width: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- Kalender-Abo-Modal: einspaltig volle Breite (kein `termin-grid` mit 2–4 Spalten)
- Copy-Buttons und URL-Felder füllen die Modalbreite
- Desktop-Admin-Nav: Sektion der aktiven Seite bleibt aufgeklappt

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-147

## Test plan
- [ ] Kalender → Info (Desktop): Felder/Buttons volle Breite, Text lesbar
- [ ] Admin-Seite z. B. Musikerliste: „Personen“ ist aufgeklappt
- [ ] Andere Admin-Sektion öffnen: aktive Sektion bleibt sichtbar
- [ ] Mobil: Admin-Akkordeon weiterhin manuell bedienbar