### PR TITLE
MELD-150: Inventar-Labels oben links ausrichten

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -4112,7 +4112,7 @@ select.profile-control {
   max-width: var(--inv-id-col-w);
   min-width: 0;
   box-sizing: border-box;
-  align-self: center;
+  align-self: start;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -4150,7 +4150,7 @@ select.profile-control {
 
 .inv-main {
   min-width: 0;
-  align-self: center;
+  align-self: start;
 }
 
 .inv-product {


### PR DESCRIPTION
## Summary
- Inventar-Zeilen: Nr./Typ und Hauptinhalt oben links statt vertikal zentriert (`align-self: start`)
- Analog zu den Termin-Daten in der Meldeliste

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-150

## Test plan
- [ ] Inventarliste öffnen (Admin / Mein Inventar)
- [ ] Mehrzeilige Einträge: Labels sitzen oben links, nicht mittig
- [ ] Einzeilige Einträge unverändert sauber