### PR TITLE
MELD-163: Dirigent immer in Meldungsliste

### DIFF
--- a/config/ConfigDefaults.php
+++ b/config/ConfigDefaults.php
@@ -480,12 +480,6 @@ function getConfigDefaults() {
             'Description' => 'Nicht-Mitgliederliste anzeigen',
         ),
         array(
-            'Parameter' => 'showConductor',
-            'Value' => '1',
-            'Type' => 'bool',
-            'Description' => 'Dirigent in Listen anzeigen',
-        ),
-        array(
             'Parameter' => 'showRegisterLead',
             'Value' => '1',
             'Type' => 'bool',

--- a/libs/DatabaseManager.php
+++ b/libs/DatabaseManager.php
@@ -1171,7 +1171,8 @@ class DatabaseManager
         }
 
         // MELD-84: Termine-Seite entfällt; verwaiste Schalter entfernen
-        $obsoleteParams = array('entriesMainPage', 'showAppmntPage');
+        // MELD-163: Dirigent immer in Listen; showConductor entfällt
+        $obsoleteParams = array('entriesMainPage', 'showAppmntPage', 'showConductor');
         foreach($obsoleteParams as $param) {
             $sql = sprintf(
                 "SELECT `Parameter` FROM `%sconfig` WHERE `Parameter` = '%s' LIMIT 1;",

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -157,28 +157,20 @@ function germanDateCompact($string) {
 
 function getActiveUsers($date) {
     $users = array();
-    if($GLOBALS['optionsDB']['showConductor']) {
-        $dirigent = '';
-    }
-    else {
-        $dirigent = 'AND `iName` != "Dirigent"';
-    }
     if($date) {
-        $sql = sprintf('SELECT * FROM `%sUser` INNER JOIN (SELECT `Index` AS `iIndex`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `iIndex` = `Instrument` WHERE `Joined` >= "%s" AND (`DeletedOn` <= "%s" OR `DeletedOn` = NULL) AND `Active` = 1 AND `iName` != "Admin" %s ORDER BY `Nachname`, `Vorname`;',
+        $sql = sprintf('SELECT * FROM `%sUser` INNER JOIN (SELECT `Index` AS `iIndex`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `iIndex` = `Instrument` WHERE `Joined` >= "%s" AND (`DeletedOn` <= "%s" OR `DeletedOn` = NULL) AND `Active` = 1 AND `iName` != "Admin" ORDER BY `Nachname`, `Vorname`;',
         $GLOBALS['dbprefix'],
         $GLOBALS['dbprefix'],
         $GLOBALS['dbprefix'],
         $date,
-        $date,
-        $dirigent
+        $date
         );
     }
     else {
-        $sql = sprintf('SELECT * FROM `%sUser` INNER JOIN (SELECT `Index` AS `iIndex`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `iIndex` = `Instrument` WHERE `Deleted` = 0 AND `Active` = 1 AND `iName` != "Admin" %s ORDER BY `Nachname`, `Vorname`;',
+        $sql = sprintf('SELECT * FROM `%sUser` INNER JOIN (SELECT `Index` AS `iIndex`, `Name` AS `iName` FROM `%sInstrument`) `%sInstrument` ON `iIndex` = `Instrument` WHERE `Deleted` = 0 AND `Active` = 1 AND `iName` != "Admin" ORDER BY `Nachname`, `Vorname`;',
         $GLOBALS['dbprefix'],
         $GLOBALS['dbprefix'],
-        $GLOBALS['dbprefix'],
-        $dirigent
+        $GLOBALS['dbprefix']
         );
     }
     $dbr = mysqli_query($GLOBALS['conn'], $sql);

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -2175,18 +2175,11 @@ ORDER BY `Nachname`, `Vorname`;",
 
         if($this->Auftritt) {
             $aMeldungen = $this->fetchResponseMeldungenRows();
-            if($GLOBALS['optionsDB']['showConductor']) {
-                $sql = sprintf(
-                    "SELECT `Index`, `Name` FROM `%sRegister` WHERE `Name` != 'keins' ORDER BY `Sortierung`;",
-                    $GLOBALS['dbprefix']
-                );
-            }
-            else {
-                $sql = sprintf(
-                    "SELECT `Index`, `Name` FROM `%sRegister` WHERE `Name` != 'Dirigent' AND `Name` != 'keins' ORDER BY `Sortierung`;",
-                    $GLOBALS['dbprefix']
-                );
-            }
+            // Include all registers except 'keins' (Dirigent included; parity with orchestra SVG).
+            $sql = sprintf(
+                "SELECT `Index`, `Name` FROM `%sRegister` WHERE `Name` != 'keins' ORDER BY `Sortierung`;",
+                $GLOBALS['dbprefix']
+            );
             $dbr = mysqli_query($GLOBALS['conn'], $sql);
             sqlerror();
             $memberCounts = $this->getRegisterMemberCounts();
@@ -2443,16 +2436,10 @@ ORDER BY `Nachname`, `Vorname`;",
                 $registerIds = array($filterregister);
             }
             else {
-                if($GLOBALS['optionsDB']['showConductor']) {
-                    $sql = sprintf("SELECT `Index` FROM `%sRegister` WHERE `Name` != 'keins' ORDER BY `Sortierung`;",
+                $sql = sprintf(
+                    "SELECT `Index` FROM `%sRegister` WHERE `Name` != 'keins' ORDER BY `Sortierung`;",
                     $GLOBALS['dbprefix']
-                    );
-                }
-                else {
-                    $sql = sprintf("SELECT `Index` FROM `%sRegister` WHERE `Name` != 'Dirigent' AND `Name` != 'keins' ORDER BY `Sortierung`;",
-                    $GLOBALS['dbprefix']
-                    );
-                }
+                );
                 $dbr = mysqli_query($GLOBALS['conn'], $sql);
                 sqlerror();
                 $registerIds = array();


### PR DESCRIPTION
## Summary
- Dirigent erscheint wieder in Auftritt-Meldungsliste und -Modal (wie Orchester-SVG)
- Config-Parameter `showConductor` entfernt; verwaister DB-Eintrag wird beim Schema-Check gelöscht
- `getActiveUsers` filtert Dirigent nicht mehr

## Test plan
- [ ] Auftritt mit Dirigent-Meldung: Register „Dirigent“ in Response-Line und Modal
- [ ] PHPUnit `TerminTest` (inkl. `testAuftrittResponseIncludesDirigent`)
- [ ] Config-Menü: kein Schalter „showConductor“ mehr; nach DB-Integrity ggf. Parameter weg

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-163