### PR TITLE
MELD-148: Log-Trennlinie auf schmalen Screens enger

### DIFF
--- a/libs/log.php
+++ b/libs/log.php
@@ -214,17 +214,23 @@ class Log
         $userLabel = $User->Index ? $User->getName() : 'SYSTEM';
         $classes = trim('log-row list-row '.$hover);
         $tsRaw = (string)$this->Timestamp;
-        $tsView = (string)germanDate($tsRaw, false);
+        $datePart = (string)germanDate($tsRaw, false);
+        $timePart = '';
         if(strlen($tsRaw) >= 19) {
-            $tsView .= ' '.substr($tsRaw, 11, 8);
+            $timePart = substr($tsRaw, 11, 8);
         }
         elseif(strlen($tsRaw) >= 16) {
-            $tsView .= ' '.substr($tsRaw, 11, 5);
+            $timePart = substr($tsRaw, 11, 5);
         }
 
         echo '<div id="'.(int)$this->Index.'" class="'.htmlspecialchars($classes, ENT_QUOTES, 'UTF-8').'">';
         echo '<div class="log-id">';
-        echo '<div class="log-time">'.htmlspecialchars($tsView, ENT_QUOTES, 'UTF-8').'</div>';
+        echo '<div class="log-time">';
+        echo '<span class="log-date">'.htmlspecialchars($datePart, ENT_QUOTES, 'UTF-8').'</span>';
+        if($timePart !== '') {
+            echo '<span class="log-clock">'.htmlspecialchars($timePart, ENT_QUOTES, 'UTF-8').'</span>';
+        }
+        echo '</div>';
         if($type !== '') {
             echo '<span class="w3-tag log-type-chip log-type-chip--'.htmlspecialchars($chipMod, ENT_QUOTES, 'UTF-8').'">'
                 .htmlspecialchars($type, ENT_QUOTES, 'UTF-8').'</span>';

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -4596,6 +4596,10 @@ select.profile-control {
   word-break: break-word;
 }
 
+.log-clock::before {
+  content: ' ';
+}
+
 .log-rail {
   width: var(--log-rail-w);
   align-self: stretch;
@@ -4682,11 +4686,28 @@ select.profile-control {
 
 @media (max-width: 600px) {
   .log-row {
-    --log-id-col-w: 8.5rem;
+    --log-id-col-w: max-content;
     --log-row-pad-y: 0.25rem;
+    grid-template-columns: max-content var(--log-rail-w) minmax(0, 1fr);
     padding-left: 0.5rem;
     padding-right: 0.5rem;
-    column-gap: 0.4rem;
+    column-gap: 0.35rem;
+  }
+
+  .log-id {
+    width: max-content;
+    max-width: none;
+  }
+
+  .log-time {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+  }
+
+  .log-clock::before {
+    content: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- Datum/Uhrzeit getrennt; auf schmalen Screens untereinander
- Linke Log-Spalte `max-content`, Trennlinie weiter links, mehr Platz für die Meldung

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-148

## Test plan
- [ ] Log breit: Datum und Uhrzeit in einer Zeile, Layout unverändert gut
- [ ] Log schmal: Uhrzeit unter Datum, Trennlinie eng am Chip, Meldung nutzt mehr Breite