### PR TITLE
MELD-145: Mein Inventar Nav, Leihe und Listen-Layout

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -39,7 +39,7 @@ $yearTo = min(2100, max($calYear, (int)date('Y')) + 10);
 .meld-cal-page {
   max-width: 72rem;
   margin: 0 auto;
-  padding: 0 16px 1rem;
+  padding: 0 0 1rem;
   box-sizing: border-box;
   width: 100%;
 }

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -338,6 +338,12 @@ function deferPageModalHtml($html) {
     $GLOBALS['mlDeferredPageModals'] .= $html;
 }
 
+/**
+ * Start list page shell (hero in sticky chrome).
+ * Content after this (or after an optional toolbar/search) goes into padded .admin-list-body.
+ *
+ * @param array $options actionsHtml, shellClass, groupId, permKey
+ */
 function adminListPageBegin($kicker, $title, $options = array()) {
     $actionsHtml = isset($options['actionsHtml']) ? (string)$options['actionsHtml'] : '';
     $shellClass = isset($options['shellClass']) ? trim((string)$options['shellClass']) : '';
@@ -363,29 +369,54 @@ function adminListPageBegin($kicker, $title, $options = array()) {
     }
     echo '    </header>'."\n";
     $GLOBALS['mlAdminListChrome'] = 'open';
+    $GLOBALS['mlAdminListBody'] = null;
+    /* Buffer until Search/ChromeClose/End so content lands in padded body */
+    ob_start();
+    $GLOBALS['mlAdminListCapturing'] = true;
+}
+
+/**
+ * Flush chrome capture buffer into open chrome (toolbar etc.), then stop capturing.
+ */
+function adminListFlushChromeCapture() {
+    if(empty($GLOBALS['mlAdminListCapturing'])) {
+        return '';
+    }
+    $chunk = ob_get_clean();
+    $GLOBALS['mlAdminListCapturing'] = false;
+    return ($chunk === false) ? '' : $chunk;
 }
 
 /**
  * Close open app-page-chrome and open scrollable body (after search or before other content).
+ *
+ * @param bool $captureToBody true = buffered content belongs in body (End without toolbar)
  */
-function adminListChromeClose() {
-    if(!empty($GLOBALS['mlAdminListChrome']) && $GLOBALS['mlAdminListChrome'] === 'open') {
-        echo '    </div><!-- .app-page-chrome -->'."\n";
-        echo '    <div class="admin-list-body">'."\n";
-        $GLOBALS['mlAdminListChrome'] = 'closed';
-        $GLOBALS['mlAdminListBody'] = 'open';
+function adminListChromeClose($captureToBody = false) {
+    if(empty($GLOBALS['mlAdminListChrome']) || $GLOBALS['mlAdminListChrome'] !== 'open') {
         return;
+    }
+    $chunk = adminListFlushChromeCapture();
+    if(!$captureToBody && $chunk !== '') {
+        echo $chunk;
+        $chunk = '';
+    }
+    echo '    </div><!-- .app-page-chrome -->'."\n";
+    echo '    <div class="admin-list-body">'."\n";
+    $GLOBALS['mlAdminListChrome'] = 'closed';
+    $GLOBALS['mlAdminListBody'] = 'open';
+    if($captureToBody && $chunk !== '') {
+        echo $chunk;
     }
 }
 
 /** Close adminListPageBegin(). */
 function adminListPageEnd() {
     if(!empty($GLOBALS['mlAdminListChrome']) && $GLOBALS['mlAdminListChrome'] === 'open') {
-        /* Kein Search/ChromeClose: Inhalt liegt im Chrome — nur Chrome schließen */
-        echo '    </div><!-- .app-page-chrome -->'."\n";
-        $GLOBALS['mlAdminListChrome'] = 'closed';
+        /* Kein Search/ChromeClose: Capture → Body mit Seiten-Gutter */
+        adminListChromeClose(true);
     }
-    elseif(!empty($GLOBALS['mlAdminListBody']) && $GLOBALS['mlAdminListBody'] === 'open') {
+    if(!empty($GLOBALS['mlAdminListBody']) && $GLOBALS['mlAdminListBody'] === 'open') {
         echo '    </div><!-- .admin-list-body -->'."\n";
         $GLOBALS['mlAdminListBody'] = 'closed';
     }
@@ -408,6 +439,10 @@ function adminListSearchField($placeholder, $options = array()) {
     $aria = isset($options['ariaLabel']) && (string)$options['ariaLabel'] !== ''
         ? (string)$options['ariaLabel']
         : (string)$placeholder;
+    $pre = adminListFlushChromeCapture();
+    if($pre !== '') {
+        echo $pre;
+    }
     echo '    <div class="admin-list-toolbar">'."\n";
     echo '      <div class="profile-field admin-list-search">'."\n";
     echo '        <input type="search" id="'.htmlspecialchars($id, ENT_QUOTES, 'UTF-8').'"'
@@ -424,7 +459,7 @@ function adminListSearchField($placeholder, $options = array()) {
         echo '      <div class="admin-list-toolbar-extra">'.$extra.'</div>'."\n";
     }
     echo '    </div>'."\n";
-    adminListChromeClose();
+    adminListChromeClose(false);
 }
 
 function getNextRegInventoryNumber($inventoryTypeId = 0) {

--- a/libs/inventories.php
+++ b/libs/inventories.php
@@ -345,12 +345,27 @@ class Inventories
         if($insured) {
             $classes[] = 'inv-row--insured';
         }
+        $viewerId = isset($_SESSION['userid']) ? (int)$_SESSION['userid'] : 0;
+        $loanedToViewer = false;
+        if($viewerId > 0 && (int)$this->Owner !== $viewerId) {
+            $activeLoanId = $this->getActiveLoan();
+            if($activeLoanId) {
+                $activeLoan = new InventoriesLoan;
+                $activeLoan->load_by_id($activeLoanId);
+                $loanedToViewer = ((int)$activeLoan->User === $viewerId);
+            }
+        }
+        if($loanedToViewer) {
+            $classes[] = 'inv-row--loaned';
+            $searchParts[] = 'geliehen ausleihe';
+        }
         $hover = $GLOBALS['optionsDB']['HoverEffect'];
         if($hover) {
             $classes[] = $hover;
         }
 
         $attrs = 'data-insured="'.($insured ? '1' : '0').'"'
+            .' data-loaned="'.($loanedToViewer ? '1' : '0').'"'
             .' data-sort-regnumber="'.$h((string)(int)$row['RegNumber']).'"'
             .' data-sort-typ="'.$h($typLabel).'"'
             .' data-sort-description="'.$h($desc).'"'
@@ -373,6 +388,9 @@ class Inventories
         $str .= '<div class="inv-typ">'.$h($typLabel).'</div>';
         if($insured) {
             $str .= '<span class="mail-recipient-chip mail-recipient-chip--insured">versichert</span>';
+        }
+        if($loanedToViewer) {
+            $str .= '<span class="mail-recipient-chip mail-recipient-chip--loaned">geliehen</span>';
         }
         $str .= '</div>';
         $str .= '<div class="inv-rail" aria-hidden="true"></div>';
@@ -398,7 +416,11 @@ class Inventories
         if($comment !== '') {
             $meta[] = '<span class="inv-meta-item"><span class="inv-meta-k">Kommentar</span> '.$h($comment).'</span>';
         }
-        if($loanShort !== '' || $loanDate !== '') {
+        if($loanedToViewer) {
+            $loanLabel = $loanDate !== '' ? 'seit '.$h($loanDate) : 'aktiv';
+            $meta[] = '<span class="inv-meta-item"><span class="inv-meta-k">Ausleihe</span> '.$loanLabel.'</span>';
+        }
+        elseif($loanShort !== '' || $loanDate !== '') {
             $loanBits = array();
             if($loanShort !== '') {
                 $loanBits[] = $h($loanShort);
@@ -610,20 +632,14 @@ class Inventories
     }
 
     public function getActiveLoan() {
-        $loans = $this->getLoans();
-        if($loans) {
+        foreach($this->getLoans() as $loanId) {
             $l = new InventoriesLoan;
-            $l->load_by_id($loans[0]);
-            
-            if($l->EndDate) {
-                $end = new DateTime($l->EndDate);
-                $now = new DateTime(date("Y-m-d"));
-                if($end > $now) return $loans[0];
-            }
-            else {
-                return $loans[0];
+            $l->load_by_id($loanId);
+            if($l->isActive()) {
+                return (int)$loanId;
             }
         }
+        return null;
     }
 
     /**

--- a/libs/inventoriesLoan.php
+++ b/libs/inventoriesLoan.php
@@ -197,5 +197,27 @@ class InventoriesLoan
         $u->load_by_id($this->User);
         return $u->getName();
     }
+
+    /**
+     * Offene/aktive Leihe: kein EndDate oder Rückgabe liegt in der Zukunft.
+     * (EndDate = heute oder früher = beendet)
+     */
+    public static function isOpen($endDate) {
+        if($endDate === null || $endDate === '' || $endDate === '0000-00-00') {
+            return true;
+        }
+        try {
+            $end = new DateTime((string)$endDate);
+            $now = new DateTime(date('Y-m-d'));
+            return $end > $now;
+        }
+        catch(Exception $e) {
+            return false;
+        }
+    }
+
+    public function isActive() {
+        return self::isOpen($this->EndDate);
+    }
 };
 ?>

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -1769,7 +1769,7 @@ class Termin
         };
 
         $isShifts = (bool)$this->Shifts;
-        $classes = array('melde-row', 'w3-card-4', 'w3-margin');
+        $classes = array('melde-row', 'w3-card-4');
         $mainColor = $this->mainColor();
         $mainHover = $this->mainHover();
         if($mainHover) {

--- a/libs/user.php
+++ b/libs/user.php
@@ -678,9 +678,21 @@ class User
     }
 
     public function getInventoriesLoans() {
-        $sql = sprintf('SELECT `Index` FROM `%sInventoriesLoans` WHERE `User` = %d AND `EndDate` IS NULL;',
-        $GLOBALS['dbprefix'],
-        $this->Index
+        $userId = (int)$this->Index;
+        // Owner=0 = Verein; ohne gültige User-ID darf nichts als „mein“ gelten
+        if($userId < 1) {
+            return array();
+        }
+        // Aktive Leihe (auch mit geplanter Rückgabe in der Zukunft); nur existierende Stücke
+        $sql = sprintf(
+            'SELECT l.`Index` FROM `%sInventoriesLoans` l
+             INNER JOIN `%sInventories` i ON i.`Index` = l.`Inventory`
+             WHERE l.`User` = %d
+               AND (l.`EndDate` IS NULL OR l.`EndDate` > CURDATE())
+             ORDER BY l.`StartDate` DESC;',
+            $GLOBALS['dbprefix'],
+            $GLOBALS['dbprefix'],
+            $userId
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
         sqlerror();
@@ -692,10 +704,15 @@ class User
     }
 
     public function getInventories() {
+        $userId = (int)$this->Index;
+        // Owner=0 = Verein (orgNameShort); nie mit „persönlichem“ Eigentum verwechseln
+        if($userId < 1) {
+            return array();
+        }
         $sql = sprintf(
             'SELECT `Index` FROM `%sInventories` WHERE `Owner` = %d',
             $GLOBALS['dbprefix'],
-            $this->Index
+            $userId
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
         sqlerror();
@@ -706,8 +723,9 @@ class User
         return $inventories;
     }
 
+    /** Eigentum oder aktive Ausleihe (geliehenes Vereinsinventar zählt). */
     public function hasInventories() {
-        return count($this->getInventoriesLoans()) + count($this->getInventories());
+        return count($this->getInventoriesLoans()) > 0 || count($this->getInventories()) > 0;
     }
     
     public function getModalHtml($forceEditButton = false) {

--- a/meine-mails.php
+++ b/meine-mails.php
@@ -83,7 +83,7 @@ adminListPageBegin('Kommunikation', 'Meine Nachrichten');
     $job->load_by_id((int)$viewMail->Job);
     $sender = htmlspecialchars($resolveSender((int)$job->CreatedBy), ENT_QUOTES, 'UTF-8');
 ?>
-<div class="w3-container w3-padding">
+<div class="w3-container">
   <div class="w3-card w3-padding">
     <h3 class="w3-margin-top"><?php echo $subj !== '' ? $subj : '<em>(ohne Betreff)</em>'; ?></h3>
     <p class="w3-small"><?php echo $when; ?> · von <?php echo $sender; ?></p>
@@ -99,8 +99,7 @@ adminListPageBegin('Kommunikation', 'Meine Nachrichten');
 </div>
 <?php } ?>
 
-<div class="w3-container w3-padding">
-  <div class="mail-list">
+<div class="mail-list">
     <div class="mail-list-header <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
       <div>Betreff</div>
       <div></div>
@@ -141,7 +140,6 @@ else {
     }
 }
 ?>
-  </div>
 </div>
 <?php
 adminListPageEnd();

--- a/myinventories.php
+++ b/myinventories.php
@@ -13,29 +13,35 @@ if(handleInventoriesMutations()) {
     redirectAfterPost('myinventories.php');
 }
 
+$u = new User;
+$u->load_by_id($_SESSION['userid']);
+if(!$u->hasInventories()) {
+    header('Location: '.$GLOBALS['optionsDB']['WebSiteURL']);
+    exit;
+}
+
 include "common/header.php";
 adminListPageBegin('Inventar', 'Mein Inventar');
 
-$u = new User;
-$u->load_by_id($_SESSION['userid']);
 $shown = array();
 $html = '';
 
-$owned = $u->getInventories();
-for($i=0; $i < count($owned); $i++) {
-    $id = (int)$owned[$i];
-    if(isset($shown[$id])) continue;
+// Zuerst aktive Leihen (typisch Vereinsinventar), dann Eigentum
+$loans = $u->getInventoriesLoans();
+for($i=0; $i < count($loans); $i++) {
+    $loan = new InventoriesLoan;
+    $loan->load_by_id($loans[$i]);
+    $id = (int)$loan->Inventory;
+    if($id < 1 || isset($shown[$id])) continue;
     $shown[$id] = true;
     $inventory = new Inventories;
     $inventory->load_by_id($id);
     $html .= $inventory->printTableLine(false);
 }
 
-$loans = $u->getInventoriesLoans();
-for($i=0; $i < count($loans); $i++) {
-    $loan = new InventoriesLoan;
-    $loan->load_by_id($loans[$i]);
-    $id = (int)$loan->Inventory;
+$owned = $u->getInventories();
+for($i=0; $i < count($owned); $i++) {
+    $id = (int)$owned[$i];
     if(isset($shown[$id])) continue;
     $shown[$id] = true;
     $inventory = new Inventories;

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -25,7 +25,7 @@ body.app-layout {
   align-items: flex-start;
   justify-content: center;
   gap: 0.15rem;
-  padding: 0.5rem 4.5rem 0.5rem 1rem;
+  padding: 0.5rem 5rem 0.5rem 1rem;
   min-height: 0;
   overflow: hidden;
   box-sizing: border-box;
@@ -52,15 +52,17 @@ body.app-layout {
 
 .app-titlebar-logo {
   position: absolute;
-  top: 50%;
+  top: 0.35rem;
+  bottom: 0.35rem;
   right: 0.65rem;
-  transform: translateY(-50%);
-  height: 2.75rem;
+  height: auto;
   width: auto;
-  max-height: 2.75rem;
-  max-width: 3.5rem;
+  max-height: none;
+  max-width: min(4.5rem, 22vw);
+  aspect-ratio: 1;
   display: block;
   object-fit: contain;
+  box-sizing: border-box;
 }
 
 a.app-titlebar-logo {
@@ -70,10 +72,10 @@ a.app-titlebar-logo {
 }
 
 .app-titlebar-logo img {
-  height: 2.75rem;
-  width: auto;
-  max-height: 2.75rem;
-  max-width: 3.5rem;
+  height: 100%;
+  width: 100%;
+  max-height: 100%;
+  max-width: 100%;
   display: block;
   object-fit: contain;
 }
@@ -91,18 +93,15 @@ a.app-titlebar-logo {
 
 @media (max-width: 600px) {
   .app-titlebar {
-    padding-right: 3.75rem;
+    padding-right: 4rem;
   }
 
   .app-titlebar-name {
     font-size: 1.4rem;
   }
 
-  .app-titlebar-logo,
-  .app-titlebar-logo img {
-    height: 2.25rem;
-    max-height: 2.25rem;
-    max-width: 2.75rem;
+  .app-titlebar-logo {
+    max-width: min(3.25rem, 28vw);
   }
 }
 
@@ -289,6 +288,18 @@ a.app-titlebar-logo {
 .admin-list-shell > .app-page-chrome > .perm-toolbar {
   margin-left: 1.25rem;
   margin-right: 1.25rem;
+}
+
+/* Listeninhalt: seitlich wie Suchleiste — kein Extra von .w3-margin */
+.admin-list-body .w3-margin {
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.admin-list-body #Liste > [id^="responseLine"],
+.admin-list-body #Liste > .w3-card {
+  margin-top: 0.65rem !important;
+  margin-bottom: 0 !important;
 }
 
 /* Seiten ohne Body (Hilfe, …): Chrome padded, Hero negativ zurück auf Kanten */
@@ -2092,6 +2103,11 @@ a.app-titlebar-logo {
   border-color: #7f9dc1;
 }
 
+.mail-recipient-chip--loaned {
+  background: #fff3e0;
+  border-color: #ffb74d;
+}
+
 .mail-recipient-chip--audience,
 .mail-recipient-chip--group {
   background: #345a95;
@@ -3625,6 +3641,9 @@ select.profile-control {
   overflow: hidden;
   cursor: pointer;
   position: relative;
+  /* Horizontal wie Suchleiste (.admin-list-body Padding); nur vertikaler Abstand */
+  margin: 0 0 0.65rem;
+  box-sizing: border-box;
 }
 
 /* Soften tint (config: meldeRowResponseOpacity) without fading buttons/text.
@@ -3683,9 +3702,9 @@ select.profile-control {
   max-width: var(--melde-date-col-w);
   min-width: 0;
   box-sizing: border-box;
-  align-self: center;
+  align-self: start;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   overflow: hidden;
 }
 
@@ -3701,7 +3720,7 @@ select.profile-control {
 
 .melde-date {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.5rem;
   line-height: 1.2;
   min-width: 0;
@@ -3950,8 +3969,12 @@ select.profile-control {
 .inv-sort-bar {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.45rem 0.65rem;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   padding: 0.4rem 0 0.7rem;
   margin: 0 0 0.35rem;
   background: transparent;
@@ -3971,7 +3994,7 @@ select.profile-control {
 .admin-list-shell > #listHeader.inv-sort-bar {
   position: sticky;
   top: 0;
-  background: transparent;
+  background: #fff;
   color: inherit;
   font-weight: 400;
   box-shadow: none;
@@ -3981,26 +4004,31 @@ select.profile-control {
   padding: 0.4rem 0 0.7rem;
 }
 
+#listHeader.inv-sort-bar > .inv-sort-bar-filters,
+#listHeader.inv-sort-bar > .inv-sort-bar-sorts {
+  padding-top: 0;
+  padding-bottom: 0;
+  border: none;
+  color: inherit;
+}
+
 .inv-sort-bar-filters,
 .inv-sort-bar-sorts {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.35rem;
   min-width: 0;
   max-width: 100%;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
-  padding-bottom: 0.1rem;
+  box-sizing: border-box;
 }
 
 .inv-sort-bar-filters {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
 }
 
 .inv-sort-bar-sorts {
-  flex: 1 1 auto;
+  flex: 1 1 14rem;
 }
 
 .inv-sort-chip {
@@ -4184,11 +4212,13 @@ select.profile-control {
 
   .inv-sort-bar-filters,
   .inv-sort-bar-sorts {
+    flex: 1 1 auto;
     width: 100%;
   }
 
   .inv-sort-chip {
-    padding: 0.32rem 0.6rem;
+    padding: 0.32rem 0.55rem;
+    font-size: clamp(0.68rem, 0.6rem + 0.5vw, 0.82rem);
   }
 
   .inv-row {

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -45,7 +45,7 @@ $sections[] = array(
 <li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details); Info-Button für Abo-Link, Drucken für alle kommenden Termine als Tabelle</li>
 <li><i class="fas fa-envelope"></i> <b>Meine Nachrichten</b> – empfangene Mails aus der Meldeliste (Badge bei ungelesenen)</li>
 <li><i class="fas fa-users"></i> <b>Mein Register</b> – Rückmeldungen deines Registers (auf dem Smartphone dauerhaft in der unteren Leiste)</li>
-'.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir zugeordnetes bzw. ausgeliehenes Inventar</li>' : '').'
+'.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir gehörendes oder an dich ausgeliehenes Inventar</li>' : '').'
 <li><i class="fas fa-user"></i> <b>Mein Profil</b> – eigene Stammdaten und Einstellungen (Desktop in der Seitenleiste, Smartphone unter <b>Mehr</b>)</li>
 <li><i class="fas fa-photo-film"></i> <b>Medien</b> – Links zu Aufnahmen und Social Media (konfigurierbar)</li>
 <li>Logo oben rechts – öffnet die <b>Vereinshomepage</b> in einem neuen Tab</li>
@@ -101,8 +101,8 @@ if($helpUser->hasInventories()) {
         'id' => 'mein-inventar',
         'title' => 'Mein Inventar',
         'body' => '
-<p>Wenn dir Inventar gehört oder an dich ausgeliehen ist, erscheint <b>Mein Inventar</b> in der Navigation.</p>
-<p>Dort siehst du deine Stücke (Instrumente, Kleidung, …) als Liste bzw. auf dem Handy als Karten – mit Nr., Typ, Hersteller und Modell; eine Beschreibung erscheint nur, wenn sie hinterlegt ist. Ein Tippen/Klick öffnet die Details im Modal. Bearbeiten ist nur möglich, wenn du die entsprechenden Rechte hast bzw. für dein eigenes Inventar freigegeben bist.</p>
+<p>Wenn dir Inventar gehört <b>oder an dich ausgeliehen</b> ist (aktive Leihe), erscheint <b>Mein Inventar</b> in der Navigation.</p>
+<p>Dort siehst du zuerst geliehene Stücke (Chip „geliehen“), danach eigenes Eigentum – als Liste bzw. auf dem Handy als Karten mit Nr., Typ, Hersteller und Modell. Ein Tippen/Klick öffnet die Details im Modal. Bearbeiten ist nur möglich, wenn du die entsprechenden Rechte hast.</p>
 '
     );
 }


### PR DESCRIPTION
## Summary
- Mein Inventar in der Nav nur bei Eigentum oder aktiver Leihe (auch geplante Rückgabe); geliehene Stücke zuerst mit Chip „geliehen“
- Einheitliches seitliches Listen-Gutter (admin-list-body) inkl. Seiten ohne Suche; Inventar-Sortierchips umbrechend
- Logo skaliert im Header; Termin-Datum oben links; kleine Layout-Fixes (Kalender/Mails)

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-145

## Test plan
- [ ] User ohne Eigentum/Leihe: kein „Mein Inventar“ in der Nav
- [ ] User mit offener Leihe: Nav sichtbar, Liste zeigt geliehene Stücke mit Chip
- [ ] Inventar-Admin: Sortierchips umbrechen auf schmalem Viewport
- [ ] Hauptseite: Datum oben links in Terminzeile; Seitenabstand wie Suchleiste