### PR TITLE
docs: Branchnamen klar als_dev und master

### DIFF
--- a/.cursor/rules/git-branch-shell-commands.mdc
+++ b/.cursor/rules/git-branch-shell-commands.mdc
@@ -1,0 +1,40 @@
+---
+description: Git-Befehle für Branches dev und master nur über scripts/git-flow.sh
+alwaysApply: true
+---
+
+# Git-Branches: Shell-Befehle nur über git-flow.sh
+
+Die Branches heißen **`dev`** und **`master`**.
+
+## Verbotene Shell-Formen (brechen zuverlässig)
+
+Nie Remote-Name und Branch zu einem Token verkleben und nie Flags ohne Leerzeichen an den Branchnamen hängen.
+
+Richtig:
+
+- `origin/dev`
+- `git fetch origin dev`
+- `gh pr create --base="dev"`
+
+## Stattdessen: Script
+
+Alle Pull/Push/PR/Merge-Schritte mit:
+
+```bash
+./scripts/git-flow.sh sync-dev
+./scripts/git-flow.sh push
+./scripts/git-flow.sh pr-dev --title "MELD-n: …" --body "## Summary\n…"
+./scripts/git-flow.sh merge-pr
+./scripts/git-flow.sh release-master
+```
+
+Branchnamen stehen **nur im Script**. Wenn du doch `git`/`gh` direkt brauchst: Variable nutzen:
+
+```bash
+B=dev
+git fetch origin "$B"
+gh pr create --base="$B" …
+```
+
+Niemals `origin` und Branchname ohne Slash bzw. ohne Leerzeichen hintereinander schreiben.

--- a/.cursor/rules/git-no-ask.mdc
+++ b/.cursor/rules/git-no-ask.mdc
@@ -1,0 +1,19 @@
+---
+description: Keine Rückfragen bei klaren Git-Aufträgen; Rechte direkt anfordern
+alwaysApply: true
+---
+
+# Git: nicht nachfragen
+
+Wenn der User Git-Aktionen bereits verlangt hat (z. B. committen, pushen, PR erstellen, mergen, Freigabe für dev/master), **nicht** erneut im Chat fragen („Darf ich…?“, „Soll ich pushen?“). Sofort ausführen.
+
+## Shell-Rechte
+
+- Benötigte `required_permissions` (`git_write`, `full_network`, `all`) **direkt** mitschicken — keine Extra-Bestätigung im Dialogtext erbitten.
+- Read-only (`git status`, `git log`, `git diff`, `git show`) ohne erhöhte Rechte, wenn der Sandbox das erlaubt.
+- Für Schreiben/Commit: `git_write`. Für Push/`gh`: zusätzlich Netzwerk (`full_network` oder `all`).
+- Nicht zwischen `git_write` und `all` hin- und herwechseln, wenn `git_write` (+ Netzwerk) reicht — sonst neue Permission-Karten.
+
+## Unverändert
+
+Weiterhin **nicht** committen/pushen/mergen ohne expliziten Auftrag bzw. ohne Freigabe laut Ticket-Workflow. Nur die doppelte Rückfrage entfällt.

--- a/.cursor/rules/ticket-workflow-freigabe.mdc
+++ b/.cursor/rules/ticket-workflow-freigabe.mdc
@@ -1,0 +1,44 @@
+---
+description: Ticket-Workflow mit Jira/GitHub-PR, Freigabe für dev und master
+alwaysApply: true
+---
+
+# Ticket-Workflow: Jira ↔ GitHub, Freigabe, PR, `dev`/`master`
+
+Project **MELD** on Jira (`musikverein-bonn-duisdorf.atlassian.net`) is linked to GitHub via **GitHub for Jira** (Development panel). Branches, commits, and PRs appear there automatically when the issue key is in the name/title/message — no manual remote link needed.
+
+Git-Branches heißen **`dev`** und **`master`**. Pull/Push/PR/Merge immer über **`./scripts/git-flow.sh`** — siehe Regel `git-branch-shell-commands`.
+
+## Naming (required for Jira Development panel)
+
+- **Branch:** `MELD-<n>-Kurzbeschreibung` (ASCII, hyphens; e.g. `MELD-64-Orchester`)
+- **Commits:** start with `MELD-<n>: …`
+- **PR title:** start with `MELD-<n>: …` (same style as commits)
+- **PR body:** Summary + Test plan; mention the Jira key/URL once
+
+Do **not** rely on Smart Commits (`#done` etc.) to close tickets — Freigabe and **Fertig** stay manual (see below).
+
+## Steps
+
+1. **Implement locally** on a feature branch created from **`origin/dev`** (never from `master`; they may diverge). Workflow: `git fetch origin` then `git checkout -b MELD-n-Kurzbeschreibung origin/dev`. Commit locally when appropriate. Set Jira to **In Arbeit** when starting.
+2. **Stop and wait** for local test. Do **not** push to `origin` yet unless the user explicitly asks.
+3. After local OK, wait for **Freigabe für den Branch `dev`** („nach `dev`“, „in `dev` mergen“). Then:
+   - `./scripts/git-flow.sh pr-dev --title "MELD-n: …" --body "…"` (push + PR into branch `dev`)
+   - Optionally comment on the Jira issue with the PR URL (panel usually picks it up anyway).
+   - **Babysit the PR autonomously** until merge-ready, then `./scripts/git-flow.sh merge-pr` — no second ask once Freigabe für `dev` was given.
+   - **Immediately after the merge into `dev`:** set Jira to **Review**. The ticket stays in Review while branch `dev` is tested.
+4. After testing on `dev` is OK, wait for **Freigabe für den Branch `master`** („nach `master`“, „releasen“). Then `./scripts/git-flow.sh release-master` (merge `dev`→`master`, `makeVersion`, push, sync release files back to `dev`).
+5. **Delete the feature branch on GitHub** once it is in `master`. Never delete `master` or `dev`.
+6. Set Jira to **Fertig** only after the master release (or when the user says done without release). Add a short release comment (version/`makeVersion` id) as usual. Do **not** leave the ticket in **In Arbeit** once it is on `dev` — that is **Review**.
+7. **User-facing features:** update `views/help/guide.php` in the same ticket when workflows/nav/rights change.
+
+## PRs eigenständig abarbeiten
+
+When a PR exists (opened by us or pointed out):
+
+- Fix CI, review/Bugbot comments, and conflicts **without waiting to be asked** each time.
+- Push scoped fixes with `./scripts/git-flow.sh push`; loop until merge-ready.
+- Act only on valid findings; if unsure, ask briefly.
+- Do **not** merge to `dev`/`master` without Freigabe (except step 3: Freigabe für `dev` covers merging that PR into `dev`).
+
+Do **not** assume Freigabe from plan approval or „implement the plan“. Local test, branch `dev`, and `master` each need an explicit go-ahead.

--- a/scripts/generateChangelog.py
+++ b/scripts/generateChangelog.py
@@ -129,7 +129,7 @@ def notes_from_paths(newer: str, older: str | None) -> list[str]:
 def collect_notes(newer: str, older: str | None) -> list[str]:
     rng = f"{older}..{newer}" if older else newer
     try:
-        # Not first-parent: releases often FF from_dev, so ticket notes live on into_dev merges.
+        # Not first-parent: releases often FF from dev, so ticket notes live on merges into dev.
         out = run(["git", "log", "--pretty=format:%s%n%b%n==END==", rng])
     except subprocess.CalledProcessError:
         return []

--- a/scripts/git-flow.sh
+++ b/scripts/git-flow.sh
@@ -2,7 +2,7 @@
 # Meldeliste: pull / push / PR / merge helpers.
 #
 # Branch names live ONLY here. Agents must call this script instead of typing
-# "origin" + branch as one token (e.g. never "origin_dev" / "--base_dev").
+# Never glue remote and branch into one token (use origin/dev, not a glued name).
 #
 # Usage:
 #   ./scripts/git-flow.sh sync-dev


### PR DESCRIPTION
## Summary
- Cursor-Regeln ohne _dev/_master-Schreibweisen; klar `dev`/`master`
- git-flow und Changelog-Kommentare angepasst
- Git-Regeln erstmals versioniert unter `.cursor/rules/`

## Test plan
- [ ] Regeln lesbar; Branchnamen nur `dev`/`master`