### PR TITLE
MELD-160: Log-Zeitstempel bei Dedup per Ajax aktualisieren

### DIFF
--- a/getLog.php
+++ b/getLog.php
@@ -19,17 +19,10 @@ if($maxIndex === null || !is_numeric($maxIndex)) {
     die('invalid maxIndex');
 }
 
-$sql = sprintf('SELECT `Index` FROM `%sLog` WHERE `Index` > %d ORDER BY `Timestamp` ASC LIMIT 1;',
-    $GLOBALS['dbprefix'],
-    (int)$maxIndex
-);
-$dbr = mysqli_query($conn, $sql);
-sqlerror();
-while($row = mysqli_fetch_array($dbr)) {
-    $M = new Log;
-    $M->load_by_id($row['Index']);
-    if($M->Index > 0) {
-        echo $M->printTableLine();
-    }
+$topTimestamp = meldeRequest('topTimestamp');
+if($topTimestamp === null) {
+    $topTimestamp = '';
 }
+
+echo logPollNextHtml((int)$maxIndex, (string)$topTimestamp);
 ?>

--- a/libs/log.php
+++ b/libs/log.php
@@ -223,7 +223,8 @@ class Log
             $timePart = substr($tsRaw, 11, 5);
         }
 
-        echo '<div id="'.(int)$this->Index.'" class="'.htmlspecialchars($classes, ENT_QUOTES, 'UTF-8').'">';
+        echo '<div id="'.(int)$this->Index.'" class="'.htmlspecialchars($classes, ENT_QUOTES, 'UTF-8').'"'
+            .' data-timestamp="'.htmlspecialchars($tsRaw, ENT_QUOTES, 'UTF-8').'">';
         echo '<div class="log-id">';
         echo '<div class="log-time">';
         echo '<span class="log-date">'.htmlspecialchars($datePart, ENT_QUOTES, 'UTF-8').'</span>';
@@ -244,4 +245,54 @@ class Log
         echo '</div>';
     }
 };
+
+/**
+ * Live-Poll HTML for the log page (MELD-160).
+ * Returns a new row when Index > $maxIndex, or the same row when its Timestamp
+ * was bumped by Log dedupe (identical Message+User → UPDATE Timestamp only).
+ *
+ * @return string HTML of one log row, or empty string
+ */
+function logPollNextHtml($maxIndex, $topTimestamp = '') {
+    $maxIndex = (int)$maxIndex;
+    if($maxIndex < 1) {
+        return '';
+    }
+    $sql = sprintf(
+        'SELECT `Index` FROM `%sLog` WHERE `Index` > %d ORDER BY `Timestamp` ASC LIMIT 1;',
+        $GLOBALS['dbprefix'],
+        $maxIndex
+    );
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    if($dbr && ($row = mysqli_fetch_array($dbr))) {
+        $M = new Log;
+        $M->load_by_id((int)$row['Index']);
+        if($M->Index > 0) {
+            ob_start();
+            $M->printTableLine();
+            $html = ob_get_clean();
+            return $html === false ? '' : $html;
+        }
+        return '';
+    }
+
+    $topTimestamp = trim((string)$topTimestamp);
+    if($topTimestamp === '') {
+        return '';
+    }
+    $M = new Log;
+    $M->load_by_id($maxIndex);
+    if($M->Index < 1) {
+        return '';
+    }
+    $serverTs = (string)$M->Timestamp;
+    if($serverTs === '' || strcmp($serverTs, $topTimestamp) <= 0) {
+        return '';
+    }
+    ob_start();
+    $M->printTableLine();
+    $html = ob_get_clean();
+    return $html === false ? '' : $html;
+}
 ?>

--- a/log.php
+++ b/log.php
@@ -26,6 +26,12 @@ adminListSearchField('Log durchsuchen…', array('onkeyup' => 'filterLog()'));
 </div>
 <?php adminListPageEnd(); ?>
 <script>
+function getLogTopRow() {
+    var parent = document.getElementById("Liste");
+    if(!parent) return null;
+    return parent.querySelector(":scope > div[id]:not(#listSentinel)");
+}
+
 function getLogMaxIndex() {
     var parent = document.getElementById("Liste");
     if(!parent) return 0;
@@ -39,9 +45,16 @@ function getLogMaxIndex() {
     return max;
 }
 
+function getLogTopTimestamp() {
+    var top = getLogTopRow();
+    if(!top) return '';
+    return top.getAttribute('data-timestamp') || '';
+}
+
 function getLog() {
     var maxIndex = getLogMaxIndex();
     if(!(maxIndex > 0)) return;
+    var topTimestamp = getLogTopTimestamp();
 
     var xmlhttp;
     if (window.XMLHttpRequest) {
@@ -57,7 +70,12 @@ function getLog() {
             var doc = new DOMParser().parseFromString(xmlhttp.responseText, 'text/html');
             var div = doc.body.firstElementChild;
             if(!div || !div.id) return;
-            if(document.getElementById(div.id)) return;
+            var existing = document.getElementById(div.id);
+            if(existing) {
+                // Deduped log: same Index, newer Timestamp — refresh in place (MELD-160)
+                existing.parentNode.replaceChild(div, existing);
+                return;
+            }
             var first = parent.querySelector(":scope > div[id]:not(#listSentinel)");
             if(first) {
                 parent.insertBefore(div, first);
@@ -69,7 +87,8 @@ function getLog() {
             }
 	}
     }
-    var body = "maxIndex="+encodeURIComponent(maxIndex);
+    var body = "maxIndex="+encodeURIComponent(maxIndex)
+        +"&topTimestamp="+encodeURIComponent(topTimestamp);
     xmlhttp.open("POST", "getLog.php", true);
     xmlhttp.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
     xmlhttp.send(body);


### PR DESCRIPTION
## Summary
- Poll (`getLog.php` / `logPollNextHtml`) liefert bei Dedup die aktualisierte Log-Zeile (gleicher Index, neuer Timestamp)
- Ajax ersetzt die bestehende DOM-Zeile; `data-timestamp` am Row
- Tests in meldeliste-tests (`LogPollTest`)

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-160

## Test plan
- [x] Log-Seite offen, gleiche Aktion zweimal → Zeitstempel aktualisiert sich ohne Reload
- [x] `LogPollTest` grün

Made with [Cursor](https://cursor.com)