### PR TITLE
MELD-163: Schema-Version 25 für Config-Cleanup

### DIFF
--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -3,5 +3,5 @@
  * Expected DB schema version number (MELD-51).
  * Bump when DBconfig.json, DatabaseManager migrations, or ConfigDefaults.php change.
  */
-return 24;
+return 25;
 ?>


### PR DESCRIPTION
## Summary
- Schema-Version 24 → 25, damit Updater nach Pull `showConductor` aus der config-DB entfernt

## Test plan
- [ ] Nach Update: Schema outdated bzw. Repair löscht `showConductor`

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-163