### PR TITLE
MELD-149: Meldungen-Übersicht und Modal in melde-row-Optik

### DIFF
--- a/libs/termin.php
+++ b/libs/termin.php
@@ -1901,121 +1901,106 @@ class Termin
         if($this->Shifts) return $this->printShiftResponseLine();
         return $this->getResponseLine(0);
     }
+    /**
+     * Status chips for response overview cards (MELD-149).
+     */
+    protected function renderResponseStatusChips($ja, $nein, $vielleicht, $allLabel = '') {
+        $h = function ($s) {
+            return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
+        };
+        $html = '<div class="melde-response-chips">';
+        if($allLabel !== '') {
+            $html .= '<span class="melde-response-chip melde-response-chip--sum" title="Gemeldet / Register">'
+                .'<i class="fas fa-user-friends" aria-hidden="true"></i> '.$h($allLabel).'</span>';
+        }
+        $html .= '<span class="melde-response-chip '.$GLOBALS['optionsDB']['colorBtnYes'].'" title="Zusagen">'
+            .'&#10004; '.(int)$ja.'</span>';
+        $html .= '<span class="melde-response-chip '.$GLOBALS['optionsDB']['colorBtnNo'].'" title="Absagen">'
+            .'&#10008; '.(int)$nein.'</span>';
+        $html .= '<span class="melde-response-chip '.$GLOBALS['optionsDB']['colorBtnMaybe'].'" title="Unsicher">'
+            .'? '.(int)$vielleicht.'</span>';
+        $html .= '</div>';
+        return $html;
+    }
+
+    /**
+     * Melde-row shell for Meldungen / Mein Register / Archiv (MELD-149).
+     * @param string $onclick JS for card click (empty = no row click)
+     * @param string $actionsHtml right-side chips / meta
+     * @param string $bodyHtml optional content below the main row
+     */
+    protected function renderMeldeResponseCard($filterregister, $onclick, $actionsHtml, $bodyHtml = '') {
+        $tid = (int)$this->Index;
+        $filterregister = (int)$filterregister;
+        $h = function ($s) {
+            return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
+        };
+        $name = $this->Name !== null && $this->Name !== '' ? (string)$this->Name : 'Termin';
+        $classes = array('melde-row', 'melde-response-row', 'w3-card-4');
+        $bg = isset($GLOBALS['optionsDB']['colorInputBackground'])
+            ? (string)$GLOBALS['optionsDB']['colorInputBackground'] : '';
+        if($bg !== '') {
+            $classes[] = $bg;
+        }
+        $attrs = ' id="responseLine'.$tid.'" data-termin="'.$tid.'" data-register="'.$filterregister.'"'
+            .' class="'.implode(' ', $classes).'" '.$this->getSearchDataAttr();
+        if($onclick !== '') {
+            $attrs .= ' onclick="'.$onclick.'" role="button" tabindex="0"'
+                .' onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();'.$onclick.';}"';
+        }
+        $html = '<div'.$attrs.'>';
+        $html .= '<div class="melde-row-main">';
+        $html .= '<div class="melde-date-col">'.$this->makeListDateInfo().'</div>';
+        $html .= '<div class="melde-date-rail" aria-hidden="true"></div>';
+        $html .= '<div class="melde-main">';
+        $html .= '<div class="melde-title">'.$h($name).'</div>';
+        $ort = trim((string)$this->getOrt());
+        if($ort !== '') {
+            $html .= '<div class="melde-ort">'.$h($ort).'</div>';
+        }
+        $html .= '</div>';
+        $html .= '<div class="melde-actions">'.$actionsHtml.'</div>';
+        $html .= '</div>'; // melde-row-main
+        if($bodyHtml !== '') {
+            $html .= $bodyHtml;
+        }
+        $html .= '</div>';
+        return $html;
+    }
+
     public function printShiftResponseLine() {
-        $str="";
-        $indent=1;
-
-        $containerdiv = new div;
-        $containerdiv->indent=$indent;
-        $containerdiv->id="responseLine".$this->Index;
-        $containerdiv->class="w3-margin-top w3-border w3-border-black w3-card";
-        $containerdiv->class=$GLOBALS['optionsDB']['colorInputBackground'];
-        $containerdiv->extraAttrs = $this->getSearchDataAttr();
-        $str=$str.$containerdiv->open();
-        $indent++;
-        
-        $maindiv = new div;
-        $maindiv->indent=$indent;
-        $maindiv->class="w3-container w3-center";
-        $str=$str.$maindiv->open();
-        $indent++;
-        
-        $mainheader = new div;
-        $mainheader->tag="h3";
-        $mainheader->class="w3-left";
-        $mainheader->body=$this->Name;
-        $mainheader->indent=$indent;
-        $str=$str.$mainheader->print();
-
-        $mainheader = new div;
-        $mainheader->tag="p";
-        $mainheader->class="w3-right";
-        $mainheader->body=$this->getGermanDate();
-        $mainheader->indent=$indent;
-        $str=$str.$mainheader->print();
-
-        $str=$str.$maindiv->close();
-        $indent--;
-
-        $content = new div;
-        $content->indent=$indent;
-        $content->class="w3-container w3-margin-bottom";
-        $str=$str.$content->open();
-        $indent++;
-        
         $shifts = $this->getShifts();
+        $body = '<div class="melde-response-body">';
         if(count($shifts) === 0) {
-            $empty = new div;
-            $empty->indent=$indent;
-            $empty->class="w3-padding w3-text-gray";
-            $empty->body="Noch keine Schichten &amp; Aufgaben angelegt.";
-            $str=$str.$empty->print();
+            $body .= '<div class="melde-response-empty">Noch keine Schichten &amp; Aufgaben angelegt.</div>';
         }
-        for($i=0; $i<count($shifts); $i++) {
-            $s = new Shift;
-            $s->load_by_id($shifts[$i]);
-            $shift = new div;
-            $shift->indent=$indent;
-            $shift->onclick="openModal('shiftResponse', ".$s->Index.")";
-            $shift->class="w3-row w3-border-bottom w3-border-black";
-            $str=$str.$shift->open();
-            $indent++;
-            
-            $shiftname = new div;
-            $shiftname->indent=$indent;
-            $shiftname->class="w3-col l4 m2 s2";
-            $shiftname->body=$s->Name;
-            $shiftname->bold();
-            $str=$str.$shiftname->print();
-
-            $shifttime = new div;
-            $shifttime->indent=$indent;
-            $shifttime->class="w3-col l4 m2 s2";
-            $shifttime->body=$s->getTime();
-            $str=$str.$shifttime->print();
-
-            $shiftbedarf = new div;
-            $shiftbedarf->indent=$indent;
-            $shiftbedarf->class="w3-col l1 m2 s2 w3-center";
-            $shiftbedarf->body="<i class=\"fas fa-user-friends\"></i> ";
-            $shiftbedarf->body=$s->Bedarf;
-            $str=$str.$shiftbedarf->print();
-
-            $shiftresponseY = new div;
-            $shiftresponseY->indent=$indent;
-            $shiftresponseY->class="w3-col l1 m2 s2 w3-center";
-            $shiftresponseY->class=$GLOBALS['optionsDB']['colorBtnYes'];
-            $shiftresponseY->body="&#10004; ";
-            $shiftresponseY->body=$s->getMeldungenVal(1);
-            $str=$str.$shiftresponseY->print();
-
-            $shiftresponseN = new div;
-            $shiftresponseN->indent=$indent;
-            $shiftresponseN->class="w3-col l1 m2 s2 w3-center";
-            $shiftresponseN->class=$GLOBALS['optionsDB']['colorBtnNo'];
-            $shiftresponseN->body="&#10008; ";
-            $shiftresponseN->body=$s->getMeldungenVal(2);
-            $str=$str.$shiftresponseN->print();
-
-            $shiftresponseM = new div;
-            $shiftresponseM->indent=$indent;
-            $shiftresponseM->class="w3-col l1 m2 s2 w3-center";
-            $shiftresponseM->class=$GLOBALS['optionsDB']['colorBtnMaybe'];
-            $shiftresponseM->body="? ";
-            $shiftresponseM->body=$s->getMeldungenVal(3);
-            $str=$str.$shiftresponseM->print();
-
-            $str=$str.$shift->close();
-            $indent--;
-
+        else {
+            foreach($shifts as $shiftId) {
+                $s = new Shift;
+                $s->load_by_id($shiftId);
+                $ja = (int)$s->getMeldungenVal(1);
+                $nein = (int)$s->getMeldungenVal(2);
+                $vielleicht = (int)$s->getMeldungenVal(3);
+                $bedarf = (int)$s->Bedarf;
+                $allLabel = $bedarf > 0 ? ($ja.' / '.$bedarf) : '';
+                $time = (string)$s->getTime();
+                $body .= '<div class="melde-shift melde-response-shift" role="button" tabindex="0"'
+                    .' onclick="event.stopPropagation();openModal(\'shiftResponse\', '.(int)$s->Index.')"'
+                    .' onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();event.stopPropagation();openModal(\'shiftResponse\', '.(int)$s->Index.');}">';
+                $body .= '<div class="melde-shift-info">';
+                $body .= '<div class="melde-shift-name">'.htmlspecialchars((string)$s->Name, ENT_QUOTES, 'UTF-8').'</div>';
+                if($time !== '') {
+                    $body .= '<div class="melde-shift-time">'.htmlspecialchars($time, ENT_QUOTES, 'UTF-8').'</div>';
+                }
+                $body .= '</div>';
+                $body .= '<div class="melde-actions">';
+                $body .= $this->renderResponseStatusChips($ja, $nein, $vielleicht, $allLabel);
+                $body .= '</div>';
+                $body .= '</div>';
+            }
         }
-                
-        $str=$str.$content->close();
-        $indent--;
-        $str=$str.$containerdiv->close();
-        $indent--;
-
-        return $str;
+        $body .= '</div>';
+        return $this->renderMeldeResponseCard(0, '', '', $body);
     }
 
     public function getShiftResponseModalHtml($s) {
@@ -2034,6 +2019,9 @@ class Termin
             'yesHtml' => $this->renderShiftResponseNames($yesNames, $colorYes),
             'maybeHtml' => $this->renderShiftResponseNames($maybeNames, $colorMaybe),
             'noHtml' => $this->renderShiftResponseNames($noNames, $colorNo),
+            'countYes' => count($yesNames),
+            'countMaybe' => count($maybeNames),
+            'countNo' => count($noNames),
         ));
     }
 
@@ -2042,13 +2030,20 @@ class Termin
      */
     private function renderShiftResponseNames(array $names, $colorClass) {
         if(!count($names)) {
-            return '<div class="profile-value">—</div>';
+            return '';
         }
         $html = '';
         foreach($names as $name) {
-            $html .= '<div class="shift-response-name '.$colorClass.'">'
-                .htmlspecialchars((string)$name, ENT_QUOTES, 'UTF-8')
-                .'</div>';
+            $html .= render('termin/response_line', array(
+                'entry' => array(
+                    'colorClass' => $colorClass,
+                    'name' => (string)$name,
+                    'instrument' => '',
+                    'children' => null,
+                    'guests' => null,
+                    'freeText' => null,
+                ),
+            ));
         }
         return $html;
     }
@@ -2083,18 +2078,18 @@ class Termin
      * @return array
      */
     protected function fetchResponseMeldungenRows() {
-        $sql = sprintf("(SELECT `Index`, `Timestamp`, `User`, `Termin`, `Wert`, `Instrument` AS `mInstrument`, `Guests`, `Nachname`, `Vorname`, `iName`, `Children`, `Register`, `rIndex`, `rName` FROM `%sMeldungen`
+        $sql = sprintf("(SELECT `Index`, `Timestamp`, `User`, `Termin`, `Wert`, `Instrument` AS `mInstrument`, `Guests`, `Nachname`, `Vorname`, `iName`, `Children`, `Register`, `rIndex`, `rName`, `rColor` FROM `%sMeldungen`
 INNER JOIN (SELECT `Index` AS `uIndex`, `Vorname`, `Nachname`, `Instrument` AS `iInstrument` FROM `%sUser`) `%sUser` ON `User` = `uIndex`
 INNER JOIN (SELECT `Index` AS `iIndex`, `Register`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `%sUser`.`iInstrument` = `iIndex`
-INNER JOIN (SELECT `Index` AS `rIndex`, `Name` AS `rName`, `Sortierung` FROM `%sRegister`) `%sRegister` ON `Register` = `rIndex`
+INNER JOIN (SELECT `Index` AS `rIndex`, `Name` AS `rName`, `Sortierung`, `Color` AS `rColor` FROM `%sRegister`) `%sRegister` ON `Register` = `rIndex`
 WHERE `Termin` = '%d' AND `%sMeldungen`.`Instrument` = '0')
 
 UNION
 
-(SELECT `Index`, `Timestamp`, `User`, `Termin`, `Wert`, `Instrument` AS `iInstrument`, `Guests`, `Nachname`, `Vorname`, `iName`, `Children`, `Register`, `rIndex`, `rName` FROM `%sMeldungen`
+(SELECT `Index`, `Timestamp`, `User`, `Termin`, `Wert`, `Instrument` AS `iInstrument`, `Guests`, `Nachname`, `Vorname`, `iName`, `Children`, `Register`, `rIndex`, `rName`, `rColor` FROM `%sMeldungen`
 INNER JOIN (SELECT `Index` AS `uIndex`, `Vorname`, `Nachname`, `Instrument` AS `mInstrument` FROM `%sUser`) `%sUser` ON `User` = `uIndex`
 INNER JOIN (SELECT `Index` AS `iIndex`, `Register`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `%sMeldungen`.`Instrument` = `iIndex`
-INNER JOIN (SELECT `Index` AS `rIndex`, `Name` AS `rName`, `Sortierung` FROM `%sRegister`) `%sRegister` ON `Register` = `rIndex`
+INNER JOIN (SELECT `Index` AS `rIndex`, `Name` AS `rName`, `Sortierung`, `Color` AS `rColor` FROM `%sRegister`) `%sRegister` ON `Register` = `rIndex`
 WHERE `Termin` = '%d' AND `%sMeldungen`.`Instrument` != '0')
 
 ORDER BY `Nachname`, `Vorname`;",
@@ -2132,182 +2127,192 @@ ORDER BY `Nachname`, `Vorname`;",
 
     public function getResponseLine($filterregister) {
         $filterregister = (int)$filterregister;
+        $bus = ($this->vName == 'Bus');
+        $modalOpen = "openModal('terminResponse', ".$this->Index.($filterregister ? ', '.$filterregister : '').')';
 
-        if($this->vName == "Bus") {
-            $cols = (int)$GLOBALS['optionsDB']['showChildOption']+(int)$GLOBALS['optionsDB']['showGuestOption']+2;
-            $bus=true;
+        if($this->Auftritt && $filterregister) {
+            $lists = $this->buildResponseLists($filterregister);
+            $ja = count($lists['whoYes']);
+            $nein = count($lists['whoNo']);
+            $vielleicht = count($lists['whoMaybe']);
+            $actions = $this->renderResponseStatusChips($ja, $nein, $vielleicht);
+            return $this->renderMeldeResponseCard($filterregister, $modalOpen, $actions);
         }
-        else {
-            $cols = 2;
-            $bus=false;
-        }
-        if($this->defaultFreeText && isAdmin()) $cols++;
-        switch($cols) {
-        case 3:
-            $colsize = array(4,3,5);
-            break;
-        case 4:
-            $colsize = array(4,4,2,2);
-            break;
-        case 5:
-            $colsize = array(3,3,2,2,2);
-            break;
-        case 2:
-        default:
-            $colsize = array(6,6);
-            break;
-        }
-
-        $modalOpen = "openModal('terminResponse', ".$this->Index.($filterregister ? ", ".$filterregister : "").")";
-        $str = "<div id=\"responseLine".$this->Index."\" data-termin=\"".$this->Index."\" data-register=\"".$filterregister."\" ".$this->getSearchDataAttr()." class=\"w3-card w3-border w3-margin-top w3-border-black ".$GLOBALS['optionsDB']['colorInputBackground']."\"><div onclick=\"".$modalOpen."\" class=\"w3-container w3-center\"><h3 class=\"w3-left\">".$this->Name."</h3><p class=\"w3-right\">".$this->getGermanDate()."</p></div>\n";
-        $str=$str."<div onclick=\"".$modalOpen."\" class=\"w3-container w3-margin-bottom\">\n";
 
         if($this->Auftritt) {
-            if($filterregister) {
-                $lists = $this->buildResponseLists($filterregister);
-                $str=$str.$this->renderResponseEntries($lists['whoYes'], $lists['colsize'])
-                    .$this->renderResponseEntries($lists['whoNo'], $lists['colsize'])
-                    .$this->renderResponseEntries($lists['whoMaybe'], $lists['colsize']);
+            $aMeldungen = $this->fetchResponseMeldungenRows();
+            if($GLOBALS['optionsDB']['showConductor']) {
+                $sql = sprintf(
+                    "SELECT `Index`, `Name` FROM `%sRegister` WHERE `Name` != 'keins' ORDER BY `Sortierung`;",
+                    $GLOBALS['dbprefix']
+                );
             }
             else {
-                $aMeldungen = $this->fetchResponseMeldungenRows();
-                if($GLOBALS['optionsDB']['showConductor']) {
-                    $sql = sprintf("SELECT `Index`, `Name` FROM `%sRegister` WHERE `Name` != 'keins' ORDER BY `Sortierung`;",
+                $sql = sprintf(
+                    "SELECT `Index`, `Name` FROM `%sRegister` WHERE `Name` != 'Dirigent' AND `Name` != 'keins' ORDER BY `Sortierung`;",
                     $GLOBALS['dbprefix']
-                    );
-                }
-                else {
-                    $sql = sprintf("SELECT `Index`, `Name` FROM `%sRegister` WHERE `Name` != 'Dirigent' AND `Name` != 'keins' ORDER BY `Sortierung`;",
-                    $GLOBALS['dbprefix']
-                    );
-                }
-                $dbr = mysqli_query($GLOBALS['conn'], $sql);
-                sqlerror();
-                $memberCounts = $this->getRegisterMemberCounts();
-                $sja=0;
-                $sall=0;
-                $snReg=0;
-                $snein=0;
-                $svielleicht=0;
-                $childrenYes=0;
-                $guestsYes=0;
-                $childrenMaybe=0;
-                $guestsMaybe=0;
-                while($row = mysqli_fetch_array($dbr)) {
-                    $regId = (int)$row['Index'];
-                    $nReg = isset($memberCounts[$regId]) ? (int)$memberCounts[$regId] : 0;
-                    $snReg+=$nReg;
-                    $ja=0;
-                    $nein=0;
-                    $vielleicht=0;
-                    foreach($aMeldungen as $row2) {
-                        if((int)$row2['rIndex'] != $regId) continue;
-                        switch($row2['Wert']) {
-                        case 1:
-                            $ja++;
-                            $sja++;
-                            if($GLOBALS['optionsDB']['showChildOption'] && $bus) {
-                                $childrenYes+=$row2['Children'];
-                            }
-                            if($GLOBALS['optionsDB']['showGuestOption'] && $bus) {
-                                $guestsYes+=$row2['Guests'];
-                            }
-                            break;
-                        case 2:
-                            $nein++;
-                            $snein++;
-                            break;
-                        case 3:
-                            $vielleicht++;
-                            $svielleicht++;
-                            if($GLOBALS['optionsDB']['showChildOption'] && $bus) {
-                                $childrenMaybe+=$row2['Children'];
-                            }
-                            if($GLOBALS['optionsDB']['showGuestOption'] && $bus) {
-                                $guestsMaybe+=$row2['Guests'];
-                            }
-                            break;
-                        default:
-                            break;
-                        }
-                    }
-
-                    $all = $ja+$nein+$vielleicht;
-                    $sall=$sall+$all;
-                    $str=$str."<div class=\"w3-row w3-border-bottom w3-border-black\"><div class=\"".$GLOBALS['optionsDB']['HoverEffect']." w3-col l7 m4 s4\">".$row['Name']."</div>\n<div class=\"w3-col l2 m2 s2\">".$all." / ".sprintf("%02d", $nReg)."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnYes']." w3-col l1 m2 s2 w3-center w3-opacity-min\">&#10004; ".$ja."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnNo']." w3-col l1 m2 s2 w3-center w3-opacity-min\">&#10008; ".$nein."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnMaybe']." w3-col l1 m2 s2 w3-center w3-opacity-min\">? ".$vielleicht."</div>\n</div>\n";
-                }
-                if($bus && $GLOBALS['optionsDB']['showChildOption']) {
-                    $str=$str."<div class=\"w3-row\"><div class=\"w3-col l9 m6 s6\">Kinder</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnYes']." w3-col l1 m2 s2 w3-center\">&#10004; ".$childrenYes."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnNo']." w3-col l1 m2 s2 w3-center\">&#10008; 0</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnMaybe']." w3-col l1 m2 s2 w3-center\">? ".$childrenMaybe."</div>\n</div>\n";
-                }
-                if($bus && $GLOBALS['optionsDB']['showGuestOption']) {
-                    $str=$str."<div class=\"w3-row\"><div class=\"w3-col l9 m6 s6\">G&auml;ste</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnYes']." w3-col l1 m2 s2 w3-center\">&#10004; ".$guestsYes."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnNo']." w3-col l1 m2 s2 w3-center\">&#10008; 0</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnMaybe']." w3-col l1 m2 s2 w3-center\">? ".$guestsMaybe."</div>\n</div>\n";
-                }
-                $str=$str."<div class=\"w3-row\"><div class=\"".$GLOBALS['optionsDB']['HoverEffect']." w3-col l7 m4 s4\"><b>Summe</b></div>\n<div class=\"w3-col l2 m2 s2\"><b>".$sall;
-                if($bus && ($GLOBALS['optionsDB']['showChildOption'] || $GLOBALS['optionsDB']['showGuestOption'])) {
-                    $str=$str."+".($childrenYes+$childrenMaybe+$guestsYes+$guestsMaybe);
-                }
-                $str=$str." / ".sprintf("%02d", $snReg)."</b></div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnYes']." w3-col l1 m2 s2 w3-center\">&#10004; ".($sja+$childrenYes+$guestsYes)."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnNo']." w3-col l1 m2 s2 w3-center\">&#10008; ".$snein."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnMaybe']." w3-col l1 m2 s2 w3-center\">? ".($svielleicht+$childrenMaybe+$guestsMaybe)."</div>\n</div>\n";
+                );
             }
+            $dbr = mysqli_query($GLOBALS['conn'], $sql);
+            sqlerror();
+            $memberCounts = $this->getRegisterMemberCounts();
+            $sja = 0;
+            $sall = 0;
+            $snReg = 0;
+            $snein = 0;
+            $svielleicht = 0;
+            $childrenYes = 0;
+            $guestsYes = 0;
+            $childrenMaybe = 0;
+            $guestsMaybe = 0;
+            $regRows = '';
+            while($row = mysqli_fetch_array($dbr)) {
+                $regId = (int)$row['Index'];
+                $nReg = isset($memberCounts[$regId]) ? (int)$memberCounts[$regId] : 0;
+                $snReg += $nReg;
+                $ja = 0;
+                $nein = 0;
+                $vielleicht = 0;
+                foreach($aMeldungen as $row2) {
+                    if((int)$row2['rIndex'] != $regId) continue;
+                    switch($row2['Wert']) {
+                    case 1:
+                        $ja++;
+                        $sja++;
+                        if($GLOBALS['optionsDB']['showChildOption'] && $bus) {
+                            $childrenYes += (int)$row2['Children'];
+                        }
+                        if($GLOBALS['optionsDB']['showGuestOption'] && $bus) {
+                            $guestsYes += (int)$row2['Guests'];
+                        }
+                        break;
+                    case 2:
+                        $nein++;
+                        $snein++;
+                        break;
+                    case 3:
+                        $vielleicht++;
+                        $svielleicht++;
+                        if($GLOBALS['optionsDB']['showChildOption'] && $bus) {
+                            $childrenMaybe += (int)$row2['Children'];
+                        }
+                        if($GLOBALS['optionsDB']['showGuestOption'] && $bus) {
+                            $guestsMaybe += (int)$row2['Guests'];
+                        }
+                        break;
+                    default:
+                        break;
+                    }
+                }
+                $all = $ja + $nein + $vielleicht;
+                $sall += $all;
+                $regRows .= '<div class="melde-response-reg">';
+                $regRows .= '<div class="melde-response-reg-name">'.htmlspecialchars((string)$row['Name'], ENT_QUOTES, 'UTF-8').'</div>';
+                $regRows .= $this->renderResponseStatusChips(
+                    $ja,
+                    $nein,
+                    $vielleicht,
+                    $all.' / '.sprintf('%02d', $nReg)
+                );
+                $regRows .= '</div>';
+            }
+            if($bus && $GLOBALS['optionsDB']['showChildOption']) {
+                $regRows .= '<div class="melde-response-reg melde-response-reg--meta">';
+                $regRows .= '<div class="melde-response-reg-name">Kinder</div>';
+                $regRows .= $this->renderResponseStatusChips($childrenYes, 0, $childrenMaybe);
+                $regRows .= '</div>';
+            }
+            if($bus && $GLOBALS['optionsDB']['showGuestOption']) {
+                $regRows .= '<div class="melde-response-reg melde-response-reg--meta">';
+                $regRows .= '<div class="melde-response-reg-name">Gäste</div>';
+                $regRows .= $this->renderResponseStatusChips($guestsYes, 0, $guestsMaybe);
+                $regRows .= '</div>';
+            }
+            $sumYes = $sja + $childrenYes + $guestsYes;
+            $sumMaybe = $svielleicht + $childrenMaybe + $guestsMaybe;
+            $sumAll = (string)$sall;
+            if($bus && ($GLOBALS['optionsDB']['showChildOption'] || $GLOBALS['optionsDB']['showGuestOption'])) {
+                $sumAll .= '+'.($childrenYes + $childrenMaybe + $guestsYes + $guestsMaybe);
+            }
+            $sumAll .= ' / '.sprintf('%02d', $snReg);
+            $actions = $this->renderResponseStatusChips($sumYes, $snein, $sumMaybe, $sumAll);
+            $body = '<div class="melde-response-body">'.$regRows.'</div>';
+            return $this->renderMeldeResponseCard($filterregister, $modalOpen, $actions, $body);
         }
-        else { // $this->Auftritt
-            $sql = sprintf("SELECT * FROM `%sMeldungen` INNER JOIN (SELECT `Index` AS `uIndex`, `Vorname`, `Nachname` FROM `%sUser`) `%sUser` ON `User` = `uIndex` WHERE `Termin` = '%d' ORDER BY `Nachname`, `Vorname`;",
+
+        // Non-Auftritt: aggregate only
+        $sql = sprintf(
+            "SELECT * FROM `%sMeldungen` INNER JOIN (SELECT `Index` AS `uIndex`, `Vorname`, `Nachname` FROM `%sUser`) `%sUser` ON `User` = `uIndex` WHERE `Termin` = '%d' ORDER BY `Nachname`, `Vorname`;",
             $GLOBALS['dbprefix'],
             $GLOBALS['dbprefix'],
             $GLOBALS['dbprefix'],
             $this->Index
-            );
-            $dbr = mysqli_query($GLOBALS['conn'], $sql);
-            sqlerror();
-            $ja=0;
-            $nein=0;
-            $vielleicht=0;
-            $childrenYes=0;
-            $guestsYes=0;
-            $childrenMaybe=0;
-            $guestsMaybe=0;
-            while($row = mysqli_fetch_array($dbr)) {
-                switch($row['Wert']) {
-                case 1:
-                    $ja++;
-                    if($GLOBALS['optionsDB']['showChildOption'] && $bus) {
-                        $childrenYes+=$row['Children'];
-                    }
-                    if($GLOBALS['optionsDB']['showGuestOption'] && $bus) {
-                        $guestsYes+=$row['Guests'];
-                    }
-                    break;
-                case 2:
-                    $nein++;
-                    break;
-                case 3:
-                    $vielleicht++;
-                    $childrenMaybe+=$row['Children'];
-                    $guestsMaybe+=$row['Guests'];
-                    break;
-                default:
-                    break;
+        );
+        $dbr = mysqli_query($GLOBALS['conn'], $sql);
+        sqlerror();
+        $ja = 0;
+        $nein = 0;
+        $vielleicht = 0;
+        $childrenYes = 0;
+        $guestsYes = 0;
+        $childrenMaybe = 0;
+        $guestsMaybe = 0;
+        while($row = mysqli_fetch_array($dbr)) {
+            switch($row['Wert']) {
+            case 1:
+                $ja++;
+                if($GLOBALS['optionsDB']['showChildOption'] && $bus) {
+                    $childrenYes += (int)$row['Children'];
                 }
+                if($GLOBALS['optionsDB']['showGuestOption'] && $bus) {
+                    $guestsYes += (int)$row['Guests'];
+                }
+                break;
+            case 2:
+                $nein++;
+                break;
+            case 3:
+                $vielleicht++;
+                $childrenMaybe += (int)$row['Children'];
+                $guestsMaybe += (int)$row['Guests'];
+                break;
+            default:
+                break;
             }
-            if($bus && $GLOBALS['optionsDB']['showChildOption']) {
-                $str=$str."<div class=\"w3-row\"><div class=\"w3-col l9 m6 s6\">Kinder</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnYes']." w3-col l1 m2 s2 w3-center\">&#10004; ".$childrenYes."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnNo']." w3-col l1 m2 s2 w3-center\">&#10008; ".$nein."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnMaybe']." w3-col l1 m2 s2 w3-center\">? ".$childrenMaybe."</div>\n</div>\n";
-            }
-            if($bus && $GLOBALS['optionsDB']['showGuestOption']) {
-                $str=$str."<div class=\"w3-row\"><div class=\"w3-col l9 m6 s6\">G&auml;ste</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnYes']." w3-col l1 m2 s2 w3-center\">&#10004; ".$guestsYes."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnNo']." w3-col l1 m2 s2 w3-center\">&#10008; ".$nein."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnMaybe']." w3-col l1 m2 s2 w3-center\">? ".$guestsMaybe."</div>\n</div>\n";
-            }
-            $str=$str."<div class=\"w3-row\"><div class=\"w3-col l9 m6 s6\"><b>Summe</b></div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnYes']." w3-col l1 m2 s2 w3-center\">&#10004; ".($ja+$childrenYes+$guestsYes)."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnNo']." w3-col l1 m2 s2 w3-center\">&#10008; ".$nein."</div>\n<div class=\"".$GLOBALS['optionsDB']['colorBtnMaybe']." w3-col l1 m2 s2 w3-center\">? ".($vielleicht+$childrenMaybe+$guestsMaybe)."</div>\n</div>\n";
         }
-        $str=$str."</div></div>\n";
-        return $str;
+        $metaRows = '';
+        if($bus && $GLOBALS['optionsDB']['showChildOption']) {
+            $metaRows .= '<div class="melde-response-reg melde-response-reg--meta">';
+            $metaRows .= '<div class="melde-response-reg-name">Kinder</div>';
+            $metaRows .= $this->renderResponseStatusChips($childrenYes, $nein, $childrenMaybe);
+            $metaRows .= '</div>';
+        }
+        if($bus && $GLOBALS['optionsDB']['showGuestOption']) {
+            $metaRows .= '<div class="melde-response-reg melde-response-reg--meta">';
+            $metaRows .= '<div class="melde-response-reg-name">Gäste</div>';
+            $metaRows .= $this->renderResponseStatusChips($guestsYes, $nein, $guestsMaybe);
+            $metaRows .= '</div>';
+        }
+        $actions = $this->renderResponseStatusChips(
+            $ja + $childrenYes + $guestsYes,
+            $nein,
+            $vielleicht + $childrenMaybe + $guestsMaybe
+        );
+        $body = $metaRows !== '' ? '<div class="melde-response-body">'.$metaRows.'</div>' : '';
+        return $this->renderMeldeResponseCard($filterregister, $modalOpen, $actions, $body);
     }
 
-    private function makeResponseEntry($wert, $name, $instrument, $children, $guests, $userId, $bus) {
-        $colors = array(
+    private function makeResponseEntry($wert, $name, $instrument, $children, $guests, $userId, $bus, $registerColor = '') {
+        $statusColors = array(
             1 => $GLOBALS['optionsDB']['colorBtnYes'],
             2 => $GLOBALS['optionsDB']['colorBtnNo'],
             3 => $GLOBALS['optionsDB']['colorBtnMaybe'],
         );
+        $regHex = function_exists('normalizeHexColor') ? normalizeHexColor($registerColor) : '';
         $entry = array(
-            'colorClass' => isset($colors[$wert]) ? $colors[$wert] : '',
+            'colorClass' => '',
+            'statusClass' => isset($statusColors[$wert]) ? $statusColors[$wert] : '',
+            'registerColor' => $regHex,
             'name' => $name,
             'instrument' => $instrument,
             'children' => null,
@@ -2356,12 +2361,11 @@ ORDER BY `Nachname`, `Vorname`;",
         return $this->_freeTextByUser;
     }
 
-    private function renderResponseEntries($entries, $colsize) {
+    private function renderResponseEntries($entries, $colsize = null) {
         $html = '';
         foreach($entries as $entry) {
             $html .= render('termin/response_line', array(
                 'entry' => $entry,
-                'colsize' => $colsize,
             ));
         }
         return $html;
@@ -2428,15 +2432,16 @@ ORDER BY `Nachname`, `Vorname`;",
                     if((int)$row2['rIndex'] != $registerId) continue;
                     $name = $row2['Vorname']." ".$row2['Nachname'];
                     $instrument = $row2['iName'];
+                    $regColor = isset($row2['rColor']) ? $row2['rColor'] : '';
                     switch($row2['Wert']) {
                     case 1:
-                        $whoYes[] = $this->makeResponseEntry(1, $name, $instrument, $row2['Children'], $row2['Guests'], $row2['User'], $bus);
+                        $whoYes[] = $this->makeResponseEntry(1, $name, $instrument, $row2['Children'], $row2['Guests'], $row2['User'], $bus, $regColor);
                         break;
                     case 2:
-                        $whoNo[] = $this->makeResponseEntry(2, $name, $instrument, $row2['Children'], $row2['Guests'], $row2['User'], $bus);
+                        $whoNo[] = $this->makeResponseEntry(2, $name, $instrument, $row2['Children'], $row2['Guests'], $row2['User'], $bus, $regColor);
                         break;
                     case 3:
-                        $whoMaybe[] = $this->makeResponseEntry(3, $name, $instrument, $row2['Children'], $row2['Guests'], $row2['User'], $bus);
+                        $whoMaybe[] = $this->makeResponseEntry(3, $name, $instrument, $row2['Children'], $row2['Guests'], $row2['User'], $bus, $regColor);
                         break;
                     default:
                         break;
@@ -2482,7 +2487,6 @@ ORDER BY `Nachname`, `Vorname`;",
 
     public function getResponseModalHtml($filterregister = 0) {
         $lists = $this->buildResponseLists($filterregister);
-        $colsize = $lists['colsize'];
         $bus = $lists['bus'];
 
         $orchestraFull = '';
@@ -2514,12 +2518,14 @@ ORDER BY `Nachname`, `Vorname`;",
             'showOrchestra' => $showOrchestra,
             'orchestraFull' => $orchestraFull,
             'orchestraActive' => $orchestraActive,
-            'colsize' => $colsize,
             'showChildrenHeader' => ($GLOBALS['optionsDB']['showChildOption'] && $bus),
             'showGuestsHeader' => ($GLOBALS['optionsDB']['showGuestOption'] && $bus),
-            'whoYesHtml' => $this->renderResponseEntries($lists['whoYes'], $colsize),
-            'whoMaybeHtml' => $this->renderResponseEntries($lists['whoMaybe'], $colsize),
-            'whoNoHtml' => $this->renderResponseEntries($lists['whoNo'], $colsize),
+            'whoYesHtml' => $this->renderResponseEntries($lists['whoYes']),
+            'whoMaybeHtml' => $this->renderResponseEntries($lists['whoMaybe']),
+            'whoNoHtml' => $this->renderResponseEntries($lists['whoNo']),
+            'countYes' => count($lists['whoYes']),
+            'countMaybe' => count($lists['whoMaybe']),
+            'countNo' => count($lists['whoNo']),
         ));
     }
 

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -373,9 +373,14 @@ a.app-titlebar-logo {
 }
 
 .admin-list-body #Liste > [id^="responseLine"],
+.admin-list-body #Liste > .melde-response-row,
 .admin-list-body #Liste > .w3-card {
   margin-top: 0.65rem !important;
   margin-bottom: 0 !important;
+}
+
+.admin-list-body #Liste > .melde-response-row:first-child {
+  margin-top: 0 !important;
 }
 
 /* Seiten ohne Body (Hilfe, …): Chrome padded, Hero negativ zurück auf Kanten */
@@ -2064,9 +2069,21 @@ a.app-titlebar-logo {
 }
 
 /* Orchestra: full vs packed active seating toggle */
+.orchestra-panel {
+  margin: 1rem 1.25rem 0;
+}
+
 .orchestra-panel-header {
-  margin-bottom: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: space-between;
   align-items: baseline;
+  margin-bottom: 0.5rem;
+}
+
+.orchestra-panel-title {
+  font-size: 1rem;
 }
 
 .orchestra-panel-toggle {
@@ -3189,6 +3206,137 @@ body.meld-cal-print {
   word-break: break-word;
 }
 
+/* MELD-149: response modal person lists */
+.modal-shell .profile-subtitle {
+  margin: 0.25rem 0 0;
+  font-weight: 400;
+  opacity: 0.9;
+}
+
+.melde-response-modal-lists {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem 1.25rem 1.25rem;
+}
+
+.melde-response-section-title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem 0.75rem;
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.melde-response-section-hint {
+  margin: -0.15rem 0 0.5rem;
+  font-size: 0.82rem;
+  opacity: 0.8;
+}
+
+.melde-response-list {
+  display: grid;
+  gap: 0.35rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 720px) {
+  .melde-response-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.4rem 0.65rem;
+  }
+}
+
+@media (min-width: 1000px) {
+  .melde-response-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.melde-response-person {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.25rem 0.75rem;
+  align-items: center;
+  padding: 0.45rem 0.65rem;
+  border-radius: 0.3rem;
+}
+
+.melde-response-person--register {
+  background-color: var(--melde-person-reg, transparent);
+  color: var(--melde-person-fg, inherit);
+}
+
+@supports (background: color-mix(in srgb, red 50%, white)) {
+  .melde-response-person--register {
+    background-color: color-mix(in srgb, var(--melde-person-reg) 42%, white);
+    color: #111;
+  }
+}
+
+.melde-response-person--register .melde-response-person-extra {
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.melde-response-person-main {
+  min-width: 0;
+}
+
+.melde-response-person-name {
+  font-weight: 700;
+  line-height: 1.25;
+  word-break: break-word;
+}
+
+.melde-response-person-instrument {
+  margin-top: 0.1rem;
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+.melde-response-person-extras {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  justify-content: flex-end;
+}
+
+.melde-response-person-extra {
+  display: inline-block;
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.2rem;
+  background: rgba(255, 255, 255, 0.45);
+  font-size: 0.8rem;
+  line-height: 1.2;
+  max-width: 14rem;
+  word-break: break-word;
+}
+
+@media (max-width: 600px) {
+  .melde-response-modal-lists {
+    padding: 0.85rem 0.85rem 1rem;
+  }
+
+  .melde-response-person {
+    grid-template-columns: 1fr;
+  }
+
+  .melde-response-person-extras {
+    justify-content: flex-start;
+  }
+
+  .orchestra-panel {
+    margin-left: 0.85rem;
+    margin-right: 0.85rem;
+  }
+
+  .orchestra-panel-toggle {
+    text-align: left;
+  }
+}
+
 .calendar-melde-buttons {
   margin-top: 0;
 }
@@ -4027,7 +4175,7 @@ select.profile-control {
 .melde-row {
   --melde-date-col-w: 9.5rem;
   --melde-date-rail-w: 0.35rem;
-  --melde-date-rail-color: #fff;
+  --melde-date-rail-color: var(--page-title-accent, #345A95);
   --melde-col-gap: 0.85rem;
   --melde-pad-x: 1rem;
   --melde-shift-indent: calc(
@@ -4080,8 +4228,10 @@ select.profile-control {
   outline-offset: 2px;
 }
 
-/* Schicht-Termine: eine durchgehende vertikale Linie Header → Schichten */
-.melde-row:has(> .melde-shift) {
+/* Durchgehende vertikale Linie: Header → Schichten / Register-Body (MELD-149) */
+.melde-row:has(> .melde-shift),
+.melde-row:has(> .melde-response-body),
+.melde-response-row {
   --melde-date-rail-inset: 0.4rem;
   --melde-rail-left: calc(
     var(--melde-pad-x)
@@ -4090,12 +4240,14 @@ select.profile-control {
   );
 }
 
-.melde-row:has(> .melde-shift)::after {
+.melde-row:has(> .melde-shift)::after,
+.melde-row:has(> .melde-response-body)::after,
+.melde-response-row::after {
   content: "";
   position: absolute;
   left: var(--melde-rail-left);
   top: var(--melde-date-rail-inset);
-  bottom: 0;
+  bottom: var(--melde-date-rail-inset);
   width: var(--melde-date-rail-w);
   background: var(--melde-date-rail-color);
   border-radius: 2px;
@@ -4103,7 +4255,9 @@ select.profile-control {
   pointer-events: none;
 }
 
-.melde-row:has(> .melde-shift) > .melde-row-main > .melde-date-rail {
+.melde-row:has(> .melde-shift) > .melde-row-main > .melde-date-rail,
+.melde-row:has(> .melde-response-body) > .melde-row-main > .melde-date-rail,
+.melde-response-row > .melde-row-main > .melde-date-rail {
   visibility: hidden;
 }
 
@@ -4367,6 +4521,120 @@ select.profile-control {
   opacity: 0.9;
 }
 
+/* MELD-149: Meldungen / Mein Register overview cards */
+.melde-response-row .melde-actions {
+  align-items: flex-start;
+}
+
+.melde-response-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.melde-response-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.45rem;
+  border-radius: 0.25rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.melde-response-chip--sum {
+  background: rgba(0, 0, 0, 0.06);
+  font-weight: 500;
+}
+
+.melde-response-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0 var(--melde-pad-x, 1rem) 0.75rem;
+  /*
+   * Rechts vom Strich wie die Titelspalte:
+   * date-col + gap + rail + gap  (+ pad-x kommt über padding-left)
+   */
+  margin-left: calc(
+    var(--melde-date-col-w, 9.5rem)
+    + var(--melde-date-rail-w, 0.35rem)
+    + (2 * var(--melde-col-gap, 0.85rem))
+  );
+}
+
+/* Schichten stecken im Body — kein zweites Melde-Shift-Indent / kein zweiter Strich */
+.melde-response-body > .melde-shift,
+.melde-response-body > .melde-response-shift {
+  margin-left: 0;
+  border-left: none;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.melde-response-empty {
+  padding: 0.35rem 0;
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.melde-response-reg {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.35rem 0.75rem;
+  align-items: center;
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.melde-response-reg:last-child {
+  border-bottom: 0;
+}
+
+.melde-response-reg-name {
+  min-width: 0;
+  font-weight: 600;
+  font-size: 0.92rem;
+  line-height: 1.25;
+}
+
+.melde-response-reg--meta .melde-response-reg-name {
+  font-weight: 500;
+  opacity: 0.9;
+}
+
+.melde-response-shift {
+  cursor: pointer;
+}
+
+.melde-response-shift:hover .melde-shift-name {
+  text-decoration: underline;
+}
+
+@media (max-width: 600px) {
+  /* Body bleibt rechts vom Strich (nicht margin-left: 0) */
+  .melde-response-row .melde-actions {
+    grid-column: 1 / -1;
+  }
+
+  .melde-response-chips {
+    justify-content: flex-start;
+  }
+
+  .melde-response-reg {
+    grid-template-columns: 1fr;
+    gap: 0.3rem;
+  }
+
+  .melde-response-reg .melde-response-chips {
+    justify-content: flex-start;
+  }
+}
+
 @media (max-width: 600px) {
   .melde-row {
     --melde-pad-x: 0.75rem;
@@ -4380,12 +4648,56 @@ select.profile-control {
     max-width: none;
   }
 
+  /* Startseite-Schichten: Kurz-Strich im Header reicht auf Mobile */
   .melde-row:has(> .melde-shift)::after {
     display: none;
   }
 
   .melde-row:has(> .melde-shift) > .melde-row-main > .melde-date-rail {
     visibility: visible;
+  }
+
+  /*
+   * Meldungen/Mein Register (Mobile):
+   * Keine leere Datums-Gutter neben Schichten/Registern —
+   * Strich als linker Kartenrand (volle Höhe), Header: Datum | Titel.
+   */
+  .melde-response-row {
+    --melde-date-col-w: max-content;
+    border-left: var(--melde-date-rail-w) solid var(--melde-date-rail-color);
+    border-radius: 0 0.35rem 0.35rem 0;
+  }
+
+  .melde-response-row::after,
+  .melde-row.melde-response-row:has(> .melde-response-body)::after {
+    display: none !important;
+  }
+
+  .melde-response-row > .melde-row-main > .melde-date-rail {
+    display: none;
+  }
+
+  .melde-response-row .melde-date-col {
+    width: auto;
+    max-width: none;
+  }
+
+  .melde-response-row .melde-row-main {
+    grid-template-columns: max-content minmax(0, 1fr);
+    column-gap: 0.65rem;
+  }
+
+  .melde-response-body {
+    margin-left: 0;
+    padding-top: 0.15rem;
+  }
+
+  /* Response-Schichten: volle Breite unter dem Header */
+  .melde-response-body > .melde-shift,
+  .melde-response-body > .melde-response-shift {
+    margin-left: 0;
+    border-left: none;
+    padding: 0.55rem 0;
   }
 
   .melde-row-main {

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -78,7 +78,7 @@ $sections[] = array(
     'id' => 'mein-register',
     'title' => 'Mein Register',
     'body' => '
-<p>Unter <b>Mein Register</b> siehst du, wie sich die Musikerinnen und Musiker deines Registers zu Terminen gemeldet haben:</p>
+<p>Unter <b>Mein Register</b> siehst du, wie sich die Musikerinnen und Musiker deines Registers zu Terminen gemeldet haben. Die Übersicht nutzt dieselbe Zeilenoptik wie die Startseite (Datum, Titel, Status-Chips); Tippen/Klick öffnet die Namensliste im Detail – Personenzeilen in Registerfarbe, gruppiert nach Zusage / Unsicher / Absage.</p>
 <ul>
 <li>Über die Suchzeile findest du Termine nach Titel, Ort, Datum oder Beschreibung.</li>
 </ul>
@@ -202,8 +202,8 @@ $sections[] = array(
     'title' => 'Admin: Meldungen',
     'visible' => isAdmin() && requirePermission('perm_showResponse'),
     'body' => '
-<p>Unter Admin → <b>Meldungen</b> siehst du Rückmeldungen übergreifend; im <b>Archiv</b> vergangene Termine. Beide Listen haben eine Suchzeile (Titel, Ort, Datum, Beschreibung).</p>
-<p>In Termin- und Register-Ansichten kannst du Rückmeldungs-Modals öffnen. Die Orchesterübersicht skaliert auf die Fensterbreite und zeigt die Besetzung farbig nach Meldestatus (Hover zeigt Name und Status). Mit <b>Nur aktive Besetzung</b> siehst du einen Sitzplan nur mit Zusagen und Unsicheren – ohne Lücken durch Absagen oder fehlende Meldungen.</p>
+<p>Unter Admin → <b>Meldungen</b> siehst du Rückmeldungen übergreifend; im <b>Archiv</b> vergangene Termine. Beide Listen haben eine Suchzeile (Titel, Ort, Datum, Beschreibung) und dieselben kompakten Terminzeilen wie auf der Startseite (Status-Chips, Register-Zusammenfassung).</p>
+<p>In Termin- und Register-Ansichten kannst du Rückmeldungs-Modals öffnen – Namenslisten nach Status gruppiert, Personenzeilen in Registerfarbe. Die Orchesterübersicht skaliert auf die Fensterbreite und zeigt die Besetzung farbig nach Meldestatus (Hover zeigt Name und Status). Mit <b>Nur aktive Besetzung</b> siehst du einen Sitzplan nur mit Zusagen und Unsicheren – ohne Lücken durch Absagen oder fehlende Meldungen.</p>
 '.(requirePermission('perm_editResponse') ? '<p>Mit Recht <b>Rückmeldungen bearbeiten</b> kannst du im Orchesterplan per Klick auf einen Kreis den Status durchschalten: (keine Meldung →) Zusage → Absage → unsicher → Zusage …</p>' : '').'
 '
 );

--- a/views/termin/response_line.php
+++ b/views/termin/response_line.php
@@ -1,39 +1,54 @@
 <?php
-$col = $colsize;
-$actcol = 2;
+/**
+ * One person row in termin/shift response modals (MELD-149).
+ * Expects $entry: registerColor, statusClass, name, instrument, children, guests, freeText
+ */
+$h = function ($s) {
+    return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
+};
+$name = isset($entry['name']) ? (string)$entry['name'] : '';
+$instrument = isset($entry['instrument']) ? (string)$entry['instrument'] : '';
+$regHex = '';
+if(!empty($entry['registerColor']) && function_exists('normalizeHexColor')) {
+    $regHex = normalizeHexColor($entry['registerColor']);
+}
+$statusClass = isset($entry['statusClass']) ? (string)$entry['statusClass'] : '';
+if($statusClass === '' && !empty($entry['colorClass'])) {
+    $statusClass = (string)$entry['colorClass'];
+}
+$extras = array();
+if(isset($entry['children']) && $entry['children'] !== null && $entry['children'] !== false && (int)$entry['children'] > 0) {
+    $extras[] = '+'.(int)$entry['children'].' Kinder';
+}
+if(isset($entry['guests']) && $entry['guests'] !== null && $entry['guests'] !== false && (int)$entry['guests'] > 0) {
+    $extras[] = '+'.(int)$entry['guests'].' Gäste';
+}
+if(isset($entry['freeText']) && $entry['freeText'] !== null && (string)$entry['freeText'] !== '') {
+    $extras[] = (string)$entry['freeText'];
+}
+$cls = 'melde-response-person';
+$style = '';
+if($regHex !== '') {
+    $cls .= ' melde-response-person--register';
+    $fg = function_exists('hexContrastText') ? hexContrastText($regHex) : '#111';
+    $style = ' style="--melde-person-reg:'.$h($regHex).';--melde-person-fg:'.$h($fg).'"';
+}
+elseif($statusClass !== '') {
+    $cls .= ' '.$statusClass;
+}
 ?>
-<div class="w3-row <?php echo $entry['colorClass']; ?>"><div class="w3-col l<?php echo $col[0]; ?> m<?php echo $col[0]; ?> s<?php echo $col[0]; ?>"><?php echo $entry['name']; ?></div>
-<div class="w3-col l<?php echo $col[1]; ?> m<?php echo $col[1]; ?> s<?php echo $col[1]; ?>"><?php echo $entry['instrument'] !== '' ? $entry['instrument'] : '&nbsp;'; ?></div><?php
-if($entry['children'] !== null) {
-    echo '<div class="w3-col l'.$col[$actcol].' m'.$col[$actcol].' s'.$col[$actcol].'">';
-    if($entry['children'] === false) {
-        // empty placeholder for Absage
-    }
-    elseif($entry['children'] > 0) {
-        echo '+ '.$entry['children'];
-    }
-    else {
-        echo '&nbsp;';
-    }
-    echo '</div>';
-    $actcol++;
-}
-if($entry['guests'] !== null) {
-    echo '<div class="w3-col l'.$col[$actcol].' m'.$col[$actcol].' s'.$col[$actcol].'">';
-    if($entry['guests'] === false) {
-        // empty placeholder for Absage
-    }
-    elseif($entry['guests'] > 0) {
-        echo '+ '.$entry['guests'];
-    }
-    else {
-        echo '&nbsp;';
-    }
-    echo '</div>';
-    $actcol++;
-}
-if($entry['freeText'] !== null && $entry['freeText'] !== '') {
-    echo '<div class="w3-col l'.$col[$actcol].' m'.$col[$actcol].' s'.$col[$actcol].'">'.htmlspecialchars((string)$entry['freeText'], ENT_QUOTES, 'UTF-8').'</div>';
-}
-?>
+<div class="<?php echo $h($cls); ?>"<?php echo $style; ?>>
+  <div class="melde-response-person-main">
+    <div class="melde-response-person-name"><?php echo $h($name); ?></div>
+<?php if($instrument !== '') { ?>
+    <div class="melde-response-person-instrument"><?php echo $h($instrument); ?></div>
+<?php } ?>
+  </div>
+<?php if(count($extras)) { ?>
+  <div class="melde-response-person-extras">
+<?php foreach($extras as $ex) { ?>
+    <span class="melde-response-person-extra"><?php echo $h($ex); ?></span>
+<?php } ?>
+  </div>
+<?php } ?>
 </div>

--- a/views/termin/response_modal.php
+++ b/views/termin/response_modal.php
@@ -1,24 +1,42 @@
+<?php
+/**
+ * Termin response detail modal (MELD-149).
+ * Expects: $terminId, $filterRegister, $terminName, $showOrchestra,
+ * $orchestraFull, $orchestraActive, $showChildrenHeader, $showGuestsHeader,
+ * $whoYesHtml, $whoMaybeHtml, $whoNoHtml, $countYes, $countMaybe, $countNo
+ */
+$h = function ($s) {
+    return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
+};
+$countYes = isset($countYes) ? (int)$countYes : 0;
+$countMaybe = isset($countMaybe) ? (int)$countMaybe : 0;
+$countNo = isset($countNo) ? (int)$countNo : 0;
+$yesColor = $GLOBALS['optionsDB']['colorBtnYes'];
+$maybeColor = $GLOBALS['optionsDB']['colorBtnMaybe'];
+$noColor = $GLOBALS['optionsDB']['colorBtnNo'];
+?>
 <div class="profile-shell modal-shell termin-response-modal"
      data-termin-id="<?php echo (int)$terminId; ?>"
      data-register="<?php echo (int)$filterRegister; ?>">
   <header class="profile-hero">
     <div class="profile-hero-text">
       <p class="profile-kicker">Meldungen</p>
-      <h2 class="profile-title"><?php echo htmlspecialchars((string)$terminName, ENT_QUOTES, 'UTF-8'); ?></h2>
+      <h2 class="profile-title"><?php echo $h($terminName); ?></h2>
     </div>
     <div class="profile-hero-actions">
       <button type="button" class="modal-close w3-button" onclick="closeModal()" aria-label="Schließen">&times;</button>
     </div>
   </header>
+
 <?php if($showOrchestra) { ?>
-  <div class="orchestra-panel w3-margin-top"
-       data-color-yes="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnYes'], ENT_QUOTES, 'UTF-8'); ?>"
-       data-color-no="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnNo'], ENT_QUOTES, 'UTF-8'); ?>"
-       data-color-maybe="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnMaybe'], ENT_QUOTES, 'UTF-8'); ?>"
-       data-color-disabled="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorDisabled'], ENT_QUOTES, 'UTF-8'); ?>">
-    <div class="orchestra-panel-header w3-row">
-      <div class="w3-col s12 m6 l6"><b>Besetzung</b></div>
-      <div class="w3-col s12 m6 l6 orchestra-panel-toggle">
+  <div class="orchestra-panel"
+       data-color-yes="<?php echo $h($yesColor); ?>"
+       data-color-no="<?php echo $h($noColor); ?>"
+       data-color-maybe="<?php echo $h($maybeColor); ?>"
+       data-color-disabled="<?php echo $h(isset($GLOBALS['optionsDB']['colorDisabled']) ? $GLOBALS['optionsDB']['colorDisabled'] : ''); ?>">
+    <div class="orchestra-panel-header">
+      <div class="orchestra-panel-title"><b>Besetzung</b></div>
+      <div class="orchestra-panel-toggle">
         <label class="w3-small">
           <input type="checkbox" class="w3-check" onchange="toggleActiveOrchestra(this)">
           Nur aktive Besetzung
@@ -37,30 +55,46 @@
     </div>
   </div>
 <?php } ?>
-  <div class="w3-container w3-margin-top"><div class="w3-row"><div class="w3-col l<?php echo $colsize[0]; ?> m<?php echo $colsize[0]; ?> s<?php echo $colsize[0]; ?>"><b>Zusagen</b></div>
-<div class="w3-col l<?php echo $colsize[1]; ?> m<?php echo $colsize[1]; ?> s<?php echo $colsize[1]; ?>">&nbsp;</div><?php
-$actcol = 2;
-if($showChildrenHeader) {
-    echo '<div class="w3-col l'.$colsize[$actcol].' m'.$colsize[$actcol].' s'.$colsize[$actcol].'">Kinder</div>';
-    $actcol++;
-}
-if($showGuestsHeader) {
-    echo '<div class="w3-col l'.$colsize[$actcol].' m'.$colsize[$actcol].' s'.$colsize[$actcol].'">G&auml;ste</div>';
-}
+
+  <div class="melde-response-modal-lists">
+    <section class="melde-response-section" aria-labelledby="resp-yes">
+      <h3 id="resp-yes" class="melde-response-section-title">
+        <span>Zusagen</span>
+        <span class="melde-response-chip <?php echo $h($yesColor); ?>">&#10004; <?php echo $countYes; ?></span>
+      </h3>
+<?php if($showChildrenHeader || $showGuestsHeader) { ?>
+      <p class="melde-response-section-hint">
+<?php
+    $hints = array();
+    if($showChildrenHeader) $hints[] = 'Kinder';
+    if($showGuestsHeader) $hints[] = 'Gäste';
+    echo $h(implode(' · ', $hints).' erscheinen als Zusatz bei der Person');
 ?>
-</div>
-</div>
-  <div class="w3-container">
-<?php echo $whoYesHtml; ?>
-  </div>
-  <div class="w3-container w3-margin-top"><b>unsicher</b></div>
-  <div class="w3-container">
-<?php echo $whoMaybeHtml; ?>
-  </div>
-  <div class="w3-container w3-margin-top"><b>Absagen</b></div>
-  <div class="w3-container">
-<?php echo $whoNoHtml; ?>
-  </div>
-  <div class="w3-container w3-margin-bottom"><br />
+      </p>
+<?php } ?>
+      <div class="melde-response-list">
+<?php echo $whoYesHtml !== '' ? $whoYesHtml : '<div class="melde-response-empty">—</div>'; ?>
+      </div>
+    </section>
+
+    <section class="melde-response-section" aria-labelledby="resp-maybe">
+      <h3 id="resp-maybe" class="melde-response-section-title">
+        <span>Unsicher</span>
+        <span class="melde-response-chip <?php echo $h($maybeColor); ?>">? <?php echo $countMaybe; ?></span>
+      </h3>
+      <div class="melde-response-list">
+<?php echo $whoMaybeHtml !== '' ? $whoMaybeHtml : '<div class="melde-response-empty">—</div>'; ?>
+      </div>
+    </section>
+
+    <section class="melde-response-section" aria-labelledby="resp-no">
+      <h3 id="resp-no" class="melde-response-section-title">
+        <span>Absagen</span>
+        <span class="melde-response-chip <?php echo $h($noColor); ?>">&#10008; <?php echo $countNo; ?></span>
+      </h3>
+      <div class="melde-response-list">
+<?php echo $whoNoHtml !== '' ? $whoNoHtml : '<div class="melde-response-empty">—</div>'; ?>
+      </div>
+    </section>
   </div>
 </div>

--- a/views/termin/shift_response_modal.php
+++ b/views/termin/shift_response_modal.php
@@ -1,20 +1,27 @@
 <?php
 /**
- * Shift response list modal (profile-shell).
- * Expects: $terminName, $shiftName, $shiftTime, $yesHtml, $maybeHtml, $noHtml
+ * Shift response list modal (MELD-149, aligned with termin response modal).
+ * Expects: $terminName, $shiftName, $shiftTime, $yesHtml, $maybeHtml, $noHtml,
+ * optional $countYes, $countMaybe, $countNo
  */
 $h = function ($s) {
     return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
 };
 $subtitle = trim($shiftName.($shiftTime !== '' ? ' · '.$shiftTime : ''));
+$countYes = isset($countYes) ? (int)$countYes : 0;
+$countMaybe = isset($countMaybe) ? (int)$countMaybe : 0;
+$countNo = isset($countNo) ? (int)$countNo : 0;
+$yesColor = $GLOBALS['optionsDB']['colorBtnYes'];
+$maybeColor = $GLOBALS['optionsDB']['colorBtnMaybe'];
+$noColor = $GLOBALS['optionsDB']['colorBtnNo'];
 ?>
-<div class="profile-shell modal-shell shift-response-modal">
+<div class="profile-shell modal-shell shift-response-modal termin-response-modal">
   <header class="profile-hero">
     <div class="profile-hero-text">
       <p class="profile-kicker">Schicht/Aufgabe</p>
       <h2 class="profile-title"><?php echo $h($terminName !== '' ? $terminName : 'Termin'); ?></h2>
 <?php if($subtitle !== '') { ?>
-      <p class="profile-value" style="font-weight:400;margin:0.25rem 0 0;"><?php echo $h($subtitle); ?></p>
+      <p class="profile-subtitle"><?php echo $h($subtitle); ?></p>
 <?php } ?>
     </div>
     <div class="profile-hero-actions">
@@ -22,18 +29,33 @@ $subtitle = trim($shiftName.($shiftTime !== '' ? ' · '.$shiftTime : ''));
     </div>
   </header>
 
-  <div class="profile-grid profile-grid--3">
-    <section class="profile-col" aria-labelledby="shift-yes">
-      <h3 id="shift-yes" class="profile-col-title">Zusagen</h3>
-      <div class="shift-response-list"><?php echo $yesHtml; ?></div>
+  <div class="melde-response-modal-lists">
+    <section class="melde-response-section" aria-labelledby="shift-yes">
+      <h3 id="shift-yes" class="melde-response-section-title">
+        <span>Zusagen</span>
+        <span class="melde-response-chip <?php echo $h($yesColor); ?>">&#10004; <?php echo $countYes; ?></span>
+      </h3>
+      <div class="melde-response-list">
+<?php echo $yesHtml !== '' ? $yesHtml : '<div class="melde-response-empty">—</div>'; ?>
+      </div>
     </section>
-    <section class="profile-col" aria-labelledby="shift-maybe">
-      <h3 id="shift-maybe" class="profile-col-title">Unsicher</h3>
-      <div class="shift-response-list"><?php echo $maybeHtml; ?></div>
+    <section class="melde-response-section" aria-labelledby="shift-maybe">
+      <h3 id="shift-maybe" class="melde-response-section-title">
+        <span>Unsicher</span>
+        <span class="melde-response-chip <?php echo $h($maybeColor); ?>">? <?php echo $countMaybe; ?></span>
+      </h3>
+      <div class="melde-response-list">
+<?php echo $maybeHtml !== '' ? $maybeHtml : '<div class="melde-response-empty">—</div>'; ?>
+      </div>
     </section>
-    <section class="profile-col" aria-labelledby="shift-no">
-      <h3 id="shift-no" class="profile-col-title">Absagen</h3>
-      <div class="shift-response-list"><?php echo $noHtml; ?></div>
+    <section class="melde-response-section" aria-labelledby="shift-no">
+      <h3 id="shift-no" class="melde-response-section-title">
+        <span>Absagen</span>
+        <span class="melde-response-chip <?php echo $h($noColor); ?>">&#10008; <?php echo $countNo; ?></span>
+      </h3>
+      <div class="melde-response-list">
+<?php echo $noHtml !== '' ? $noHtml : '<div class="melde-response-empty">—</div>'; ?>
+      </div>
     </section>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Mein Register / Admin Meldungen: Response-Karten im melde-row-Layout mit Datum-Rail und Status-Chips
- Modal: Namenslisten nach Zusage/Unsicher/Absage, Personenzeilen in Registerfarben
- Hilfe angepasst (Mein Register, Admin Meldungen)

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-149

## Test plan
- [ ] Mein Register: Kartenoptik, Klick öffnet Modal mit Namen
- [ ] Admin → Meldungen: Übersicht inkl. Register-Zusammenfassung / Schichten
- [ ] Modal: Abschnitte + Registerfarben der Personenzeilen
- [ ] Desktop: Namensliste mehrspaltig; Mobile ok

Made with [Cursor](https://cursor.com)