### PR TITLE
chore: restliche Cursor-Regeln versionieren

### DIFF
--- a/.cursor/rules/meld-124-owner-rename.mdc
+++ b/.cursor/rules/meld-124-owner-rename.mdc
@@ -1,0 +1,14 @@
+---
+description: MELD-124 follow-up — Inventories.Owner DB rename to Eigentümer
+alwaysApply: true
+---
+
+# MELD-124: Owner → Eigentümer (DB noch offen)
+
+UI-Labels sind bereits „Eigentümer“. Die **Datenbankspalte** `Inventories.Owner` (und PHP: Property/`$_POST`/`getOwner`) heißt weiter `Owner`.
+
+Bei der nächsten bewussten Schema-/Spalten-Umbenennung mitziehen:
+
+- Spalte `Owner` → `Eigentuemer` (ASCII in DB, analog zu anderen technischen Namen)
+- `config/DBconfig.json`, Schema-Migration, alle SQL/PHP-Referenzen, Form-Feld `name`, Helper `getOwner`
+- Ticket-Bezug: MELD-124 (UI erledigt; Spalten-Rename separat)

--- a/.cursor/rules/short-ui-labels.mdc
+++ b/.cursor/rules/short-ui-labels.mdc
@@ -1,0 +1,25 @@
+---
+description: Kurze UI-Labels; keine Instruktions-/Beschreibungstexte auf Seiten
+alwaysApply: true
+---
+
+# Kurze UI-Labels
+
+- Formular-, Nav- und Checkbox-Labels kurz und funktional halten (meist 1–3 Wörter).
+- Keine länglichen Erklärungstexte neben Feldern oder Checkboxen.
+- Details, Beispiele und „wann greift das?“ gehören in `views/help/guide.php` (Anker-Link vom Formular ist ok).
+- `title`/Tooltips nur für Icons oder Aktionen ohne sichtbares Label — nicht als Ersatz für Hilfe-Absätze.
+
+# Keine UI-Instruktionen / Beschreibungstexte
+
+- Keine Sätze wie „Änderungen mit Speichern übernehmen“, „Hier kannst du …“, „Bitte zuerst …“, „Tipp:“, „Hier findest du …“ in Formularen, Titelleisten, Listenköpfen oder neben Buttons.
+- Die Oberfläche soll selbsterklärend durch Labels und Anordnung sein — nicht durch Anleitungsprosa.
+- Erklärungen nur in der Hilfe; optional ein kurzer Anker-Link (z. B. „Hilfe: Benachrichtigungen“), kein Fließtext.
+- Ausnahme: technisch notwendige Inhalte in einem bewusst geöffneten Hilfsdialog (z. B. Kalender-Abo-URLs), weiterhin ohne Belehrungston.
+
+# Suchfelder
+
+- Listen-Suche über `adminListSearchField()` — **kein sichtbares Label** („Suchen“, „Termine suchen“, …).
+- Nur Placeholder (+ `aria-label`, defaults auf den Placeholder).
+- Keine doppelten Hinweise über der Suche; der Seiten-Hero reicht als Kontext.
+- Gleiches Muster für andere Suchfelder (z. B. Rechte-Matrix): Placeholder statt `profile-label`.

--- a/.cursor/rules/ticket-tests.mdc
+++ b/.cursor/rules/ticket-tests.mdc
@@ -1,0 +1,34 @@
+---
+description: Bei Ticket-Arbeit und Releases passende PHPUnit-Tests in meldeliste-tests schreiben
+alwaysApply: true
+---
+
+# Tests bei Ticket-Arbeit
+
+Bei jedem Feature-/Bug-Ticket **sinnvolle Regressionstests** mitliefern — nicht erst auf Nachfrage.
+
+## Wo
+
+- Tests liegen im Sibling-Repo **`meldeliste-tests`** (`../meldeliste-tests`), nicht im App-Repo.
+- Ausführen: `cd ../meldeliste-tests && composer test` (Pre-Push-Hook der App ruft das bereits auf).
+- Basis: `MeldelisteTestCase` (Schema, Session, Hilfsfixture). Muster: `ReturnUrlTest`, `InventoryLoanTest`, `AppTokenTest`.
+
+## Was testen
+
+- Domain-Logik / Helpers / Auth / Logging / Schema-relevante Verhalten — **ja**.
+- Reine Docs, CSS/Layout, triviale Label-Änderungen — nur wenn leicht regressierbar (z. B. Log-Wording „Eigentümer“).
+- JS-UI: PHPUnit nur für serverseitig erzeugte Attribute/HTML; reines JS separat oder manuell.
+
+## Wann
+
+1. **Während** der Ticket-Implementierung (gleicher Arbeitszyklus, nicht „später“).
+2. Vor Freigabe für `dev`: neue/angepasste Tests grün.
+3. Bei „Ticket abschließen“ / Nachziehen: fehlende Tests für gerade gelieferte Funktionalität nachziehen.
+
+## Stil
+
+- `final class … extends MeldelisteTestCase`
+- Eindeutige Marker (`PHPUnit-` + random) in Namen
+- Echte Test-DB, keine Mocks (außer I/O-Grenzen wie Mail)
+- `assertSame` / `assertStringContainsString`; bei HTML nur relevante Substrings
+- Neue App-Libs ggf. in `tests/bootstrap.php` nachziehen

--- a/.cursor/rules/ui-modals-overlays.mdc
+++ b/.cursor/rules/ui-modals-overlays.mdc
@@ -1,0 +1,34 @@
+---
+description: Modal-/Overlay-Design und Platzierung außerhalb von .app-main
+alwaysApply: true
+---
+
+# Modals & Overlays
+
+## Shell-Markup (Pflicht für neue Dialoge)
+
+- Inhalt in `profile-shell modal-shell` (Referenz: `views/termin/calendar_melde_modal.php`, Kalender-Abo, Termin-Löschen).
+- Hero: `profile-hero` mit `profile-kicker`, `profile-title`, optional `profile-actions` / `profile-btn-primary`, Schließen als `modal-close w3-button`.
+- Körper: `termin-grid` / `profile-grid` + `profile-col` / `profile-field` — **kein** altes `w3-container`+`colorTitleBar`-Header-Card-Layout.
+- Bestätigungen (Löschen): gleiche Shell; Primäraktion klar („Löschen“), Abbrechen sekundär — nicht „ja“/„nein“ in alten Grid-Spalten.
+
+## Platzierung (MELD-147)
+
+`.app-main` hat Overflow + `z-index: 1` → feste Overlays darin kollidieren mit Titlebar/Nav/Inhalt.
+
+- **AJAX-Dialoge:** nur in `#ajaxModalHost` (`common/footer.php`, außerhalb `.app-shell`).
+- **Seiten-lokale `.w3-modal`:** mit `deferPageModalHtml()` puffern; Footer gibt sie neben `#ajaxModalHost` aus. Nicht in die Seitenkarte legen.
+- **Safety-Net:** `liftPageModalsOutOfAppMain()` in `js/modal.js` — trotzdem PHP-seitig korrekt deferren (MOTD öffnet sofort).
+- Sheets/Bottom-Bars (`orchestra-seat-sheet` u. Ä.): an `document.body` hängen, nicht in `#ajaxModalHost`.
+- `.w3-modal` hat global `z-index: 2000` (über Titlebar 1100 / Nav 1000).
+
+## Nicht tun
+
+- Keine neuen Dialoge im Stil `w3-modal-content w3-card` + farbiger `w3-container`-Titelbalken.
+- Kein `position:fixed`-Overlay als Kind von `.app-main` / `.admin-list-body` ohne Defer/Lift.
+- Keine doppelte Modal-Infrastruktur neben `#ajaxModalHost`, wenn AJAX reicht.
+
+# Melde-Zeilen (Kapazität)
+
+- Melde-Buttons: feste Größe (`.melde-btn`), nicht `flex: 1` über die Aktionsbreite — 2 Buttons (Kapazität) müssen wie 3 Buttons wirken.
+- Kapazitäts-/Bedarfsinfo (`.melde-meta`) **links** der Buttons, nicht rechts.


### PR DESCRIPTION
## Summary
- Version remaining Cursor rules previously only local (gitignored): short-ui-labels, ui-modals-overlays, ticket-tests, MELD-124 owner rename note

## Test plan
- [ ] Files present under `.cursor/rules/` on_dev