### PR TITLE
MELD-162: Log-Chunk konfigurierbar, Filter-Nachladen stoppen

### DIFF
--- a/config/ConfigDefaults.php
+++ b/config/ConfigDefaults.php
@@ -582,6 +582,12 @@ function getConfigDefaults() {
             'Description' => 'Termine.published nach VisibilitySpec (Alle User) migriert',
         ),
         array(
+            'Parameter' => 'logListChunkSize',
+            'Value' => '100',
+            'Type' => 'int',
+            'Description' => 'Log-Liste: Einträge pro AJAX-Nachladen (1–500)',
+        ),
+        array(
             'Parameter' => 'SchemaVersion',
             'Value' => '0',
             'Type' => 'int',

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -3,5 +3,5 @@
  * Expected DB schema version number (MELD-51).
  * Bump when DBconfig.json, DatabaseManager migrations, or ConfigDefaults.php change.
  */
-return 25;
+return 26;
 ?>

--- a/getList.php
+++ b/getList.php
@@ -27,6 +27,9 @@ case 'log':
         header('X-Has-More: 0');
         exit;
     }
+    if(!isset($_GET['limit']) || (int)$_GET['limit'] < 1) {
+        $limit = listChunkLogConfiguredLimit();
+    }
     $result = listChunkLog($cursor !== '' ? (int)$cursor : 0, $limit);
     break;
 

--- a/js/infiniteScroll.js
+++ b/js/infiniteScroll.js
@@ -3,15 +3,23 @@
  * Expects #Liste and #listSentinel with data-list-type, data-cursor, data-has-more.
  * Optional data-filter-fn: name of global filter function to re-run after append.
  * Optional data-extra: query string fragment (e.g. user=123).
+ * Optional data-limit: page size for getList.php (default 50; log uses config).
  * Optional data-sort / data-dir: server-side sort for user lists (MELD-96).
  * Exposes window.listInfiniteReload(sort, dir) to reset and reload from offset 0.
+ *
+ * MELD-162: With an active client-side filter, stop auto-loading after consecutive
+ * chunks that add no visible matches (avoids endless load when the list collapses).
  */
 (function() {
     var loading = false;
     var observer = null;
+    var emptyFilterLoads = 0;
+    var pausedForFilter = false;
+    var MAX_EMPTY_FILTER_LOADS = 2;
     var MSG_LOADING = 'Weitere Einträge werden geladen…';
     var MSG_END = 'Keine weiteren Einträge';
     var MSG_ERROR = 'Laden fehlgeschlagen. Bitte erneut versuchen.';
+    var MSG_FILTER_PAUSE = 'Keine Treffer in nachgeladenen Einträgen — Filter anpassen oder leeren';
 
     function getSentinel() {
         return document.getElementById('listSentinel');
@@ -19,6 +27,11 @@
 
     function getList() {
         return document.getElementById('Liste');
+    }
+
+    function filterActive() {
+        var input = document.getElementById('filterString');
+        return !!(input && String(input.value).trim() !== '');
     }
 
     function setBarVisible(visible) {
@@ -69,8 +82,22 @@
         }
     }
 
+    function countVisibleNodes(nodes) {
+        var n = 0;
+        var i;
+        for(i = 0; i < nodes.length; i++) {
+            var el = nodes[i];
+            if(!el || el.nodeType !== 1) continue;
+            if(el.classList && el.classList.contains('list-filtered-out')) continue;
+            if(el.style && el.style.display === 'none') continue;
+            n++;
+        }
+        return n;
+    }
+
     function appendHtml(list, sentinel, html) {
-        if(!html) return;
+        var appended = [];
+        if(!html) return appended;
         var wrap = document.createElement('div');
         wrap.innerHTML = html;
         while(wrap.firstChild) {
@@ -80,7 +107,11 @@
                 continue;
             }
             list.insertBefore(node, sentinel);
+            if(node.nodeType === 1) {
+                appended.push(node);
+            }
         }
+        return appended;
     }
 
     function clearRows(list, sentinel) {
@@ -96,11 +127,18 @@
         }
     }
 
+    function pageLimit(sentinel) {
+        var raw = sentinel.getAttribute('data-limit');
+        var n = raw ? parseInt(raw, 10) : 50;
+        if(!(n > 0)) n = 50;
+        return n;
+    }
+
     function buildUrl(sentinel, cursor) {
         var type = sentinel.getAttribute('data-list-type') || '';
         var url = 'getList.php?type=' + encodeURIComponent(type)
             + '&cursor=' + encodeURIComponent(cursor)
-            + '&limit=50';
+            + '&limit=' + encodeURIComponent(String(pageLimit(sentinel)));
         var extra = sentinel.getAttribute('data-extra');
         if(extra) url += '&' + extra;
         var sort = sentinel.getAttribute('data-sort');
@@ -110,10 +148,23 @@
         return url;
     }
 
+    function reobserveSoon() {
+        var sentinel = getSentinel();
+        if(!observer || !sentinel) return;
+        if(pausedForFilter) return;
+        if(sentinel.getAttribute('data-has-more') !== '1') return;
+        setTimeout(function() {
+            if(observer && !pausedForFilter && sentinel.getAttribute('data-has-more') === '1') {
+                observer.observe(sentinel);
+            }
+        }, 100);
+    }
+
     function loadMore() {
         var sentinel = getSentinel();
         var list = getList();
         if(!sentinel || !list || loading) return;
+        if(pausedForFilter) return;
         if(sentinel.getAttribute('data-has-more') !== '1') return;
 
         var type = sentinel.getAttribute('data-list-type') || '';
@@ -138,7 +189,7 @@
                 setStatus(MSG_ERROR, false);
                 if(observer && sentinel.getAttribute('data-has-more') === '1') {
                     setTimeout(function() {
-                        if(observer) observer.observe(sentinel);
+                        if(observer && !pausedForFilter) observer.observe(sentinel);
                     }, 500);
                 }
                 return;
@@ -155,21 +206,39 @@
             sentinel.setAttribute('data-has-more', hasMore ? '1' : '0');
             sentinel.setAttribute('data-cursor', nextCursor);
 
-            appendHtml(list, sentinel, xhr.responseText);
+            var appended = appendHtml(list, sentinel, xhr.responseText);
             applyFilter(sentinel);
+
+            if(filterActive()) {
+                var visibleNew = countVisibleNodes(appended);
+                if(visibleNew === 0) {
+                    emptyFilterLoads++;
+                    if(emptyFilterLoads >= MAX_EMPTY_FILTER_LOADS) {
+                        pausedForFilter = true;
+                        if(hasMore) {
+                            setStatus(MSG_FILTER_PAUSE, false);
+                        }
+                        else {
+                            showEnd();
+                        }
+                        return;
+                    }
+                }
+                else {
+                    emptyFilterLoads = 0;
+                }
+            }
+            else {
+                emptyFilterLoads = 0;
+                pausedForFilter = false;
+            }
 
             if(!hasMore) {
                 showEnd();
                 return;
             }
             setStatus('', false);
-            if(observer) {
-                setTimeout(function() {
-                    if(sentinel.getAttribute('data-has-more') === '1') {
-                        observer.observe(sentinel);
-                    }
-                }, 100);
-            }
+            reobserveSoon();
         };
         xhr.open('GET', buildUrl(sentinel, cursor), true);
         xhr.send();
@@ -181,6 +250,8 @@
         if(!sentinel || !list) return;
         if(observer) observer.unobserve(sentinel);
         loading = false;
+        emptyFilterLoads = 0;
+        pausedForFilter = false;
         if(sort) sentinel.setAttribute('data-sort', sort);
         if(dir) sentinel.setAttribute('data-dir', dir);
         clearRows(list, sentinel);
@@ -191,9 +262,26 @@
 
     window.listInfiniteReload = reloadFromStart;
 
+    function bindFilterResume() {
+        var input = document.getElementById('filterString');
+        if(!input || input.getAttribute('data-infinite-bound') === '1') return;
+        input.setAttribute('data-infinite-bound', '1');
+        input.addEventListener('input', function() {
+            emptyFilterLoads = 0;
+            pausedForFilter = false;
+            var sentinel = getSentinel();
+            if(!sentinel || sentinel.getAttribute('data-has-more') !== '1') return;
+            if(!filterActive()) {
+                setStatus('', false);
+            }
+            reobserveSoon();
+        });
+    }
+
     function init() {
         var sentinel = getSentinel();
         if(!sentinel) return;
+        bindFilterResume();
         if(sentinel.getAttribute('data-has-more') !== '1') {
             showEnd();
             return;
@@ -213,6 +301,7 @@
         }
         else {
             window.addEventListener('scroll', function() {
+                if(pausedForFilter) return;
                 var rect = sentinel.getBoundingClientRect();
                 if(rect.top < window.innerHeight + 80) loadMore();
             });

--- a/libs/listChunk.php
+++ b/libs/listChunk.php
@@ -11,8 +11,31 @@ function listChunkLimit($requested = 50) {
     return $n;
 }
 
+/**
+ * Configured page size for log infinite scroll (MELD-162).
+ * Clamped to 1–500; default 100 when unset/invalid.
+ */
+function listChunkLogConfiguredLimit() {
+    $n = 100;
+    if(isset($GLOBALS['optionsDB']['logListChunkSize'])) {
+        $n = (int)$GLOBALS['optionsDB']['logListChunkSize'];
+    }
+    if($n < 1) $n = 100;
+    if($n > 500) $n = 500;
+    return $n;
+}
+
+function listChunkLogLimit($requested = 0) {
+    $n = (int)$requested;
+    if($n < 1) {
+        return listChunkLogConfiguredLimit();
+    }
+    if($n > 500) $n = 500;
+    return $n;
+}
+
 function listChunkLog($beforeIndex, $limit) {
-    $limit = listChunkLimit($limit);
+    $limit = listChunkLogLimit($limit);
     $beforeIndex = (int)$beforeIndex;
     if($beforeIndex > 0) {
         $sql = sprintf(

--- a/log.php
+++ b/log.php
@@ -9,8 +9,9 @@ if(!requirePermission("perm_showLog")) {
 }
 
 // Buffer chunk build so any echo cannot appear above the search field
+$logChunkLimit = listChunkLogConfiguredLimit();
 ob_start();
-$chunk = listChunkLog(0, 50);
+$chunk = listChunkLog(0, $logChunkLimit);
 $leak = ob_get_clean();
 if($leak !== false && $leak !== '') {
     $chunk['html'] = $leak.$chunk['html'];
@@ -22,7 +23,7 @@ adminListSearchField('Log durchsuchen…', array('onkeyup' => 'filterLog()'));
 ?>
 <div id="Liste" style="clear:both;">
 <?php echo $chunk['html']; ?>
-<?php echo listChunkRenderSentinel('log', $chunk['nextCursor'], $chunk['hasMore'], 'filterLog'); ?>
+<?php echo listChunkRenderSentinel('log', $chunk['nextCursor'], $chunk['hasMore'], 'filterLog', ' data-limit="'.(int)$logChunkLimit.'"'); ?>
 </div>
 <?php adminListPageEnd(); ?>
 <script>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -263,7 +263,7 @@ $sections[] = array(
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Statistik</b> – Auswertungen mit Abschnittsnavigation; auf breiten Bildschirmen Diagramme und Tabellen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking (Quote = Ja-Meldungen / Termine im Zeitraum; Spalten sortierbar) und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>)</li>
-<li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung)</li>
+<li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung); Chunk-Größe über <code>logListChunkSize</code> in der Konfiguration</li>
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '
 <li><b>Backup</b> – Datenbank-ZIP herunterladen (inkl. Versionsinfo) oder wieder einspielen; im Browser über <code>Backup</code>, per CLI mit <code>php cron.php CRONID backup</code>; automatisiert remote nur mit eigenem <code>$backupToken</code> in <code>config.php</code> (mind. 32 Zeichen) über <code>cron.php?id=…&amp;cmd=backup</code> — nicht mit dem allgemeinen Cron-ID. Erfolgreiche Downloads erscheinen im <b>Log</b> als Info, fehlgeschlagene als Fehler</li>


### PR DESCRIPTION
## Summary
- Config `logListChunkSize` (Default 100, max 500), Schema 26
- Log infinite scroll nutzt konfigurierte Chunk-Größe
- Bei aktivem Suchfilter kein Endlos-Nachladen mehr (Pause nach 2 Chunks ohne Treffer)

## Test plan
- [ ] Log: mehr Einträge pro Nachladen (Default 100)
- [ ] Config `logListChunkSize` ändern, Reload
- [ ] Suchfilter ohne Treffer: Nachladen stoppt mit Hinweis
- [ ] Filter leeren: Nachladen geht weiter
- [ ] PHPUnit `ListChunkLogTest`

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-162