### PR TITLE
MELD-144: Emails durchsuchen

### DIFF
--- a/getList.php
+++ b/getList.php
@@ -93,6 +93,19 @@ case 'gastmusiker':
     $result = listChunkUsers('gastmusiker', $cursor !== '' ? (int)$cursor : 0, $limit, $sort, $dir);
     break;
 
+case 'mailJobs':
+    if(!requirePermission('perm_sendEmail')) {
+        http_response_code(403);
+        header('X-Has-More: 0');
+        exit;
+    }
+    $result = listChunkMailJobs($cursor, $limit);
+    break;
+
+case 'meineMails':
+    $result = listChunkUserMails((int)$_SESSION['userid'], $cursor, $limit);
+    break;
+
 default:
     http_response_code(400);
     header('X-Has-More: 0');

--- a/js/filterMail.js
+++ b/js/filterMail.js
@@ -1,0 +1,23 @@
+function filterMail() {
+    var input, filter, table, tr, i, txtValue;
+    input = document.getElementById("filterString");
+    if(!input) return;
+    filter = input.value.toUpperCase();
+    table = document.getElementById("Liste");
+    if(!table) return;
+    tr = table.getElementsByTagName("div");
+    for (i = 0; i < tr.length; i++) {
+	if(tr[i].id === "listSentinel") continue;
+	if(tr[i].classList && tr[i].classList.contains("mail-list-header")) continue;
+	if(tr[i].parentNode !== table) continue;
+	if(!tr[i].classList || !tr[i].classList.contains("mail-list-item")) continue;
+	txtValue = (typeof listRowSearchText === 'function' ? listRowSearchText(tr[i]) : (tr[i].textContent || tr[i].innerText));
+	if (txtValue.toUpperCase().indexOf(filter) > -1) {
+	    tr[i].style.display = "";
+	    tr[i].classList.remove("list-filtered-out");
+	} else {
+	    tr[i].style.display = "none";
+	    tr[i].classList.add("list-filtered-out");
+	}
+    }
+}

--- a/libs/listChunk.php
+++ b/libs/listChunk.php
@@ -396,6 +396,237 @@ function listChunkUsers($kind, $offset, $limit, $sort = '', $dir = 'asc') {
     );
 }
 
+/**
+ * Compact Created/list timestamps for mail list meta (short weekday + date).
+ */
+function mailListFormatDate($raw) {
+    $raw = (string)$raw;
+    if($raw === '') return '';
+    $out = (string)germanDates($raw, true, true);
+    if(strlen($raw) >= 16) {
+        $out .= ' '.sql2timeRaw(substr($raw, 11, 8));
+    }
+    return $out;
+}
+
+/**
+ * Resolve user display name with a shared cache map.
+ */
+function mailListResolveUserName($userId, &$userNameCache) {
+    $userId = (int)$userId;
+    if($userId <= 0) return 'System';
+    if(!isset($userNameCache[$userId])) {
+        $u = new User;
+        $u->load_by_id($userId);
+        $userNameCache[$userId] = $u->Index ? $u->getName() : ('User '.$userId);
+    }
+    return $userNameCache[$userId];
+}
+
+/**
+ * One row for Meine Nachrichten overview.
+ * @param array $row MailOutbox fields + optional SenderId
+ */
+function mailOutboxRenderListItemHtml(array $row, &$userNameCache = null) {
+    if(!is_array($userNameCache)) {
+        $userNameCache = array();
+    }
+    $id = (int)$row['Index'];
+    $unread = empty($row['ReadAt']);
+    $when = htmlspecialchars(mailListFormatDate(isset($row['Created']) ? $row['Created'] : ''), ENT_QUOTES, 'UTF-8');
+    $senderName = mailListResolveUserName(isset($row['SenderId']) ? $row['SenderId'] : 0, $userNameCache);
+    $sender = htmlspecialchars($senderName, ENT_QUOTES, 'UTF-8');
+    $subject = (isset($row['Subject']) && $row['Subject'] !== '' && $row['Subject'] !== null)
+        ? htmlspecialchars((string)$row['Subject'], ENT_QUOTES, 'UTF-8')
+        : '<em>(ohne Betreff)</em>';
+    $rowCls = $unread ? ' mail-unread' : '';
+    $neu = $unread
+        ? '<span class="w3-tag '.$GLOBALS['optionsDB']['colorLogEmail'].'">neu</span>'
+        : '';
+    $mailFail = (isset($row['Status']) && $row['Status'] === 'failed')
+        ? ' <span class="w3-tag '.(isset($GLOBALS['optionsDB']['colorLogError']) ? $GLOBALS['optionsDB']['colorLogError'] : 'w3-red').'">E-Mail fehlgeschlagen</span>'
+        : '';
+    if($unread) {
+        $subject = '<strong>'.$subject.'</strong>';
+    }
+    $searchBits = array(
+        isset($row['Subject']) ? (string)$row['Subject'] : '',
+        $senderName,
+        isset($row['Created']) ? (string)$row['Created'] : '',
+        $unread ? 'neu' : '',
+        (isset($row['Status']) && $row['Status'] === 'failed') ? 'fehlgeschlagen' : '',
+    );
+    $html = '<div class="mail-list-item'.$rowCls.'" data-search="'.htmlspecialchars(implode(' ', $searchBits), ENT_QUOTES, 'UTF-8').'">';
+    $html .= '<div class="mail-list-primary"><a href="meine-mails.php?id='.$id.'">'.$subject.'</a></div>';
+    $html .= '<div class="mail-list-meta">'.$when.' · '.$sender.'</div>';
+    $html .= '<div class="mail-list-status">'.$neu.$mailFail.'</div>';
+    $html .= '<div class="mail-list-actions">';
+    $html .= '<a class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnEdit'].'" href="meine-mails.php?id='.$id.'">Anzeigen</a>';
+    $html .= '<form method="post" action="meine-mails.php" onsubmit="return confirm(\'Nachricht ausblenden?\');">';
+    $html .= '<input type="hidden" name="id" value="'.$id.'" />';
+    $html .= '<button type="submit" name="delete" value="1" class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnNo'].'">Ausblenden</button>';
+    $html .= '</form>';
+    $html .= '</div>';
+    $html .= '</div>';
+    return $html;
+}
+
+/**
+ * Admin mail job list chunks (ORDER BY queue/created DESC, Index DESC).
+ * Cursor: "timestamp|id" of last emitted row, or empty for start.
+ * @return array{html:string,nextCursor:string,hasMore:bool,sendingIds:int[]}
+ */
+function listChunkMailJobs($cursor, $limit) {
+    $limit = listChunkLimit($limit);
+    MailJob::ensureSchema();
+    $prefix = $GLOBALS['dbprefix'];
+    $cursorTs = '';
+    $cursorId = 0;
+    if($cursor !== '' && strpos($cursor, '|') !== false) {
+        $parts = explode('|', $cursor, 2);
+        $cursorTs = $parts[0];
+        $cursorId = (int)$parts[1];
+    }
+    $sortExpr = sprintf(
+        'COALESCE((SELECT MIN(o2.`Created`) FROM `%sMailOutbox` o2 WHERE o2.`Job` = j.`Index`), j.`Created`)',
+        $prefix
+    );
+    $queueCreated = sprintf(
+        '(SELECT MIN(o.`Created`) FROM `%sMailOutbox` o WHERE o.`Job` = j.`Index`) AS `QueueCreated`',
+        $prefix
+    );
+    if($cursorTs !== '') {
+        $esc = mysqli_real_escape_string($GLOBALS['conn'], $cursorTs);
+        $sql = sprintf(
+            'SELECT j.*, %s FROM `%sMailJob` j
+             WHERE (%s < "%s") OR (%s = "%s" AND j.`Index` < %d)
+             ORDER BY %s DESC, j.`Index` DESC LIMIT %d;',
+            $queueCreated,
+            $prefix,
+            $sortExpr,
+            $esc,
+            $sortExpr,
+            $esc,
+            $cursorId,
+            $sortExpr,
+            $limit + 1
+        );
+    }
+    else {
+        $sql = sprintf(
+            'SELECT j.*, %s FROM `%sMailJob` j ORDER BY %s DESC, j.`Index` DESC LIMIT %d;',
+            $queueCreated,
+            $prefix,
+            $sortExpr,
+            $limit + 1
+        );
+    }
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    $jobs = array();
+    if($dbr) {
+        while($row = mysqli_fetch_array($dbr)) {
+            $j = new MailJob;
+            $j->fill_from_array($row);
+            $jobs[] = $j;
+        }
+    }
+    $hasMore = count($jobs) > $limit;
+    if($hasMore) {
+        $jobs = array_slice($jobs, 0, $limit);
+    }
+    $html = '';
+    $userNameCache = array();
+    $sendingIds = array();
+    $nextCursor = $cursor;
+    foreach($jobs as $job) {
+        $html .= $job->renderAdminListItemHtml($userNameCache, $sendingIds);
+        $nextCursor = $job->listTimestamp().'|'.(int)$job->Index;
+    }
+    return array(
+        'html' => $html,
+        'nextCursor' => (string)$nextCursor,
+        'hasMore' => $hasMore,
+        'sendingIds' => $sendingIds,
+    );
+}
+
+/**
+ * User inbox (Meine Nachrichten) chunks.
+ * Cursor: "created|id" of last emitted row, or empty for start.
+ */
+function listChunkUserMails($userId, $cursor, $limit) {
+    $limit = listChunkLimit($limit);
+    $userId = (int)$userId;
+    MailJob::ensureSchema();
+    $prefix = $GLOBALS['dbprefix'];
+    $cursorTs = '';
+    $cursorId = 0;
+    if($cursor !== '' && strpos($cursor, '|') !== false) {
+        $parts = explode('|', $cursor, 2);
+        $cursorTs = $parts[0];
+        $cursorId = (int)$parts[1];
+    }
+    $baseWhere = sprintf(
+        'o.`User` = %d AND o.`DeletedByUser` = 0 AND o.`Status` IN ("pending", "sending", "sent", "failed")',
+        $userId
+    );
+    if($cursorTs !== '') {
+        $esc = mysqli_real_escape_string($GLOBALS['conn'], $cursorTs);
+        $sql = sprintf(
+            'SELECT o.*, j.`CreatedBy` AS `SenderId`
+             FROM `%sMailOutbox` o
+             LEFT JOIN `%sMailJob` j ON j.`Index` = o.`Job`
+             WHERE %s AND ((o.`Created` < "%s") OR (o.`Created` = "%s" AND o.`Index` < %d))
+             ORDER BY o.`Created` DESC, o.`Index` DESC LIMIT %d;',
+            $prefix,
+            $prefix,
+            $baseWhere,
+            $esc,
+            $esc,
+            $cursorId,
+            $limit + 1
+        );
+    }
+    else {
+        $sql = sprintf(
+            'SELECT o.*, j.`CreatedBy` AS `SenderId`
+             FROM `%sMailOutbox` o
+             LEFT JOIN `%sMailJob` j ON j.`Index` = o.`Job`
+             WHERE %s
+             ORDER BY o.`Created` DESC, o.`Index` DESC LIMIT %d;',
+            $prefix,
+            $prefix,
+            $baseWhere,
+            $limit + 1
+        );
+    }
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    $rows = array();
+    if($dbr) {
+        while($row = mysqli_fetch_assoc($dbr)) {
+            $rows[] = $row;
+        }
+    }
+    $hasMore = count($rows) > $limit;
+    if($hasMore) {
+        $rows = array_slice($rows, 0, $limit);
+    }
+    $html = '';
+    $userNameCache = array();
+    $nextCursor = $cursor;
+    foreach($rows as $row) {
+        $html .= mailOutboxRenderListItemHtml($row, $userNameCache);
+        $nextCursor = (string)$row['Created'].'|'.(int)$row['Index'];
+    }
+    return array(
+        'html' => $html,
+        'nextCursor' => (string)$nextCursor,
+        'hasMore' => $hasMore,
+    );
+}
+
 function listChunkRenderSentinelAttrs($type, $cursor, $hasMore, $filterFn = '') {
     $attrs = ' id="listSentinel" data-list-type="'.htmlspecialchars($type, ENT_QUOTES, 'UTF-8').'"'
         .' data-cursor="'.htmlspecialchars((string)$cursor, ENT_QUOTES, 'UTF-8').'"'

--- a/libs/mailJob.php
+++ b/libs/mailJob.php
@@ -688,6 +688,89 @@ class MailJob
     }
 
     /**
+     * One admin overview row (Betreff / Status / Aktion).
+     * @param array $userNameCache by-ref map userId => display name
+     * @param array|null $sendingIds collected job ids that are queued/processing
+     * @return string HTML
+     */
+    public function renderAdminListItemHtml(&$userNameCache = null, &$sendingIds = null) {
+        if(!is_array($userNameCache)) {
+            $userNameCache = array();
+        }
+        $id = (int)$this->Index;
+        $subject = $this->Subject !== '' && $this->Subject !== null
+            ? htmlspecialchars((string)$this->Subject, ENT_QUOTES, 'UTF-8')
+            : '<em>(ohne Betreff)</em>';
+        $createdRaw = (string)$this->listTimestamp();
+        $created = htmlspecialchars(mailListFormatDate($createdRaw), ENT_QUOTES, 'UTF-8');
+        $byId = (int)$this->CreatedBy;
+        if($byId > 0) {
+            if(!isset($userNameCache[$byId])) {
+                $u = new User;
+                $u->load_by_id($byId);
+                $userNameCache[$byId] = $u->Index ? $u->getName() : ('User '.$byId);
+            }
+            $byName = htmlspecialchars($userNameCache[$byId], ENT_QUOTES, 'UTF-8');
+        }
+        else {
+            $byName = 'System';
+        }
+        $status = htmlspecialchars($this->statusLabel(), ENT_QUOTES, 'UTF-8');
+        $statusCls = $this->statusClass();
+        if($this->Status !== 'draft') {
+            $counts = MailJob::formatCounts($this->Sent, $this->Total, $this->Failed);
+        }
+        else {
+            $counts = '—';
+        }
+        $isSending = in_array((string)$this->Status, array('queued', 'processing'), true);
+        if($isSending && is_array($sendingIds)) {
+            $sendingIds[] = $id;
+        }
+        $searchBits = array(
+            (string)$this->Subject,
+            '#'.$id,
+            $this->statusLabel(),
+            isset($userNameCache[$byId]) ? (string)$userNameCache[$byId] : $byName,
+            $createdRaw,
+        );
+        $html = '<div class="mail-list-item" data-mail-id="'.$id.'"'
+            .($isSending ? ' data-mail-sending="1"' : '')
+            .' data-search="'.htmlspecialchars(implode(' ', $searchBits), ENT_QUOTES, 'UTF-8').'">';
+        $html .= '<div class="mail-list-primary"><a href="mail.php?id='.$id.'">'.$subject.'</a></div>';
+        $html .= '<div class="mail-list-meta">#'.$id.' · '.$created.' · '.$byName.'</div>';
+        $html .= '<div class="mail-list-status"><span class="w3-tag mail-status-tag '.$statusCls.'">'.$status.'</span>';
+        $html .= ' <span class="mail-counts-cell">'.htmlspecialchars($counts, ENT_QUOTES, 'UTF-8').'</span></div>';
+        $html .= '<div class="mail-list-actions mail-actions-cell">';
+        if($this->Status === 'draft') {
+            $html .= '<a class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnEdit'].'" href="mail.php?id='.$id.'">Bearbeiten</a>';
+        }
+        if($this->canCancel()) {
+            $html .= '<span class="mail-cancel-wrap">';
+            $html .= '<form method="post" action="mail.php" onsubmit="return confirm(\'Versand von Email-ID '.$id.' wirklich abbrechen?\');">';
+            $html .= '<input type="hidden" name="id" value="'.$id.'" />';
+            $html .= '<button type="submit" name="cancel_job" value="1" class="w3-button w3-small '.$GLOBALS['optionsDB']['colorWarning'].'">Abbrechen</button>';
+            $html .= '</form>';
+            $html .= '</span>';
+        }
+        if($this->canDelete()) {
+            $delConfirm = $this->Status === 'draft'
+                ? 'Entwurf #'.$id.' wirklich löschen?'
+                : 'Email-ID '.$id.' wirklich löschen? (noch an niemanden per PHPMailer versendet)';
+            $html .= '<span class="mail-delete-wrap">';
+            $html .= '<form method="post" action="mail.php" onsubmit="return confirm(\''.htmlspecialchars($delConfirm, ENT_QUOTES, 'UTF-8').'\');">';
+            $html .= '<input type="hidden" name="id" value="'.$id.'" />';
+            $html .= '<button type="submit" name="delete_job" value="1" class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnNo'].'">Löschen</button>';
+            $html .= '</form>';
+            $html .= '</span>';
+        }
+        $html .= '<a class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnSubmit'].'" href="mail.php?copy='.$id.'">Als Entwurf kopieren</a>';
+        $html .= '</div>';
+        $html .= '</div>';
+        return $html;
+    }
+
+    /**
      * @param string|null $statusFilter null = all
      * @return MailJob[]
      */

--- a/mail.php
+++ b/mail.php
@@ -216,7 +216,10 @@ if(!empty($recipientSpec['termine']) && is_array($recipientSpec['termine'])) {
     }
 }
 
-$allJobs = MailJob::listJobs(null, 300);
+$mailListChunk = null;
+if(!$job) {
+    $mailListChunk = listChunkMailJobs('', 50);
+}
 
 include_once 'common/header.php';
 $mailActions = '<a class="w3-button '.$GLOBALS['optionsDB']['colorBtnSubmit'].'" href="mail.php?new=1'.($terminParam ? '&termin='.(int)$terminParam : '').'">Neue Email</a>';
@@ -227,93 +230,36 @@ adminListPageBegin('Kommunikation', 'Email versenden', array('actionsHtml' => $m
 ?>
 <?php echo renderFlashHtml(); ?>
 
-<?php if(!$job) { ?>
-  <div class="mail-list">
+<?php if(!$job) {
+    adminListSearchField('Emails suchen (Betreff, Absender, Status, ID)…', array('onkeyup' => 'filterMail()'));
+?>
+  <div class="mail-list" id="Liste">
     <div class="mail-list-header <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
       <div>Betreff</div>
       <div>Status</div>
       <div>Aktion</div>
     </div>
 <?php
-if(!count($allJobs)) {
-    echo '<div class="mail-list-item"><div class="mail-list-primary">Noch keine Emails vorhanden.</div></div>';
+if($mailListChunk['html'] === '') {
+    echo '<div class="mail-list-item mail-list-empty"><div class="mail-list-primary">Noch keine Emails vorhanden.</div></div>';
 }
-$userNameCache = array();
-$mailSendingIds = array();
-foreach($allJobs as $rowJob) {
-    $id = (int)$rowJob->Index;
-    $subject = $rowJob->Subject !== '' && $rowJob->Subject !== null
-        ? htmlspecialchars((string)$rowJob->Subject, ENT_QUOTES, 'UTF-8')
-        : '<em>(ohne Betreff)</em>';
-    $createdRaw = (string)$rowJob->listTimestamp();
-    $created = htmlspecialchars((string)germanDate($createdRaw, true), ENT_QUOTES, 'UTF-8');
-    if(strlen($createdRaw) >= 16) {
-        $created .= ' '.htmlspecialchars(sql2timeRaw(substr($createdRaw, 11, 8)), ENT_QUOTES, 'UTF-8');
-    }
-    $byId = (int)$rowJob->CreatedBy;
-    if($byId > 0) {
-        if(!isset($userNameCache[$byId])) {
-            $u = new User;
-            $u->load_by_id($byId);
-            $userNameCache[$byId] = $u->Index ? $u->getName() : ('User '.$byId);
-        }
-        $byName = htmlspecialchars($userNameCache[$byId], ENT_QUOTES, 'UTF-8');
-    }
-    else {
-        $byName = 'System';
-    }
-    $status = htmlspecialchars($rowJob->statusLabel(), ENT_QUOTES, 'UTF-8');
-    $statusCls = $rowJob->statusClass();
-    $counts = '';
-    if($rowJob->Status !== 'draft') {
-        $counts = MailJob::formatCounts($rowJob->Sent, $rowJob->Total, $rowJob->Failed);
-    }
-    else {
-        $counts = '—';
-    }
-    $isSending = in_array((string)$rowJob->Status, array('queued', 'processing'), true);
-    if($isSending) {
-        $mailSendingIds[] = $id;
-    }
-    echo '<div class="mail-list-item" data-mail-id="'.$id.'"'.($isSending ? ' data-mail-sending="1"' : '').'>';
-    echo '<div class="mail-list-primary"><a href="mail.php?id='.$id.'">'.$subject.'</a></div>';
-    echo '<div class="mail-list-meta">#'.$id.' · '.$created.' · '.$byName.'</div>';
-    echo '<div class="mail-list-status"><span class="w3-tag mail-status-tag '.$statusCls.'">'.$status.'</span>';
-    echo ' <span class="mail-counts-cell">'.htmlspecialchars($counts, ENT_QUOTES, 'UTF-8').'</span></div>';
-    echo '<div class="mail-list-actions mail-actions-cell">';
-    if($rowJob->Status === 'draft') {
-        echo '<a class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnEdit'].'" href="mail.php?id='.$id.'">Bearbeiten</a>';
-    }
-    if($rowJob->canCancel()) {
-        echo '<span class="mail-cancel-wrap">';
-        echo '<form method="post" action="mail.php" onsubmit="return confirm(\'Versand von Email-ID '.$id.' wirklich abbrechen?\');">';
-        echo '<input type="hidden" name="id" value="'.$id.'" />';
-        echo '<button type="submit" name="cancel_job" value="1" class="w3-button w3-small '.$GLOBALS['optionsDB']['colorWarning'].'">Abbrechen</button>';
-        echo '</form>';
-        echo '</span>';
-    }
-    if($rowJob->canDelete()) {
-        $delConfirm = $rowJob->Status === 'draft'
-            ? 'Entwurf #'.$id.' wirklich löschen?'
-            : 'Email-ID '.$id.' wirklich löschen? (noch an niemanden per PHPMailer versendet)';
-        echo '<span class="mail-delete-wrap">';
-        echo '<form method="post" action="mail.php" onsubmit="return confirm(\''.htmlspecialchars($delConfirm, ENT_QUOTES, 'UTF-8').'\');">';
-        echo '<input type="hidden" name="id" value="'.$id.'" />';
-        echo '<button type="submit" name="delete_job" value="1" class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnNo'].'">Löschen</button>';
-        echo '</form>';
-        echo '</span>';
-    }
-    echo '<a class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnSubmit'].'" href="mail.php?copy='.$id.'">Als Entwurf kopieren</a>';
-    echo '</div>';
-    echo '</div>';
+else {
+    echo $mailListChunk['html'];
 }
+echo listChunkRenderSentinel('mailJobs', $mailListChunk['nextCursor'], $mailListChunk['hasMore'], 'filterMail');
 ?>
   </div>
-<?php if(count($mailSendingIds)) { ?>
 <script>
 (function() {
-  var pollIds = <?php echo json_encode(array_values($mailSendingIds)); ?>;
-  if(!pollIds.length) return;
+  function collectPollIds() {
+    var rows = document.querySelectorAll('.mail-list-item[data-mail-sending="1"]');
+    var ids = [];
+    for(var i = 0; i < rows.length; i++) {
+      var id = parseInt(rows[i].getAttribute('data-mail-id'), 10);
+      if(id > 0) ids.push(id);
+    }
+    return ids;
+  }
 
   function applyJob(job) {
     var row = document.querySelector('.mail-list-item[data-mail-id="' + job.id + '"]');
@@ -340,11 +286,11 @@ foreach($allJobs as $rowJob) {
     }
     else {
       row.removeAttribute('data-mail-sending');
-      pollIds = pollIds.filter(function(id) { return id !== job.id; });
     }
   }
 
   function poll() {
+    var pollIds = collectPollIds();
     if(!pollIds.length) return;
     var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
     xhr.onreadystatechange = function() {
@@ -364,7 +310,9 @@ foreach($allJobs as $rowJob) {
   poll();
 })();
 </script>
-<?php } ?>
+<script src="js/listRowSearch.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script src="js/filterMail.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script src="js/infiniteScroll.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
 <?php } ?>
 
 <?php if($job && $job->Status === 'draft') { ?>

--- a/meine-mails.php
+++ b/meine-mails.php
@@ -39,40 +39,19 @@ if($viewId > 0) {
 
 include_once "common/header.php";
 
-$sqlList = sprintf(
-    'SELECT o.*, j.`CreatedBy` AS `SenderId`
-     FROM `%sMailOutbox` o
-     LEFT JOIN `%sMailJob` j ON j.`Index` = o.`Job`
-     WHERE o.`User` = %d AND o.`DeletedByUser` = 0 AND o.`Status` IN ("pending", "sending", "sent", "failed")
-     ORDER BY o.`Created` DESC, o.`Index` DESC
-     LIMIT 200;',
-    $GLOBALS['dbprefix'],
-    $GLOBALS['dbprefix'],
-    $userId
-);
-$dbr = mysqli_query($GLOBALS['conn'], $sqlList);
-sqlerror();
-
 $userNameCache = array();
 $formatMailDate = function($raw) {
-    $raw = (string)$raw;
-    if($raw === '') return '';
-    $out = (string)germanDate($raw, true);
-    if(strlen($raw) >= 16) {
-        $out .= ' '.sql2timeRaw(substr($raw, 11, 8));
-    }
-    return $out;
+    return mailListFormatDate($raw);
 };
 $resolveSender = function($senderId) use (&$userNameCache) {
-    $senderId = (int)$senderId;
-    if($senderId <= 0) return 'System';
-    if(!isset($userNameCache[$senderId])) {
-        $u = new User;
-        $u->load_by_id($senderId);
-        $userNameCache[$senderId] = $u->Index ? $u->getName() : ('User '.$senderId);
-    }
-    return $userNameCache[$senderId];
+    return mailListResolveUserName($senderId, $userNameCache);
 };
+
+$mailListChunk = null;
+if(!$viewMail) {
+    $mailListChunk = listChunkUserMails($userId, '', 50);
+}
+
 adminListPageBegin('Kommunikation', 'Meine Nachrichten');
 ?>
 <?php if($viewMail) {
@@ -101,53 +80,29 @@ adminListPageBegin('Kommunikation', 'Meine Nachrichten');
     </div>
   </div>
 </div>
-<?php } ?>
-
-<div class="mail-list">
+<?php } else {
+    adminListSearchField('Nachrichten suchen (Betreff, Absender)…', array('onkeyup' => 'filterMail()'));
+?>
+<div class="mail-list" id="Liste">
     <div class="mail-list-header <?php echo $GLOBALS['optionsDB']['colorTitleBar']; ?>">
       <div>Betreff</div>
       <div></div>
       <div>Aktion</div>
     </div>
 <?php
-if(!$dbr || mysqli_num_rows($dbr) === 0) {
-    echo '<div class="mail-list-item"><div class="mail-list-primary">Keine Nachrichten vorhanden.</div></div>';
+if($mailListChunk['html'] === '') {
+    echo '<div class="mail-list-item mail-list-empty"><div class="mail-list-primary">Keine Nachrichten vorhanden.</div></div>';
 }
 else {
-    while($row = mysqli_fetch_assoc($dbr)) {
-        $id = (int)$row['Index'];
-        $unread = empty($row['ReadAt']);
-        $when = htmlspecialchars($formatMailDate($row['Created']), ENT_QUOTES, 'UTF-8');
-        $sender = htmlspecialchars($resolveSender(isset($row['SenderId']) ? $row['SenderId'] : 0), ENT_QUOTES, 'UTF-8');
-        $subject = $row['Subject'] !== '' && $row['Subject'] !== null
-            ? htmlspecialchars((string)$row['Subject'], ENT_QUOTES, 'UTF-8')
-            : '<em>(ohne Betreff)</em>';
-        $rowCls = $unread ? ' mail-unread' : '';
-        $neu = $unread
-            ? '<span class="w3-tag '.$GLOBALS['optionsDB']['colorLogEmail'].'">neu</span>'
-            : '';
-        $mailFail = (isset($row['Status']) && $row['Status'] === 'failed')
-            ? ' <span class="w3-tag '.(isset($GLOBALS['optionsDB']['colorLogError']) ? $GLOBALS['optionsDB']['colorLogError'] : 'w3-red').'">E-Mail fehlgeschlagen</span>'
-            : '';
-        if($unread) {
-            $subject = '<strong>'.$subject.'</strong>';
-        }
-        echo '<div class="mail-list-item'.$rowCls.'">';
-        echo '<div class="mail-list-primary"><a href="meine-mails.php?id='.$id.'">'.$subject.'</a></div>';
-        echo '<div class="mail-list-meta">'.$when.' · '.$sender.'</div>';
-        echo '<div class="mail-list-status">'.$neu.$mailFail.'</div>';
-        echo '<div class="mail-list-actions">';
-        echo '<a class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnEdit'].'" href="meine-mails.php?id='.$id.'">Anzeigen</a>';
-        echo '<form method="post" action="meine-mails.php" onsubmit="return confirm(\'Nachricht ausblenden?\');">';
-        echo '<input type="hidden" name="id" value="'.$id.'" />';
-        echo '<button type="submit" name="delete" value="1" class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnNo'].'">Ausblenden</button>';
-        echo '</form>';
-        echo '</div>';
-        echo '</div>';
-    }
+    echo $mailListChunk['html'];
 }
+echo listChunkRenderSentinel('meineMails', $mailListChunk['nextCursor'], $mailListChunk['hasMore'], 'filterMail');
 ?>
 </div>
+<script src="js/listRowSearch.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script src="js/filterMail.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<script src="js/infiniteScroll.js?<?php echo $GLOBALS['version']['Hash']; ?>"></script>
+<?php } ?>
 <?php
 adminListPageEnd();
 include "common/footer.php";

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -1366,6 +1366,15 @@ a.app-titlebar-logo {
   background-color: #ffffcc;
 }
 
+.mail-list-item.list-filtered-out,
+.mail-list-item.mail-list-empty.list-filtered-out {
+  display: none !important;
+}
+
+.mail-list > #listSentinel {
+  grid-column: 1 / -1;
+}
+
 .mail-list-primary {
   grid-area: primary;
   min-width: 0;
@@ -1484,41 +1493,102 @@ a.app-titlebar-logo {
 }
 
 @media (max-width: 600px) {
+  .mail-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
   .mail-list-header {
     display: none;
   }
 
   .mail-list-item {
-    display: block;
-    padding: 0.85rem 0.6rem;
-    margin-bottom: 0.65rem;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    border-radius: 4px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "primary status"
+      "meta meta"
+      "actions actions";
+    column-gap: 0.5rem;
+    row-gap: 0.3rem;
+    align-items: start;
+    padding: 0.65rem 0.7rem;
+    margin-bottom: 0;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 6px;
+    background: #fff;
   }
 
   .mail-list-primary {
-    display: block;
-    font-size: 1.05em;
-    margin-bottom: 0.35rem;
+    grid-area: primary;
+    font-size: 1em;
+    margin: 0;
+    line-height: 1.3;
   }
 
-  .mail-list-meta,
-  .mail-list-status {
-    display: block;
+  .mail-list-primary a {
+    text-decoration: none;
+  }
+
+  .mail-list-meta {
+    grid-area: meta;
+    margin: 0;
     text-align: left;
     white-space: normal;
-    margin-bottom: 0.25rem;
+    line-height: 1.35;
+    font-size: 0.8em;
+  }
+
+  .mail-list-status {
+    grid-area: status;
+    margin: 0;
+    text-align: right;
+    white-space: nowrap;
+    justify-self: end;
+    align-self: start;
+    line-height: 1.3;
+  }
+
+  .mail-list-status .mail-counts-cell {
+    display: block;
+    margin-top: 0.15rem;
+    font-size: 0.85em;
+    opacity: 0.85;
+    text-align: right;
   }
 
   .mail-list-actions {
-    display: flex;
-    justify-content: flex-start;
-    margin-top: 0.5rem;
+    grid-area: actions;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.35rem;
+    margin-top: 0.25rem;
+    justify-content: stretch;
+  }
+
+  .mail-list-actions form {
+    display: block;
+    margin: 0;
   }
 
   .mail-list-actions .w3-button,
   .mail-list-actions .w3-btn {
-    width: auto;
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    text-align: center;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+
+  /* Odd last child (1 or 3 buttons): full-width bottom row */
+  .mail-list-actions > :last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+  }
+
+  .mail-list > #listSentinel {
+    margin-top: 0.25rem;
   }
 
   .mail-compose-panel {

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -92,7 +92,7 @@ $sections[] = array(
     'title' => 'Meine Nachrichten',
     'body' => '
 <p>Über das Brief-Symbol öffnest du deinen Posteingang in der Meldeliste. Dort erscheinen Nachrichten, die über die App an dich verschickt wurden.</p>
-<p>Ungelesene Nachrichten werden in der Navigation als Badge angezeigt. Öffne eine Nachricht, um sie zu lesen; der Status aktualisiert sich entsprechend.</p>
+<p>Ungelesene Nachrichten werden in der Navigation als Badge angezeigt. Öffne eine Nachricht, um sie zu lesen; der Status aktualisiert sich entsprechend. Lange Listen werden beim Scrollen nachgeladen; die Suchleiste filtert die bereits geladenen Einträge nach Betreff oder Absender.</p>
 '
 );
 
@@ -215,7 +215,7 @@ $sections[] = array(
     'body' => '
 <p>Unter Admin → <b>Email versenden</b> erstellst du Nachrichten an Verteiler oder einzelne Empfänger.</p>
 <p>Unter Admin → <b>Gruppen</b> legst du wiederverwendbare Gruppen an. <b>Mitglieder</b> sind die Union aus Rollen, Registern und einzelnen Personen (z.&nbsp;B. Posaunen + Schlagwerk + Klarinetten + einzelne Personen). Diese Gruppen kannst du beim Mailversand und bei der Termin-Sichtbarkeit als Chip auswählen. Unter <b>Vererbte Rechte</b> kannst du einer Gruppe Rechte setzen (z.&nbsp;B. „Versteckte Termine“ für den Vorstand) – alle Mitglieder erhalten diese zusätzlich zu ihren persönlichen. Einzelne Personen kannst du den Gruppen auch direkt im Profil (Anlegen/Bearbeiten) zuordnen.</p>
-<p>Beim Mailversand kannst du Chips für Rollen, Gruppen, Register, Personen und <b>Teilnehmer</b> (ja/vielleicht) zukünftiger Termine wählen. Über <b>Email an Teilnehmer</b> am Termin wird der passende Teilnehmer-Chip vorausgewählt. Mails werden in einer Warteschlange verarbeitet; den Versandstatus siehst du in der Admin-Ansicht (<b>Versendet</b> nur bei erfolgreichem SMTP; Fehler und teilweise fehlgeschlagene Jobs werden dort mitgezählt). Bei versendeten Mails siehst du den gewählten <b>Verteiler</b> sowie die Liste der einzelnen Empfänger. Empfänger finden die Nachricht unter <b>Meine Nachrichten</b> (auch wenn der E-Mail-Versand fehlgeschlagen ist, sofern die Inbox aktiv war).</p>
+<p>Beim Mailversand kannst du Chips für Rollen, Gruppen, Register, Personen und <b>Teilnehmer</b> (ja/vielleicht) zukünftiger Termine wählen. Über <b>Email an Teilnehmer</b> am Termin wird der passende Teilnehmer-Chip vorausgewählt. Mails werden in einer Warteschlange verarbeitet; den Versandstatus siehst du in der Admin-Ansicht (<b>Versendet</b> nur bei erfolgreichem SMTP; Fehler und teilweise fehlgeschlagene Jobs werden dort mitgezählt). Bei versendeten Mails siehst du den gewählten <b>Verteiler</b> sowie die Liste der einzelnen Empfänger. Empfänger finden die Nachricht unter <b>Meine Nachrichten</b> (auch wenn der E-Mail-Versand fehlgeschlagen ist, sofern die Inbox aktiv war). Die Übersicht lädt lange Listen beim Scrollen nach; die Suchleiste filtert nach Betreff, Absender, Status oder ID.</p>
 <p>Falls Discord angebunden ist, kann der Versand optional auch dort veröffentlicht werden (nur bei konfiguriertem Webhook).</p>
 '
 );


### PR DESCRIPTION
## Summary
- Suchleiste und Infinite Scroll für Admin-Mail-Liste (`mail.php`) und Meine Nachrichten (`meine-mails.php`)
- Chunk-API `getList.php` (`mailJobs` / `meineMails`), kompakte Meta-Daten und Mobile-Layout
- Hilfe-Texte ergänzt

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-144

## Test plan
- [ ] Admin → Email versenden: Suche filtert Betreff/Absender/Status/ID; Scroll lädt weitere Einträge
- [ ] Meine Nachrichten: gleiche Suche/Nachladen
- [ ] Schmaler Viewport: Status neben Betreff, Buttons im 2er-Raster, Datum kompakt
- [ ] Versand-Status-Polling bei queued/processing weiterhin sichtbar