### PR TITLE
MELD-140: Schichten & Aufgaben, optionale Zeiten, Tabellen-Editor

### DIFF
--- a/config/DBconfig.json
+++ b/config/DBconfig.json
@@ -152,7 +152,7 @@
 	"Index": {"Type": "int", "Extra": "AUTO_INCREMENT"},
 	"Termin": {"Type": "int"},
 	"Name": {"Type": "text", "Collation": "utf8mb4_unicode_ci"},
-	"Start": {"Type": "time"},
+	"Start": {"Type": "time", "Null": "YES"},
 	"End": {"Type": "time", "Null": "YES"},
 	"Bedarf": {"Type": "int"}
     },

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -3,5 +3,5 @@
  * Expected DB schema version number (MELD-51).
  * Bump when DBconfig.json, DatabaseManager migrations, or ConfigDefaults.php change.
  */
-return 22;
+return 23;
 ?>

--- a/edit-shifts.php
+++ b/edit-shifts.php
@@ -20,7 +20,7 @@ elseif(isset($_POST['Termin'])) {
     $terminId = (int)$_POST['Termin'];
 }
 
-if(isset($_POST['save']) || isset($_POST['delete'])) {
+if(isset($_POST['save_all']) || isset($_POST['delete'])) {
     if($terminId < 1) {
         setFlash('error', 'Kein Termin angegeben.');
         redirectAfterPost('index.php');
@@ -31,18 +31,83 @@ if(isset($_POST['save']) || isset($_POST['delete'])) {
         setFlash('error', 'Termin nicht gefunden.');
         redirectAfterPost('index.php');
     }
-    if(isset($_POST['save'])) {
-        $s = new Shift;
-        $s->load_by_id($_POST['save']);
-        $s->fill_from_array($_POST);
-        $s->save();
-        setFlash('success', 'Schicht gespeichert.');
+    if(isset($_POST['save_all'])) {
+        $rows = (isset($_POST['shifts']) && is_array($_POST['shifts'])) ? $_POST['shifts'] : array();
+        $saved = 0;
+        $created = 0;
+        $errors = 0;
+        foreach($rows as $key => $row) {
+            if(!is_array($row)) {
+                continue;
+            }
+            $name = isset($row['Name']) ? trim((string)$row['Name']) : '';
+            $isNew = ($key === 'new' || strpos((string)$key, 'new_') === 0);
+            if($isNew) {
+                if($name === '') {
+                    continue;
+                }
+                $s = new Shift;
+                $s->Termin = $terminId;
+                $s->Name = $name;
+                $s->Start = isset($row['Start']) ? $row['Start'] : '';
+                $s->End = isset($row['End']) ? $row['End'] : '';
+                $s->Bedarf = isset($row['Bedarf']) ? $row['Bedarf'] : 0;
+                if($s->save() === false || (int)$s->Index < 1) {
+                    $errors++;
+                    continue;
+                }
+                $created++;
+                continue;
+            }
+            $id = (int)$key;
+            if($id < 1) {
+                continue;
+            }
+            if($name === '') {
+                $errors++;
+                continue;
+            }
+            $s = new Shift;
+            $s->load_by_id($id);
+            if(!(int)$s->Index || (int)$s->Termin !== $terminId) {
+                $errors++;
+                continue;
+            }
+            $s->Name = $name;
+            $s->Start = isset($row['Start']) ? $row['Start'] : '';
+            $s->End = isset($row['End']) ? $row['End'] : '';
+            $s->Bedarf = isset($row['Bedarf']) ? $row['Bedarf'] : 0;
+            $s->Termin = $terminId;
+            if(!$s->hasChanges()) {
+                continue;
+            }
+            if($s->save() === false) {
+                $errors++;
+                continue;
+            }
+            $saved++;
+        }
+        if($errors > 0 && ($saved + $created) === 0) {
+            setFlash('error', 'Schichten & Aufgaben konnten nicht gespeichert werden.');
+        }
+        elseif($errors > 0) {
+            setFlash('success', 'Schichten & Aufgaben teilweise gespeichert ('.$saved.' geändert, '.$created.' neu, '.$errors.' Fehler).');
+        }
+        else {
+            setFlash('success', 'Schichten & Aufgaben gespeichert'
+                .(($saved + $created) > 0 ? ' ('.$saved.' geändert, '.$created.' neu).' : '.'));
+        }
     }
     if(isset($_POST['delete'])) {
         $s = new Shift;
         $s->load_by_id($_POST['delete']);
-        $s->delete();
-        setFlash('success', 'Schicht gelöscht.');
+        if((int)$s->Index > 0 && (int)$s->Termin === $terminId) {
+            $s->delete();
+            setFlash('success', 'Schicht/Aufgabe gelöscht.');
+        }
+        else {
+            setFlash('error', 'Schicht/Aufgabe nicht gefunden.');
+        }
     }
     redirectAfterPost('edit-shifts.php?Termin='.$terminId);
 }
@@ -55,24 +120,23 @@ if($_SERVER['REQUEST_METHOD'] === 'POST' && $terminId > 0) {
 $n = new Termin;
 $n->load_by_id($terminId);
 if(!$n->Index) {
-    setFlash('error', 'Kein Termin zum Bearbeiten der Schichten.');
+    setFlash('error', 'Kein Termin zum Bearbeiten der Schichten & Aufgaben.');
     redirectAfterPost('index.php');
 }
 
 include "common/header.php";
 $shiftSub = htmlspecialchars($n->Name.' ('.germanDate($n->Datum, 1).')', ENT_QUOTES, 'UTF-8');
-adminListPageBegin('Termine', 'Schichten bearbeiten', array('permKey' => 'perm_editAppmnts'));
+adminListPageBegin('Termine', 'Schichten & Aufgaben bearbeiten', array('permKey' => 'perm_editAppmnts'));
 ?>
 <div class="admin-list-intro">
-  <p><?php echo $shiftSub; ?></p>
+  <p class="profile-value"><?php echo $shiftSub; ?></p>
 </div>
 <?php echo renderFlashHtml(); ?>
 
+<section class="shift-edit-list" aria-label="Schichten und Aufgaben">
 <?php echo $n->printShiftEdit(); ?>
-<div class="admin-list-intro w3-margin-top">
-  <p>neue Schicht anlegen</p>
-</div>
-<?php echo $n->shiftEditLine(0); ?>
+</section>
+<script src="<?php echo assetUrl('js/shiftEdit.js'); ?>"></script>
 <?php
 adminListPageEnd();
 include "common/footer.php";

--- a/evaluate.php
+++ b/evaluate.php
@@ -61,7 +61,7 @@ adminListPageBegin('System', 'Datenauswertung', array('permKey' => 'perm_showLog
   <div class="eval-charts">
     <section class="eval-panel" id="eval-attendance">
       <h3>Teilnahme über Zeit</h3>
-      <p class="w3-text-gray">Veröffentlichte Termine ohne Schichten<?php echo $besetzungOnly ? ' (nur Besetzung)' : ''; ?> der letzten <?php echo (int)$days; ?> Tage.</p>
+      <p class="w3-text-gray">Veröffentlichte Termine ohne Schichten &amp; Aufgaben<?php echo $besetzungOnly ? ' (nur Besetzung)' : ''; ?> der letzten <?php echo (int)$days; ?> Tage.</p>
       <div class="eval-chart-wrap">
         <canvas id="chartAttendance" aria-label="Teilnahme-Diagramm"></canvas>
       </div>

--- a/getModal.php
+++ b/getModal.php
@@ -69,7 +69,7 @@ case 'shiftResponse':
     $s->load_by_id($id);
     if(!(int)$s->Index) {
         http_response_code(404);
-        echo '<div class="w3-container w3-padding"><p>Schicht nicht gefunden.</p></div>';
+        echo '<div class="w3-container w3-padding"><p>Schicht/Aufgabe nicht gefunden.</p></div>';
         exit;
     }
     $t = new Termin;

--- a/js/shiftEdit.js
+++ b/js/shiftEdit.js
@@ -1,0 +1,65 @@
+(function () {
+  var form = document.querySelector('.shift-edit-form');
+  if (!form) {
+    return;
+  }
+  var tbody = form.querySelector('.shift-edit-table tbody');
+  var template = document.getElementById('shift-edit-row-template');
+  var addBtn = document.getElementById('shift-edit-add-row');
+  if (!tbody || !template) {
+    return;
+  }
+
+  function nextNewKey() {
+    var n = parseInt(form.getAttribute('data-shift-new-counter') || '1', 10);
+    if (!isFinite(n) || n < 1) {
+      n = 1;
+    }
+    form.setAttribute('data-shift-new-counter', String(n + 1));
+    return 'new_' + n;
+  }
+
+  function addRow() {
+    var key = nextNewKey();
+    var html = template.innerHTML.split('__KEY__').join(key);
+    var wrap = document.createElement('tbody');
+    wrap.innerHTML = html.trim();
+    var row = wrap.firstElementChild;
+    if (row) {
+      tbody.appendChild(row);
+      var nameInput = row.querySelector('input[name$="[Name]"]');
+      if (nameInput) {
+        nameInput.focus();
+      }
+    }
+  }
+
+  if (addBtn) {
+    addBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      addRow();
+    });
+  }
+
+  form.addEventListener('click', function (e) {
+    var clearBtn = e.target.closest('.shift-edit-clear');
+    if (clearBtn && form.contains(clearBtn)) {
+      e.preventDefault();
+      var wrap = clearBtn.closest('.shift-edit-time-wrap');
+      var input = wrap ? wrap.querySelector('input') : null;
+      if (input) {
+        input.value = '';
+        input.focus();
+      }
+      return;
+    }
+    var removeBtn = e.target.closest('.shift-edit-remove-row');
+    if (removeBtn && form.contains(removeBtn)) {
+      e.preventDefault();
+      var row = removeBtn.closest('tr.shift-edit-row--new');
+      if (row) {
+        row.remove();
+      }
+    }
+  });
+})();

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -278,7 +278,7 @@ function adminListSectionGroupId($kicker) {
         'Neuer Termin' => 'termine',
         'Termin bearbeiten' => 'termine',
         'Termin kopieren' => 'termine',
-        'Schichten bearbeiten' => 'termine',
+        'Schichten & Aufgaben bearbeiten' => 'termine',
         'Neuer Nutzer' => 'nutzer',
         'Nutzer bearbeiten' => 'nutzer',
         'Mein Profil' => 'nutzer',

--- a/libs/log.php
+++ b/libs/log.php
@@ -215,8 +215,11 @@ class Log
         $classes = trim('log-row list-row '.$hover);
         $tsRaw = (string)$this->Timestamp;
         $tsView = (string)germanDate($tsRaw, false);
-        if(strlen($tsRaw) >= 16) {
-            $tsView .= ' '.sql2timeRaw(substr($tsRaw, 11, 8));
+        if(strlen($tsRaw) >= 19) {
+            $tsView .= ' '.substr($tsRaw, 11, 8);
+        }
+        elseif(strlen($tsRaw) >= 16) {
+            $tsView .= ' '.substr($tsRaw, 11, 5);
         }
 
         echo '<div id="'.(int)$this->Index.'" class="'.htmlspecialchars($classes, ENT_QUOTES, 'UTF-8').'">';

--- a/libs/shift.php
+++ b/libs/shift.php
@@ -25,7 +25,7 @@ class Shift
             break;
 	    case 'Start':
 	    case 'End':
-            $this->_data[$key] = trim($val);
+            $this->_data[$key] = self::normalizedTime($val);
             break;
 	    case 'Name':
             $this->_data[$key] = trim((string)$val);
@@ -34,33 +34,59 @@ class Shift
             break;
         }	
     }
-    public function getChanges() {
+    /**
+     * Real field diffs vs DB row (empty = nothing changed).
+     * @return string[]
+     */
+    protected function collectChanges() {
         $old = new Shift;
         $old->load_by_id($this->Index);
+        $parts = array();
+        if((int)$this->Termin !== (int)$old->Termin) {
+            $parts[] = 'Termin: '.$old->Termin.' &rArr; <b>'.$this->Termin.'</b>';
+        }
+        if((string)$this->Name !== (string)$old->Name) {
+            $parts[] = 'Name: '.htmlspecialchars((string)$old->Name, ENT_QUOTES, 'UTF-8')
+                .' &rArr; <b>'.htmlspecialchars((string)$this->Name, ENT_QUOTES, 'UTF-8').'</b>';
+        }
+        $oldStart = self::normalizedTime($old->Start);
+        $newStart = self::normalizedTime($this->Start);
+        if($oldStart !== $newStart) {
+            $parts[] = 'Start: '.self::formatTimeLog($oldStart).' &rArr; <b>'.self::formatTimeLog($newStart).'</b>';
+        }
+        $oldEnd = self::normalizedTime($old->End);
+        $newEnd = self::normalizedTime($this->End);
+        if($oldEnd !== $newEnd) {
+            $parts[] = 'Ende: '.self::formatTimeLog($oldEnd).' &rArr; <b>'.self::formatTimeLog($newEnd).'</b>';
+        }
+        if((int)$this->Bedarf !== (int)$old->Bedarf) {
+            $parts[] = 'Bedarf: '.(int)$old->Bedarf.' &rArr; <b>'.(int)$this->Bedarf.'</b>';
+        }
+        return $parts;
+    }
 
-        $str = sprintf('Schicht: %d, Termin: <b>%d</b>, Name: <b>%s</b>',
-            (int)$this->Index,
-            (int)$this->Termin,
-            (string)$this->Name
-        );
-        if($this->Termin != $old->Termin) $str .= ', Termin: '.$old->Termin.' &rArr; <b>'.$this->Termin.'</b>';
-        if($this->Name != $old->Name) $str .= ', Name: '.$old->Name.' &rArr; <b>'.$this->Name.'</b>';
-        if($this->Start != $old->Start) $str .= ', Start: '.$old->Start.' &rArr; <b>'.$this->Start.'</b>';
-        if($this->End != $old->End) $str .= ', Ende: '.$old->End.' &rArr; <b>'.$this->End.'</b>';
-        if($this->Bedarf != $old->Bedarf) $str .= ', Bedarf: '.$old->Bedarf.' &rArr; <b>'.$this->Bedarf.'</b>';
-        return $str;
+    public function hasChanges() {
+        return count($this->collectChanges()) > 0;
+    }
+
+    public function getChanges() {
+        $parts = $this->collectChanges();
+        if(count($parts) < 1) {
+            return '';
+        }
+        return sprintf('Schicht/Aufgabe: %d, ', (int)$this->Index).implode(', ', $parts);
     }
 
     public function getVars() {
         $parts = array();
-        $parts[] = sprintf('Schicht: %d', (int)$this->Index);
+        $parts[] = sprintf('Schicht/Aufgabe: %d', (int)$this->Index);
         $parts[] = logPart('Termin', (string)(int)$this->Termin);
         logAppendFilled($parts, 'Name', $this->Name, (string)$this->Name);
-        if(logValueFilled($this->Start) && $this->Start !== '00:00:00') {
-            $parts[] = logPart('Start', (string)$this->Start);
+        if(self::normalizedTime($this->Start) !== null) {
+            $parts[] = logPart('Start', self::formatTimeLog($this->Start));
         }
-        if(logValueFilled($this->End) && $this->End !== '00:00:00') {
-            $parts[] = logPart('Ende', (string)$this->End);
+        if(self::normalizedTime($this->End) !== null) {
+            $parts[] = logPart('Ende', self::formatTimeLog($this->End));
         }
         if((int)$this->Bedarf > 0) {
             $parts[] = logPart('Bedarf', (string)(int)$this->Bedarf);
@@ -69,14 +95,62 @@ class Shift
     }
 
     public function getTime() {
-        if($this->Start == "00:00:00" && $this->End == "00:00:00") return "&nbsp;";
-        if($this->End) {
-            $str=sql2timeRaw($this->Start)." - ".sql2timeRaw($this->End);
+        $start = self::normalizedTime($this->Start);
+        $end = self::normalizedTime($this->End);
+        if($start === null && $end === null) {
+            return '';
         }
-        else {
-            $str="ab ".sql2timeRaw($this->Start);
+        if($start !== null && $end !== null) {
+            return sql2timeRaw($start).' - '.sql2timeRaw($end);
         }
-        return $str;
+        if($start !== null) {
+            return 'ab '.sql2timeRaw($start);
+        }
+        return 'bis '.sql2timeRaw($end);
+    }
+
+    /**
+     * Empty / midnight sentinel → null; otherwise canonical HH:MM:SS.
+     * HTML time inputs often send HH:MM — treat equal to HH:MM:00.
+     */
+    public static function normalizedTime($val) {
+        if($val === null) {
+            return null;
+        }
+        $val = trim((string)$val);
+        if($val === '') {
+            return null;
+        }
+        if(!preg_match('/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/', $val, $m)) {
+            return null;
+        }
+        $h = (int)$m[1];
+        $i = (int)$m[2];
+        $s = isset($m[3]) ? (int)$m[3] : 0;
+        if($h === 0 && $i === 0 && $s === 0) {
+            return null;
+        }
+        if($h > 23 || $i > 59 || $s > 59) {
+            return null;
+        }
+        return sprintf('%02d:%02d:%02d', $h, $i, $s);
+    }
+
+    /** Log/display form HH:MM (or „—“ if empty). */
+    public static function formatTimeLog($val) {
+        $t = self::normalizedTime($val);
+        if($t === null) {
+            return '—';
+        }
+        return substr($t, 0, 5);
+    }
+
+    protected function sqlTimeOrNull($val) {
+        $t = self::normalizedTime($val);
+        if($t === null) {
+            return 'NULL';
+        }
+        return '"'.mysqli_real_escape_string($GLOBALS['conn'], $t).'"';
     }
     public function getMeldungen() {
         $sql = sprintf('SELECT * FROM `%sSchichtmeldung` WHERE `Shift` = "%d";',
@@ -134,15 +208,18 @@ class Shift
     public function save() {
         if(!$this->is_valid()) return false;
         if($this->Index > 0) {
+            $changes = $this->getChanges();
+            if($changes === '') {
+                return true;
+            }
             $logentry = new Log;
-            $logentry->DBupdate($this->getChanges());
-            $this->update();
+            $logentry->DBupdate($changes);
+            return $this->update();
         }
-        else {
-            $this->insert();
-            $logentry = new Log;
-            $logentry->DBinsert($this->getVars());
-        }
+        $this->insert();
+        $logentry = new Log;
+        $logentry->DBinsert($this->getVars());
+        return (int)$this->Index > 0;
     }
     public function is_valid() {
         if(!$this->Name) return false;
@@ -150,12 +227,12 @@ class Shift
         return true;
     }
     protected function insert() {
-        $sql = sprintf('INSERT INTO `%sSchichten` (`Termin`, `Name`, `Start`, `End`, `Bedarf`) VALUES ("%d", "%s", "%s", "%s", "%d");',
+        $sql = sprintf('INSERT INTO `%sSchichten` (`Termin`, `Name`, `Start`, `End`, `Bedarf`) VALUES ("%d", "%s", %s, %s, "%d");',
         $GLOBALS['dbprefix'],
         $this->Termin,
         mysqli_real_escape_string($GLOBALS['conn'], $this->Name),
-        $this->Start,
-        $this->End,
+        $this->sqlTimeOrNull($this->Start),
+        $this->sqlTimeOrNull($this->End),
         $this->Bedarf
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
@@ -165,12 +242,12 @@ class Shift
         return true;
     }
     protected function update() {
-        $sql = sprintf('UPDATE `%sSchichten` SET `Termin` = "%d", `Name` = "%s", `Start` = "%s", `End` = "%s", `Bedarf` = "%d" WHERE `Index` = "%d";',
+        $sql = sprintf('UPDATE `%sSchichten` SET `Termin` = "%d", `Name` = "%s", `Start` = %s, `End` = %s, `Bedarf` = "%d" WHERE `Index` = "%d";',
         $GLOBALS['dbprefix'],
         $this->Termin,
         mysqli_real_escape_string($GLOBALS['conn'], $this->Name),
-        $this->Start,
-        $this->End,
+        $this->sqlTimeOrNull($this->Start),
+        $this->sqlTimeOrNull($this->End),
         $this->Bedarf,
         $this->Index
         );
@@ -209,7 +286,11 @@ class Shift
     }
     public function fill_from_array($row) {
         foreach($row as $key => $val) {
-                $this->_data[$key] = $val;
+            if($key === 'Start' || $key === 'End') {
+                $this->$key = $val;
+                continue;
+            }
+            $this->_data[$key] = $val;
         }
     }
     public function load_by_id($Index) {

--- a/libs/shiftmeldung.php
+++ b/libs/shiftmeldung.php
@@ -41,7 +41,7 @@ class Shiftmeldung
         $s->load_by_id($this->Shift);
         $t = new Termin;
         $t->load_by_id($s->Termin);
-        $str = sprintf("Melde-ID: %d, Termin: (%d) <b>%s</b>, Schicht: (%d) <b>%s %s</b> %s, User: <b>%s</b>",
+        $str = sprintf("Melde-ID: %d, Termin: (%d) <b>%s</b>, Schicht/Aufgabe: (%d) <b>%s %s</b> %s, User: <b>%s</b>",
         $this->Index,
         $t->Index,
         $t->Name,
@@ -63,7 +63,7 @@ class Shiftmeldung
         $s->load_by_id($this->Shift);
         $t = new Termin;
         $t->load_by_id($s->Termin);
-        $str = sprintf("Melde-ID: %d, Termin: (%d) <b>%s</b>, Schicht: (%d) <b>%s %s</b> %s, User: <b>%s</b>, Wert: <b>%s</b>",
+        $str = sprintf("Melde-ID: %d, Termin: (%d) <b>%s</b>, Schicht/Aufgabe: (%d) <b>%s %s</b> %s, User: <b>%s</b>, Wert: <b>%s</b>",
         $this->Index,
         $t->Index,
         $t->Name,

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -106,7 +106,7 @@ class Termin
         }
         if($this->Name != $old->Name) $str.=", Name: ".$old->Name." &rArr; <b>".$this->Name."</b>";
         if(boolsDiffer($this->Auftritt, $old->Auftritt)) $str.=", Besetzung: ".bool2string($old->Auftritt)." &rArr; <b>".bool2string($this->Auftritt)."</b>";
-        if(boolsDiffer($this->Shifts, $old->Shifts)) $str.=", Schichten: ".bool2string($old->Shifts)." &rArr; <b>".bool2string($this->Shifts)."</b>";
+        if(boolsDiffer($this->Shifts, $old->Shifts)) $str.=", Schichten &amp; Aufgaben: ".bool2string($old->Shifts)." &rArr; <b>".bool2string($this->Shifts)."</b>";
         if($this->Ort1 != $old->Ort1) $str.=", Ort1: ".$old->Ort1." &rArr; <b>".$this->Ort1."</b>";
         if($this->Ort2 != $old->Ort2) $str.=", Ort2: ".$old->Ort2." &rArr; <b>".$this->Ort2."</b>";
         if($this->Ort3 != $old->Ort3) $str.=", Ort3: ".$old->Ort3." &rArr; <b>".$this->Ort3."</b>";
@@ -194,7 +194,7 @@ class Termin
             $parts[] = sprintf("Beschreibung: <b>%s</b>", $this->Beschreibung);
         }
         if($this->Shifts) {
-            $parts[] = "Schichten: <b>".bool2string($this->Shifts)."</b>";
+            $parts[] = "Schichten &amp; Aufgaben: <b>".bool2string($this->Shifts)."</b>";
         }
         $parts[] = "sichtbar für: <b>".htmlspecialchars($this->getVisibilityLabel(), ENT_QUOTES, 'UTF-8')."</b>";
         if((int)$this->PostDiscord) {
@@ -1024,274 +1024,154 @@ class Termin
 
         return $str;
     }
-    public function shiftEditLine($shift) {
-        $indent=1;
-        $str="";
-        $s= new Shift;
-        $s->load_by_id($shift);
-        $shiftmain = new div;
-        $shiftmain->tag = "form";
-        $shiftmain->action="edit-shifts.php";
-        $shiftmain->method="POST";
-        $shiftmain->indent=$indent;
-        $shiftmain->class="w3-border-top w3-border-white w3-padding w3-row";
-        $shiftmain->class=$GLOBALS['optionsDB']['HoverEffect'];
-        $shiftmain->class=$GLOBALS['optionsDB']['colorInputBackground'];
-        $str=$str.$shiftmain->open();
-        $indent++;
-
-        $shiftNameStr = new div;
-        $shiftNameStr->indent=$indent;
-        $shiftNameStr->col(1, 6, 6);
-        $shiftNameStr->class="w3-padding";
-        $shiftNameStr->body="Bezeichnung:";
-        $str=$str.$shiftNameStr->print();
-
-        $shiftName = new div;
-        $shiftName->indent=$indent;
-        $shiftName->col(2, 0, 0);
-        $shiftName->tag="input";
-        $shiftName->type="text";
-        $shiftName->placeholder="Bezeichnung";
-        $shiftName->name="Name";
-        $shiftName->class="w3-input w3-border";
-        $shiftName->value=$s->Name;
-        $str=$str.$shiftName->print();
-
-        $shiftTimeStartStr = new div;
-        $shiftTimeStartStr->indent=$indent;
-        $shiftTimeStartStr->col(1, 6, 6);
-        $shiftTimeStartStr->class="w3-padding";
-        $shiftTimeStartStr->body="Beginn:";
-        $str=$str.$shiftTimeStartStr->print();
-
-        $shiftTimeStart = new div;
-        $shiftTimeStart->tag="input";
-        $shiftTimeStart->type="time";
-        $shiftTimeStart->name="Start";
-        $shiftTimeStart->indent=$indent;
-        $shiftTimeStart->class="w3-input w3-border";
-        $shiftTimeStart->col(1, 0, 0);
-        $shiftTimeStart->value=$s->Start;
-        $str=$str.$shiftTimeStart->print();
-
-        $shiftTimeEndStr = new div;
-        $shiftTimeEndStr->indent=$indent;
-        $shiftTimeEndStr->col(1, 6, 6);
-        $shiftTimeEndStr->class="w3-padding";
-        $shiftTimeEndStr->body="Ende (optional):";
-        $str=$str.$shiftTimeEndStr->print();
-
-        $shiftTimeEnd = new div;
-        $shiftTimeEnd->tag="input";
-        $shiftTimeEnd->type="time";
-        $shiftTimeEnd->name="End";
-        $shiftTimeEnd->indent=$indent;
-        $shiftTimeEnd->class="w3-input w3-border";
-        $shiftTimeEnd->col(1, 0, 0);
-        $shiftTimeEnd->value=$s->End;
-        $str=$str.$shiftTimeEnd->print();
-
-        $shiftBedarfStr = new div;
-        $shiftBedarfStr->indent=$indent;
-        $shiftBedarfStr->col(1, 6, 6);
-        $shiftBedarfStr->class="w3-padding";
-        $shiftBedarfStr->body="Bedarf:";
-        $str=$str.$shiftBedarfStr->print();
-
-        $shiftBedarf = new div;
-        $shiftBedarf->tag="input";
-        $shiftBedarf->type="number";
-        $shiftBedarf->name="Bedarf";
-        $shiftBedarf->min="0";
-        $shiftBedarf->indent=$indent;
-        $shiftBedarf->class="w3-input w3-border";
-        $shiftBedarf->col(1, 0, 0);
-        $shiftBedarf->value=$s->Bedarf;
-        $str=$str.$shiftBedarf->print();
-
-        $hidden = new div;
-        $hidden->indent=$indent;
-        $hidden->tag = "input";
-        $hidden->type = "hidden";
-        $hidden->name="Termin";
-        $hidden->value=$this->Index;
-
-        $str=$str.$hidden->print();
-
-        $btncntr = new div;
-        $btncntr->indent=$indent;
-        $btncntr->class="w3-row w3-mobile w3-container";
-        $btncntr->col(2, 12, 12);
-        $str=$str.$btncntr->open();
-        $indent++;
-        
-        $btnDiv = new div;
-        $btnDiv->indent=$indent;
-        $btnDiv->tag="button";
-        $btnDiv->type="submit";
-        $btnDiv->name="save";
-        $btnDiv->body="<i class=\"fas fa-save\"></i>";
-        $btnDiv->value=$s->Index;
-        $btnDiv->class="w3-button w3-center w3-border w3-border-black";
-        $btnDiv->class=$GLOBALS['optionsDB']['colorBtnEdit'];
-        $btnDiv->col(5, 5, 5);
-        $str=$str.$btnDiv->print();
-        $btnSpacer = new div;
-        $btnSpacer->indent=$indent;
-        $btnSpacer->col(1,1,1);
-        $str=$str.$btnSpacer->print();
-        
-        if($s->Index) {
-            $btnDiv = new div;
-            $btnDiv->indent=$indent;
-            $btnDiv->onclick="document.getElementById('delmodal".$s->Index."').style.display='block'";
-            $btnDiv->body="<i class=\"fas fa-trash-alt\"></i>";
-            $btnDiv->class="w3-button w3-center w3-border w3-border-black w3-hover";
-            $btnDiv->class=$GLOBALS['optionsDB']['colorBtnEdit'];
-            $btnDiv->col(5, 5, 5);
-            $str=$str.$btnDiv->print();
+    /**
+     * One editable table row for a shift (or empty new row).
+     * @param int|string $shiftId existing Index, or 0 / "new_N" for a new row key
+     */
+    public function shiftEditRowHtml($shiftId, $inputBg = '') {
+        $s = new Shift;
+        $id = 0;
+        $key = 'new_0';
+        if(is_string($shiftId) && $shiftId !== '') {
+            $key = $shiftId;
+            if(strpos($shiftId, 'new_') !== 0 && ctype_digit($shiftId)) {
+                $s->load_by_id((int)$shiftId);
+                $id = (int)$s->Index;
+                $key = (string)$id;
+            }
         }
-        $str=$str.$btncntr->close();
-        $indent--;
-
-        $str=$str.$shiftmain->close();
-        $indent--;
-        
-        if($s->Index) {
-            $divModal = new div;
-            $divModal->id="delmodal".$s->Index;
-            $divModal->class="w3-modal";
-            $divModal->indent=$indent;
-            $str=$str.$divModal->open();
-            $indent++;
-        
-            $divCard = new div;
-            $divCard->indent=$indent;
-            $divCard->class="w3-modal-content w3-card";
-            $str=$str.$divCard->open();
-            $indent++;
-        
-            $divHeader = new div;
-            $divHeader->indent=$indent;
-            $divHeader->tag="header";
-            $divHeader->class="w3-container w3-row";
-            $divHeader->class=$GLOBALS['optionsDB']['colorTitleBar'];
-            $str=$str.$divHeader->open();
-            $indent++;
-        
-            $divSpan = new div;
-            $divSpan->indent=$indent;
-            $divSpan->onclick="document.getElementById('delmodal".$s->Index."').style.display='none'";
-            $divSpan->class="w3-button w3-display-topright";
-            $str=$str.$divSpan->print();
-
-            $divH = new div;
-            $divH->indent=$indent;
-            $divH->tag="h2";
-            $divH->body="L&ouml;schen best&auml;tigen";
-            $str=$str.$divH->print();
-            
-            $str=$str.$divHeader->close();
-            $indent--;
-        
-            $divBody = new div;
-            $divBody->indent=$indent;
-            $divBody->class="w3-container w3-row w3-center w3-padding w3-margin w3-card";
-            $divBody->class=$GLOBALS['optionsDB']['colorWarning'];
-            $divBody->body="Sind Sie sicher, dass sie <b>".$s->Name." ".$s->getTime()."</b> l&ouml;schen wollen?<br />Alle Meldungen zu dieser Schicht werden ebenfalls gel&ouml;scht.";
-            $str=$str.$divBody->print();
-
-            $divForm1 = new div;
-            $divForm1->indent=$indent;
-            $divForm1->class="w3-container w3-mobile";
-            $str=$str.$divForm1->open();
-            $indent++;
-        
-            $divForm = new div;
-            $divForm->tag="form";
-            $divForm->indent=$indent;
-            $divForm->action="edit-shifts.php";
-            $divForm->method="POST";
-            $str=$str.$divForm->open();
-            $indent++;
-            
-            $divHiddenIndex = new div;
-            $divHiddenIndex->indent=$indent;
-            $divHiddenIndex->tag="input";
-            $divHiddenIndex->type="hidden";
-            $divHiddenIndex->name="Termin";
-            $divHiddenIndex->value=$this->Index;
-            $str=$str.$divHiddenIndex->print();
-
-            $divRow = new div;
-            $divRow->indent=$indent;
-            $divRow->class="w3-row";
-            $str=$str.$divRow->open();
-            $indent++;
-            
-            $divSpacer = new div;
-            $divSpacer->indent=$indent;
-            $divSpacer->class="w3-center";
-            $divSpacer->col(4, 4, 2);
-            $str=$str.$divSpacer->print();
-
-            $divBtnYes = new div;
-            $divBtnYes->indent=$indent;
-            $divBtnYes->tag="button";
-            $divBtnYes->type="submit";
-            $divBtnYes->name="delete";
-            $divBtnYes->value=$s->Index;
-            $divBtnYes->class="w3-btn w3-center w3-border w3-margin-bottom w3-mobile";
-            $divBtnYes->class=$GLOBALS['optionsDB']['colorBtnSubmit'];
-            $divBtnYes->body="ja";
-            $divBtnYes->col(4, 4, 8);
-            $str=$str.$divBtnYes->print();
-            
-            $str=$str.$divSpacer->print();
-            
-            $str=$str.$divRow->close();
-            $indent--;
-            
-            $str=$str.$divForm->close();
-            $indent--;
-            
-            $str=$str.$divRow->open();
-            $indent++;
-            $str=$str.$divSpacer->print();
-            
-            $divBtnNo = new div;
-            $divBtnNo->indent=$indent;
-            $divBtnNo->tag="button";
-            $divBtnNo->onclick="document.getElementById('delmodal".$s->Index."').style.display='none'";
-            $divBtnNo->class="w3-btn w3-center w3-border w3-margin-bottom w3-mobile";
-            $divBtnNo->class=$GLOBALS['optionsDB']['colorBtnSubmit'];
-            $divBtnNo->body="nein";
-            $divBtnNo->col(4, 4, 8);
-            $str=$str.$divBtnNo->print();
-            
-            $str=$str.$divSpacer->print();
-            $str=$str.$divRow->close();
-            $indent--;
-            
-            $str=$str.$divForm1->close();
-            $indent--;
-            $str=$str.$divCard->close();
-            $indent--;
-            $str=$str.$divModal->close();
-            $indent--;
+        elseif((int)$shiftId > 0) {
+            $s->load_by_id((int)$shiftId);
+            $id = (int)$s->Index;
+            $key = (string)$id;
         }
-        
+        $h = function ($x) {
+            return htmlspecialchars((string)$x, ENT_QUOTES, 'UTF-8');
+        };
+        if($inputBg === '') {
+            $inputBg = isset($GLOBALS['optionsDB']['colorInputBackground']) ? (string)$GLOBALS['optionsDB']['colorInputBackground'] : '';
+        }
+        $btnDelete = isset($GLOBALS['optionsDB']['colorBtnDelete']) ? (string)$GLOBALS['optionsDB']['colorBtnDelete'] : 'w3-red';
+
+        $startVal = Shift::normalizedTime($s->Start);
+        $endVal = Shift::normalizedTime($s->End);
+        $nameVal = ($s->Name !== null && $s->Name !== '') ? $h($s->Name) : '';
+        $startAttr = $startVal !== null ? ' value="'.$h(substr($startVal, 0, 5)).'"' : '';
+        $endAttr = $endVal !== null ? ' value="'.$h(substr($endVal, 0, 5)).'"' : '';
+        $prefix = 'shifts['.$h($key).']';
+        $isNew = ($id < 1);
+
+        $str = '<tr class="shift-edit-row'.($isNew ? ' shift-edit-row--new' : '').'" data-shift-key="'.$h($key).'">';
+        $str .= '<td data-label="Bezeichnung">';
+        $str .= '<input id="shift-name-'.$h($key).'" class="w3-input w3-border profile-control '.$h($inputBg).'" name="'.$prefix.'[Name]" type="text" placeholder="Bezeichnung"'.($nameVal !== '' ? ' value="'.$nameVal.'"' : '').'>';
+        $str .= '</td>';
+        $str .= '<td data-label="Beginn">';
+        $str .= '<div class="shift-edit-time-wrap">';
+        $str .= '<input id="shift-start-'.$h($key).'" class="w3-input w3-border profile-control '.$h($inputBg).'" name="'.$prefix.'[Start]" type="time"'.$startAttr.'>';
+        $str .= '<button type="button" class="termin-form-clear shift-edit-clear" title="Beginn leeren" aria-label="Beginn leeren">&#10006;</button>';
+        $str .= '</div>';
+        $str .= '</td>';
+        $str .= '<td data-label="Ende">';
+        $str .= '<div class="shift-edit-time-wrap">';
+        $str .= '<input id="shift-end-'.$h($key).'" class="w3-input w3-border profile-control '.$h($inputBg).'" name="'.$prefix.'[End]" type="time"'.$endAttr.'>';
+        $str .= '<button type="button" class="termin-form-clear shift-edit-clear" title="Ende leeren" aria-label="Ende leeren">&#10006;</button>';
+        $str .= '</div>';
+        $str .= '</td>';
+        $str .= '<td data-label="Bedarf">';
+        $str .= '<input id="shift-bedarf-'.$h($key).'" class="w3-input w3-border profile-control '.$h($inputBg).'" name="'.$prefix.'[Bedarf]" type="number" min="0" value="'.$h((string)(int)$s->Bedarf).'">';
+        $str .= '</td>';
+        $str .= '<td data-label="Aktion" class="shift-edit-row-actions">';
+        if($isNew) {
+            $str .= '<button type="button" class="w3-btn w3-border '.$h($btnDelete).' shift-edit-remove-row">Entfernen</button>';
+        }
+        else {
+            $str .= '<button type="button" class="w3-btn w3-border '.$h($btnDelete).'" onclick="document.getElementById(\'delmodal'.$id.'\').style.display=\'block\'">Löschen</button>';
+        }
+        $str .= '</td>';
+        $str .= '</tr>';
         return $str;
     }
+
+    /**
+     * Delete-confirmation modal for one shift (outside the main edit form).
+     */
+    public function shiftDeleteModalHtml($shiftId) {
+        $s = new Shift;
+        $s->load_by_id((int)$shiftId);
+        $id = (int)$s->Index;
+        if($id < 1) {
+            return '';
+        }
+        $h = function ($x) {
+            return htmlspecialchars((string)$x, ENT_QUOTES, 'UTF-8');
+        };
+        $btnSubmit = isset($GLOBALS['optionsDB']['colorBtnSubmit']) ? (string)$GLOBALS['optionsDB']['colorBtnSubmit'] : 'w3-purple';
+        $titleBar = isset($GLOBALS['optionsDB']['colorTitleBar']) ? (string)$GLOBALS['optionsDB']['colorTitleBar'] : '';
+        $warning = isset($GLOBALS['optionsDB']['colorWarning']) ? (string)$GLOBALS['optionsDB']['colorWarning'] : '';
+        $timeLabel = $s->getTime();
+        $confirmName = $h($s->Name).($timeLabel !== '' ? ' '.$h($timeLabel) : '');
+
+        $str = '<div id="delmodal'.$id.'" class="w3-modal">';
+        $str .= '<div class="w3-modal-content w3-card">';
+        $str .= '<header class="w3-container '.$h($titleBar).'">';
+        $str .= '<button type="button" class="w3-button w3-display-topright" onclick="document.getElementById(\'delmodal'.$id.'\').style.display=\'none\'" aria-label="Schließen">&times;</button>';
+        $str .= '<h2>Löschen bestätigen</h2>';
+        $str .= '</header>';
+        $str .= '<div class="w3-container w3-padding '.$h($warning).'">';
+        $str .= '<p>Sind Sie sicher, dass Sie <b>'.$confirmName.'</b> löschen wollen?<br>Alle Meldungen zu dieser Schicht/Aufgabe werden ebenfalls gelöscht.</p>';
+        $str .= '</div>';
+        $str .= '<div class="shift-edit-actions w3-padding w3-margin-bottom">';
+        $str .= '<form action="edit-shifts.php" method="POST">';
+        $str .= '<input type="hidden" name="Termin" value="'.(int)$this->Index.'">';
+        $str .= '<button type="submit" class="w3-btn w3-border '.$h($btnSubmit).'" name="delete" value="'.$id.'">Ja, löschen</button>';
+        $str .= '</form>';
+        $str .= '<button type="button" class="w3-btn w3-border '.$h($btnSubmit).'" onclick="document.getElementById(\'delmodal'.$id.'\').style.display=\'none\'">Abbrechen</button>';
+        $str .= '</div>';
+        $str .= '</div>';
+        $str .= '</div>';
+        return $str;
+    }
+
+    /**
+     * Shared table editor for all shifts of this termin (+ one empty row + add/remove).
+     */
     public function printShiftEdit() {
-        $str='';
-        $indent = 1;
-        foreach($this->getShifts() as &$shift) {
-            $str=$str.$this->ShiftEditLine($shift);
+        $h = function ($x) {
+            return htmlspecialchars((string)$x, ENT_QUOTES, 'UTF-8');
+        };
+        $inputBg = isset($GLOBALS['optionsDB']['colorInputBackground']) ? (string)$GLOBALS['optionsDB']['colorInputBackground'] : '';
+        $btnEdit = isset($GLOBALS['optionsDB']['colorBtnEdit']) ? (string)$GLOBALS['optionsDB']['colorBtnEdit'] : 'w3-teal';
+        $btnSubmit = isset($GLOBALS['optionsDB']['colorBtnSubmit']) ? (string)$GLOBALS['optionsDB']['colorBtnSubmit'] : 'w3-purple';
+        $shiftIds = $this->getShifts();
+
+        $str = '<form class="shift-edit-form" action="edit-shifts.php" method="POST" data-shift-new-counter="1">';
+        $str .= '<input type="hidden" name="Termin" value="'.(int)$this->Index.'">';
+        $str .= '<div class="shift-edit-table-wrap">';
+        $str .= '<table class="shift-edit-table">';
+        $str .= '<thead><tr>';
+        $str .= '<th scope="col">Bezeichnung</th>';
+        $str .= '<th scope="col">Beginn</th>';
+        $str .= '<th scope="col">Ende</th>';
+        $str .= '<th scope="col">Bedarf</th>';
+        $str .= '<th scope="col">Aktion</th>';
+        $str .= '</tr></thead><tbody>';
+        foreach($shiftIds as $shiftId) {
+            $str .= $this->shiftEditRowHtml((int)$shiftId, $inputBg);
+        }
+        $str .= $this->shiftEditRowHtml('new_0', $inputBg);
+        $str .= '</tbody></table></div>';
+        $str .= '<div class="shift-edit-actions shift-edit-form-actions">';
+        $str .= '<button type="button" class="w3-btn w3-border '.$h($btnSubmit).'" id="shift-edit-add-row">Zeile hinzufügen</button>';
+        $str .= '<button type="submit" class="w3-btn w3-border '.$h($btnEdit).'" name="save_all" value="1">Alle speichern</button>';
+        $str .= '</div>';
+        $str .= '</form>';
+        $str .= '<template id="shift-edit-row-template">'.$this->shiftEditRowHtml('__KEY__', $inputBg).'</template>';
+        foreach($shiftIds as $shiftId) {
+            $str .= $this->shiftDeleteModalHtml((int)$shiftId);
         }
         return $str;
     }
+
     public function printMailResponse() {
         $wertval = array('Zusagen', 'Absagen', 'unsicher');
         $colorval = array($GLOBALS['optionsDB']['colorAppmntYes'], $GLOBALS['optionsDB']['colorAppmntNo'], $GLOBALS['optionsDB']['colorAppmntMaybe']);
@@ -1912,7 +1792,7 @@ class Termin
                 $str .= '<div class="'.implode(' ', array_filter($shiftClasses)).'"'.$shiftStyleAttr.' data-melde-stop>';
                 $str .= '<div class="melde-shift-info">';
                 $str .= '<div class="melde-shift-name">'.$h($s->Name).'</div>';
-                if($s->Start != $s->End) {
+                if($s->getTime() !== '') {
                     $str .= '<div class="melde-shift-time">'.$h($s->getTime()).'</div>';
                 }
                 $str .= '</div>';
@@ -2066,7 +1946,7 @@ class Termin
             $empty = new div;
             $empty->indent=$indent;
             $empty->class="w3-padding w3-text-gray";
-            $empty->body="Noch keine Schichten angelegt.";
+            $empty->body="Noch keine Schichten &amp; Aufgaben angelegt.";
             $str=$str.$empty->print();
         }
         for($i=0; $i<count($shifts); $i++) {

--- a/new-termin.php
+++ b/new-termin.php
@@ -223,7 +223,7 @@ if($fill && $n && (int)$n->Index > 0 && !empty($GLOBALS['googlemapsapi']) && ($n
         <label class="profile-pref">
           <input type="hidden" name="Shifts" value="0">
           <input class="w3-check" type="checkbox" name="Shifts" value="1" <?php if($fill && (bool)$n->Shifts) echo 'checked'; ?>>
-          <span>Schichtdienst</span>
+          <span>Schichten &amp; Aufgaben</span>
         </label>
         <label class="profile-pref">
           <input type="hidden" name="open" value="0">

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -447,6 +447,7 @@ a.app-titlebar-logo {
 
 .admin-list-shell > .admin-list-body {
   flex: 1 1 auto;
+  min-width: 0;
   min-height: 0;
   /* ungescrollt: Inhalt erst unter / am Ende der Fade-Zone */
   padding-top: var(--app-chrome-fade-h);
@@ -475,7 +476,7 @@ a.app-titlebar-logo {
 
 @media (min-width: 601px) {
   .app-nav {
-    width: 13.5rem;
+    width: 15rem;
     align-self: stretch;
     overflow-x: visible;
     overflow-y: auto;
@@ -1167,7 +1168,7 @@ a.app-titlebar-logo {
   .admin-nav-group > .w3-button {
     font-weight: 600;
     cursor: pointer;
-    white-space: normal;
+    white-space: nowrap;
   }
 
   .admin-nav-group > .w3-dropdown-content .w3-bar-item {
@@ -1204,6 +1205,10 @@ a.app-titlebar-logo {
 }
 
 .admin-nav-group > .w3-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
   width: 100%;
   text-align: left;
   padding: 8px 16px;
@@ -1237,9 +1242,10 @@ a.app-titlebar-logo {
 }
 
 .admin-nav-caret {
-  float: right;
-  margin-left: 0.75em;
-  margin-top: 0.2em;
+  float: none;
+  flex: 0 0 auto;
+  margin: 0;
+  line-height: 1;
 }
 
 .admin-nav-group > .w3-dropdown-content {
@@ -1281,7 +1287,7 @@ a.app-titlebar-logo {
 
   .admin-nav-caret {
     display: inline-block;
-    float: right;
+    float: none;
   }
 
   .admin-nav-group.admin-nav-open > .w3-button .admin-nav-caret {
@@ -1291,7 +1297,7 @@ a.app-titlebar-logo {
   .admin-nav-group > .w3-button {
     font-weight: bold;
     pointer-events: auto;
-    white-space: normal;
+    white-space: nowrap;
     cursor: pointer;
   }
 
@@ -1749,6 +1755,241 @@ a.app-titlebar-logo {
 @media (max-width: 719px) {
   .termin-field-pair {
     grid-template-columns: 1fr;
+  }
+}
+
+/* Schichten & Aufgaben bearbeiten (edit-shifts) */
+.shift-edit-list,
+.shift-edit-form {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+
+.shift-edit-list {
+  margin: 0 0 1.25rem;
+}
+
+.shift-edit-form {
+  margin: 0;
+}
+
+.shift-edit-table-wrap {
+  overflow: auto;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  margin: 0 0 0.85rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 0.35rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.shift-edit-table {
+  width: 100%;
+  max-width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.shift-edit-table th,
+.shift-edit-table td {
+  padding: 0.45rem 0.55rem;
+  vertical-align: middle;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  text-align: left;
+  overflow: hidden;
+}
+
+.shift-edit-table thead th {
+  font-size: 0.78rem;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  opacity: 0.7;
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.shift-edit-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.shift-edit-table th:nth-child(1),
+.shift-edit-table td:nth-child(1) {
+  width: 34%;
+}
+
+.shift-edit-table th:nth-child(2),
+.shift-edit-table td:nth-child(2),
+.shift-edit-table th:nth-child(3),
+.shift-edit-table td:nth-child(3) {
+  width: 15%;
+}
+
+.shift-edit-table th:nth-child(4),
+.shift-edit-table td:nth-child(4) {
+  width: 10%;
+}
+
+.shift-edit-table th:nth-child(5),
+.shift-edit-table td:nth-child(5) {
+  width: 16%;
+}
+
+.shift-edit-table .profile-control,
+.shift-edit-table input {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+.shift-edit-time-wrap {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.shift-edit-time-wrap .profile-control {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.shift-edit-clear {
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+  padding: 0.1rem 0.25rem;
+  line-height: 1;
+}
+
+.shift-edit-row-actions {
+  white-space: normal;
+}
+
+.shift-edit-row-actions .w3-btn {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding-left: 0.55rem;
+  padding-right: 0.55rem;
+}
+
+.shift-edit-new-hint {
+  font-size: 0.78rem;
+  opacity: 0.55;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.shift-edit-row--new td {
+  background: rgba(0, 0, 0, 0.015);
+}
+
+.shift-edit-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  align-items: center;
+  min-width: 0;
+}
+
+.shift-edit-actions .w3-btn {
+  margin: 0;
+}
+
+.shift-edit-form-actions {
+  margin-top: 0.25rem;
+}
+
+@media (max-width: 900px) {
+  .shift-edit-table-wrap {
+    overflow: visible;
+  }
+
+  .shift-edit-table,
+  .shift-edit-table thead,
+  .shift-edit-table tbody {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .shift-edit-table thead {
+    display: none;
+  }
+
+  .shift-edit-table tr {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.45rem 0.65rem;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    padding: 0.75rem 0.65rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  }
+
+  .shift-edit-table tbody tr:last-child {
+    border-bottom: 0;
+  }
+
+  .shift-edit-table th,
+  .shift-edit-table td,
+  .shift-edit-table th:nth-child(1),
+  .shift-edit-table td:nth-child(1),
+  .shift-edit-table th:nth-child(2),
+  .shift-edit-table td:nth-child(2),
+  .shift-edit-table th:nth-child(3),
+  .shift-edit-table td:nth-child(3),
+  .shift-edit-table th:nth-child(4),
+  .shift-edit-table td:nth-child(4),
+  .shift-edit-table th:nth-child(5),
+  .shift-edit-table td:nth-child(5) {
+    display: block;
+    width: auto;
+    max-width: none;
+    overflow: visible;
+    border: 0;
+    padding: 0;
+    min-width: 0;
+  }
+
+  .shift-edit-table td:nth-child(1),
+  .shift-edit-table td:nth-child(4),
+  .shift-edit-table td:nth-child(5) {
+    grid-column: 1 / -1;
+  }
+
+  .shift-edit-table td::before {
+    content: attr(data-label);
+    display: block;
+    font-size: 0.72rem;
+    font-weight: 650;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    opacity: 0.65;
+    margin-bottom: 0.2rem;
+  }
+
+  .shift-edit-table .profile-control,
+  .shift-edit-table input {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .shift-edit-time-wrap {
+    width: 100%;
+  }
+
+  .shift-edit-row-actions .w3-btn {
+    width: 100%;
   }
 }
 

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -174,7 +174,7 @@ $sections[] = array(
     'body' => '
 <p>Unter Admin → <b>Termin erstellen</b> legst du neue Termine an. Das Formular ist in Abschnitte gegliedert (Was, Wann, Wo, Optionen): auf dem Smartphone untereinander, auf dem Tablet zweispaltig, am PC als vier Spalten nebeneinander.</p>
 <p>Im <b>Kalender</b> kannst du auf eine freie Tagesfläche klicken: Nach Bestätigung öffnet sich das Anlege-Formular mit vorausgefülltem Datum.</p>
-<p>Nach Speichern/Löschen von Terminen oder Schichten erfolgt ein Redirect (kein erneutes Absenden beim Aktualisieren); Rücksprungziele können über Session-Token (<code>return_token</code>) geführt werden.</p>
+<p>Nach Speichern/Löschen von Terminen oder Schichten &amp; Aufgaben erfolgt ein Redirect (kein erneutes Absenden beim Aktualisieren); Rücksprungziele können über Session-Token (<code>return_token</code>) geführt werden. Beginn- und Endzeit einer Schicht/Aufgabe sind optional.</p>
 <p>Das Flag <b>Besetzung</b> steuert, ob Registeraufschlüsselung und Orchesterdarstellung greifen – für Proben und Auftritte. Veranstaltungen ohne Besetzung (z.&nbsp;B. Grillfest, Radtour) brauchen das nicht (nur Manpower).</p>
 <p>Mit dem Chip-Feld <b>sichtbar für</b> steuerst du den Kreis (Standard: <b>Alle User</b>). Ohne Chips = versteckt – nur User mit Recht <b>Versteckte Termine anzeigen</b>. Mit Chips nur der gewählte Kreis (Rollen, Gruppen, Register, Personen); Admins mit dem genannten Recht sehen weiterhin alles. Personen ohne Haken <b>aktiv</b> (Gastmusiker) kannst du hier wie andere Personen auswählen – sie gehören dann zu Sichtbarkeit und Besetzung dieses Termins.</p>
 <p>Discord-Posts (bei konfiguriertem Webhook) erfolgen bei Sichtbarkeit <b>Alle User</b> automatisch, sonst nur mit der Checkbox <b>Auch auf Discord posten</b>.</p>

--- a/views/termin/calendar_melde_modal.php
+++ b/views/termin/calendar_melde_modal.php
@@ -48,7 +48,7 @@ $hasShifts = (bool)$t->Shifts;
     <section class="profile-col" aria-labelledby="cal-melde-response">
       <h3 id="cal-melde-response" class="profile-col-title">Rückmeldung</h3>
 <?php if($hasShifts) { ?>
-      <p class="profile-value">Schichten — bitte unter Weitere Optionen melden.</p>
+      <p class="profile-value">Schichten &amp; Aufgaben — bitte unter Weitere Optionen melden.</p>
 <?php } elseif($capacityFull) { ?>
       <p class="profile-value">Alle Plätze belegt.</p>
 <?php } elseif($buttonsHtml !== null && $buttonsHtml !== '') { ?>

--- a/views/termin/detail_modal.php
+++ b/views/termin/detail_modal.php
@@ -53,7 +53,7 @@ if(!empty($GLOBALS['googlemapsapi']) && ($t->Ort1 || $t->Ort2)) {
 <?php } ?>
 <?php if($t->Shifts) { ?>
             <form action="edit-shifts.php" method="POST">
-              <button class="w3-btn <?php echo $h($btnEdit); ?> w3-border w3-mobile" type="submit" name="Termin" value="<?php echo (int)$t->Index; ?>">Schichten bearbeiten</button>
+              <button class="w3-btn <?php echo $h($btnEdit); ?> w3-border w3-mobile" type="submit" name="Termin" value="<?php echo (int)$t->Index; ?>">Schichten &amp; Aufgaben bearbeiten</button>
             </form>
 <?php } ?>
           </div>
@@ -160,7 +160,7 @@ if(!empty($GLOBALS['googlemapsapi']) && ($t->Ort1 || $t->Ort2)) {
         <div class="profile-value"><?php echo bool2string($t->Auftritt); ?></div>
       </div>
       <div class="profile-field">
-        <span class="profile-label">Schichtdienst</span>
+        <span class="profile-label">Schichten &amp; Aufgaben</span>
         <div class="profile-value"><?php echo bool2string($t->Shifts); ?></div>
       </div>
 <?php if($t->Auftritt) { ?>

--- a/views/termin/shift_response_modal.php
+++ b/views/termin/shift_response_modal.php
@@ -11,7 +11,7 @@ $subtitle = trim($shiftName.($shiftTime !== '' ? ' · '.$shiftTime : ''));
 <div class="profile-shell modal-shell shift-response-modal">
   <header class="profile-hero">
     <div class="profile-hero-text">
-      <p class="profile-kicker">Schicht</p>
+      <p class="profile-kicker">Schicht/Aufgabe</p>
       <h2 class="profile-title"><?php echo $h($terminName !== '' ? $terminName : 'Termin'); ?></h2>
 <?php if($subtitle !== '') { ?>
       <p class="profile-value" style="font-weight:400;margin:0.25rem 0 0;"><?php echo $h($subtitle); ?></p>


### PR DESCRIPTION
## Summary
- UI-Rename „Schichten“ → „Schichten & Aufgaben“ (DB/PHP `Shift` unverändert)
- Beginn/Ende optional; Schema 23: `Schichten.Start` nullable; keine Schein-Logs bei reinem Zeitformat (`12:00` vs `12:00:00`)
- Bearbeiten als Tabelle: Zeile hinzufügen/entfernen, Batch-Speichern; responsives Layout; Admin-Nav etwas breiter

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-140

## Test plan
- [ ] DB-Repair/Updater auf Schema 23 (`Schichten.Start` nullable)
- [ ] Termin mit Schichten & Aufgaben: Zeilen ergänzen/löschen, leere Startzeit speichern
- [ ] Speichern ohne echte Änderung erzeugt keinen DB-UPDATE-Logeintrag
- [ ] Mobile: Felder volle Breite; Desktop: Tabelle + Admin-Nav ohne umbrechenden Pfeil
- [ ] Hilfe-Guide erwähnt optionale Zeiten