### PR TITLE
MELD-161: Statistik Chip-Filter für Ranking und Inaktive

### DIFF
--- a/evaluate.php
+++ b/evaluate.php
@@ -15,11 +15,14 @@ $besetzungOnly = !empty($_GET['besetzung']);
 $inactiveDays = isset($GLOBALS['optionsDB']['inactiveUsersDays'])
     ? max(1, (int)$GLOBALS['optionsDB']['inactiveUsersDays'])
     : 90;
+$inactiveScope = evaluateParseInactiveScope(isset($_GET['inactiveScope']) ? $_GET['inactiveScope'] : 'musiker');
+$inactiveScopeValue = evaluateInactiveScopeValue($inactiveScope);
 
 $attendance = evaluateAttendanceSeries($days, $besetzungOnly);
 $logSeries = evaluateLogSeries($days);
 $ranking = evaluateAttendanceRanking($days, $besetzungOnly);
-$inactive = evaluateInactiveUsers($inactiveDays);
+$inactive = evaluateInactiveUsers($inactiveDays, $inactiveScopeValue);
+$inactiveScopeOptions = evaluateInactiveScopeOptions();
 
 $assetV = isset($GLOBALS['version']['Hash']) ? $GLOBALS['version']['Hash'] : '0';
 $jsMtime = @filemtime(__DIR__.'/js/evaluate.js');
@@ -47,6 +50,7 @@ adminListPageBegin('System', 'Datenauswertung', array('permKey' => 'perm_showLog
       <input type="checkbox" name="besetzung" value="1"<?php echo $besetzungOnly ? ' checked' : ''; ?> onchange="this.form.submit()">
       nur Besetzung
     </label>
+    <input type="hidden" name="inactiveScope" value="<?php echo htmlspecialchars($inactiveScopeValue, ENT_QUOTES, 'UTF-8'); ?>">
   </form>
 </div>
 
@@ -96,7 +100,37 @@ adminListPageBegin('System', 'Datenauswertung', array('permKey' => 'perm_showLog
     </section>
 
     <section class="eval-panel" id="eval-inactive">
-      <h3>Inaktive Nutzer</h3>
+      <h3>Inaktive</h3>
+      <form method="get" action="evaluate.php" class="eval-filter eval-filter--inactive">
+        <input type="hidden" name="days" value="<?php echo (int)$days; ?>">
+        <?php if($besetzungOnly) { ?>
+        <input type="hidden" name="besetzung" value="1">
+        <?php } ?>
+        <label for="eval-inactive-scope">Kreis</label>
+        <select id="eval-inactive-scope" name="inactiveScope" class="w3-select w3-border" onchange="this.form.submit()">
+<?php
+$currentGroup = null;
+foreach($inactiveScopeOptions as $opt) {
+    $g = $opt['optgroup'];
+    if($g !== $currentGroup) {
+        if($currentGroup !== null) {
+            echo "</optgroup>\n";
+        }
+        if($g !== null) {
+            echo '<optgroup label="'.htmlspecialchars($g, ENT_QUOTES, 'UTF-8').'">'."\n";
+        }
+        $currentGroup = $g;
+    }
+    $sel = ($opt['value'] === $inactiveScopeValue) ? ' selected' : '';
+    echo '<option value="'.htmlspecialchars($opt['value'], ENT_QUOTES, 'UTF-8').'"'.$sel.'>'
+        .htmlspecialchars($opt['label'], ENT_QUOTES, 'UTF-8')."</option>\n";
+}
+if($currentGroup !== null) {
+    echo "</optgroup>\n";
+}
+?>
+        </select>
+      </form>
       <div class="eval-table-scroll">
         <table id="evalInactive" class="w3-table w3-striped w3-bordered w3-hoverable eval-data-table">
           <thead>
@@ -113,7 +147,6 @@ adminListPageBegin('System', 'Datenauswertung', array('permKey' => 'perm_showLog
     </section>
   </div>
 </div>
-
 <script type="application/json" id="evaluate-data"><?php echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS); ?></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.8/dist/chart.umd.min.js"></script>
 <script src="<?php echo $evaluateJs; ?>"></script>

--- a/evaluate.php
+++ b/evaluate.php
@@ -97,6 +97,7 @@ adminListPageBegin('System', 'Datenauswertung', array('permKey' => 'perm_showLog
 <?php } ?>
     </div>
 
+    <div class="eval-tables-grid">
     <section class="eval-panel" id="eval-ranking">
       <h3>Ranking nach Teilnahme</h3>
       <div class="eval-table-scroll">
@@ -132,6 +133,7 @@ adminListPageBegin('System', 'Datenauswertung', array('permKey' => 'perm_showLog
         </table>
       </div>
     </section>
+    </div>
   </div>
 </div>
 <script type="application/json" id="evaluate-data"><?php echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS); ?></script>

--- a/evaluate.php
+++ b/evaluate.php
@@ -15,14 +15,13 @@ $besetzungOnly = !empty($_GET['besetzung']);
 $inactiveDays = isset($GLOBALS['optionsDB']['inactiveUsersDays'])
     ? max(1, (int)$GLOBALS['optionsDB']['inactiveUsersDays'])
     : 90;
-$inactiveScope = evaluateParseInactiveScope(isset($_GET['inactiveScope']) ? $_GET['inactiveScope'] : 'musiker');
-$inactiveScopeValue = evaluateInactiveScopeValue($inactiveScope);
 
 $attendance = evaluateAttendanceSeries($days, $besetzungOnly);
 $logSeries = evaluateLogSeries($days);
 $ranking = evaluateAttendanceRanking($days, $besetzungOnly);
-$inactive = evaluateInactiveUsers($inactiveDays, $inactiveScopeValue);
-$inactiveScopeOptions = evaluateInactiveScopeOptions();
+$inactive = evaluateInactiveUsers($inactiveDays);
+$registers = evaluateRegisterFilterOptions();
+$groups = evaluateGroupFilterOptions();
 
 $assetV = isset($GLOBALS['version']['Hash']) ? $GLOBALS['version']['Hash'] : '0';
 $jsMtime = @filemtime(__DIR__.'/js/evaluate.js');
@@ -50,7 +49,6 @@ adminListPageBegin('System', 'Datenauswertung', array('permKey' => 'perm_showLog
       <input type="checkbox" name="besetzung" value="1"<?php echo $besetzungOnly ? ' checked' : ''; ?> onchange="this.form.submit()">
       nur Besetzung
     </label>
-    <input type="hidden" name="inactiveScope" value="<?php echo htmlspecialchars($inactiveScopeValue, ENT_QUOTES, 'UTF-8'); ?>">
   </form>
 </div>
 
@@ -80,6 +78,32 @@ adminListPageBegin('System', 'Datenauswertung', array('permKey' => 'perm_showLog
   </div>
 
   <div class="eval-tables">
+    <div id="evalPersonFilter" class="inv-sort-bar eval-person-filter">
+      <div class="inv-sort-bar-filters" role="toolbar" aria-label="Filter">
+        <button type="button" class="inv-sort-chip inv-filter-chip is-active" data-eval-filter="aktive" aria-pressed="true">Aktive</button>
+        <button type="button" class="inv-sort-chip inv-filter-chip is-active" data-eval-filter="gaeste" aria-pressed="true">Gäste</button>
+        <button type="button" class="inv-sort-chip inv-filter-chip is-active" data-eval-filter="mitglied" aria-pressed="true">Mitglieder</button>
+        <button type="button" class="inv-sort-chip inv-filter-chip is-active" data-eval-filter="nomitglied" aria-pressed="true">Nicht-Mitglieder</button>
+      </div>
+      <div class="inv-sort-bar-filters inv-sort-bar-filters--registers" role="toolbar" aria-label="Register">
+        <button type="button" class="inv-sort-chip inv-filter-chip" data-register-filter="0" aria-pressed="false">ohne Register</button>
+<?php foreach($registers as $reg) {
+    $hex = normalizeHexColor(isset($reg['Color']) ? $reg['Color'] : '');
+    $style = $hex !== '' ? ' style="--reg-filter-color:'.$hex.'"' : '';
+    $label = htmlspecialchars((string)$reg['Name'], ENT_QUOTES, 'UTF-8');
+?>
+        <button type="button" class="inv-sort-chip inv-filter-chip inv-filter-chip--register" data-register-filter="<?php echo (int)$reg['Index']; ?>" aria-pressed="false"<?php echo $style; ?>><?php echo $label; ?></button>
+<?php } ?>
+      </div>
+<?php if(count($groups) > 0) { ?>
+      <div class="inv-sort-bar-filters" role="toolbar" aria-label="Gruppen">
+<?php foreach($groups as $g) { ?>
+        <button type="button" class="inv-sort-chip inv-filter-chip" data-group-filter="<?php echo (int)$g['Index']; ?>" aria-pressed="false"><?php echo htmlspecialchars((string)$g['Name'], ENT_QUOTES, 'UTF-8'); ?></button>
+<?php } ?>
+      </div>
+<?php } ?>
+    </div>
+
     <section class="eval-panel" id="eval-ranking">
       <h3>Ranking nach Teilnahme</h3>
       <div class="eval-table-scroll">
@@ -101,36 +125,6 @@ adminListPageBegin('System', 'Datenauswertung', array('permKey' => 'perm_showLog
 
     <section class="eval-panel" id="eval-inactive">
       <h3>Inaktive</h3>
-      <form method="get" action="evaluate.php" class="eval-filter eval-filter--inactive">
-        <input type="hidden" name="days" value="<?php echo (int)$days; ?>">
-        <?php if($besetzungOnly) { ?>
-        <input type="hidden" name="besetzung" value="1">
-        <?php } ?>
-        <label for="eval-inactive-scope">Kreis</label>
-        <select id="eval-inactive-scope" name="inactiveScope" class="w3-select w3-border" onchange="this.form.submit()">
-<?php
-$currentGroup = null;
-foreach($inactiveScopeOptions as $opt) {
-    $g = $opt['optgroup'];
-    if($g !== $currentGroup) {
-        if($currentGroup !== null) {
-            echo "</optgroup>\n";
-        }
-        if($g !== null) {
-            echo '<optgroup label="'.htmlspecialchars($g, ENT_QUOTES, 'UTF-8').'">'."\n";
-        }
-        $currentGroup = $g;
-    }
-    $sel = ($opt['value'] === $inactiveScopeValue) ? ' selected' : '';
-    echo '<option value="'.htmlspecialchars($opt['value'], ENT_QUOTES, 'UTF-8').'"'.$sel.'>'
-        .htmlspecialchars($opt['label'], ENT_QUOTES, 'UTF-8')."</option>\n";
-}
-if($currentGroup !== null) {
-    echo "</optgroup>\n";
-}
-?>
-        </select>
-      </form>
       <div class="eval-table-scroll">
         <table id="evalInactive" class="w3-table w3-striped w3-bordered w3-hoverable eval-data-table">
           <thead>

--- a/evaluate.php
+++ b/evaluate.php
@@ -52,13 +52,6 @@ adminListPageBegin('System', 'Datenauswertung', array('permKey' => 'perm_showLog
   </form>
 </div>
 
-<nav class="eval-toc w3-container w3-margin-bottom" aria-label="Seitenabschnitte">
-  <a class="w3-button w3-border w3-round" href="#eval-attendance">Teilnahme</a>
-  <a class="w3-button w3-border w3-round" href="#eval-log">System-Log</a>
-  <a class="w3-button w3-border w3-round" href="#eval-ranking">Ranking</a>
-  <a class="w3-button w3-border w3-round" href="#eval-inactive">Inaktive</a>
-</nav>
-
 <div class="eval-layout w3-container">
   <div class="eval-charts">
     <section class="eval-panel" id="eval-attendance">

--- a/js/evaluate.js
+++ b/js/evaluate.js
@@ -16,6 +16,10 @@
   var attendance = data.attendance || { labels: [], yes: [], no: [], maybe: [], rate: [] };
   var log = data.log || { labels: [], series: {} };
   var logLabels = data.logLabels || [];
+  var rankingAll = data.ranking || [];
+  var inactiveAll = data.inactive || [];
+  var rankingCtl = null;
+  var inactiveCtl = null;
 
   function drawAttendance() {
     var canvas = document.getElementById('chartAttendance');
@@ -144,15 +148,75 @@
     });
   }
 
-  function bindSortableTable(tableId, rows, renderRow, defaultKey, defaultDir) {
+  function readPersonFilter() {
+    var root = document.getElementById('evalPersonFilter');
+    var filter = {
+      showAktive: true,
+      showGaeste: true,
+      showMitglied: true,
+      showNoMitglied: true,
+      registers: [],
+      groups: []
+    };
+    if (!root) {
+      return filter;
+    }
+    var aktiveBtn = root.querySelector('[data-eval-filter="aktive"]');
+    var gaesteBtn = root.querySelector('[data-eval-filter="gaeste"]');
+    var mitgliedBtn = root.querySelector('[data-eval-filter="mitglied"]');
+    var noMitgliedBtn = root.querySelector('[data-eval-filter="nomitglied"]');
+    if (aktiveBtn) filter.showAktive = aktiveBtn.classList.contains('is-active');
+    if (gaesteBtn) filter.showGaeste = gaesteBtn.classList.contains('is-active');
+    if (mitgliedBtn) filter.showMitglied = mitgliedBtn.classList.contains('is-active');
+    if (noMitgliedBtn) filter.showNoMitglied = noMitgliedBtn.classList.contains('is-active');
+
+    Array.prototype.forEach.call(root.querySelectorAll('[data-register-filter]'), function (btn) {
+      if (btn.classList.contains('is-active')) {
+        filter.registers.push(String(btn.getAttribute('data-register-filter') || '0'));
+      }
+    });
+    Array.prototype.forEach.call(root.querySelectorAll('[data-group-filter]'), function (btn) {
+      if (btn.classList.contains('is-active')) {
+        filter.groups.push(String(btn.getAttribute('data-group-filter') || '0'));
+      }
+    });
+    return filter;
+  }
+
+  function rowMatchesPersonFilter(row, filter) {
+    var active = Number(row.active) === 1;
+    var mitglied = Number(row.mitglied) === 1;
+    var regId = String(row.registerId == null ? 0 : row.registerId);
+    var groupIds = Array.isArray(row.groupIds) ? row.groupIds.map(function (g) { return String(g); }) : [];
+
+    if (active && !filter.showAktive) return false;
+    if (!active && !filter.showGaeste) return false;
+    if (mitglied && !filter.showMitglied) return false;
+    if (!mitglied && !filter.showNoMitglied) return false;
+    if (filter.registers.length && filter.registers.indexOf(regId) === -1) return false;
+    if (filter.groups.length) {
+      var hit = false;
+      for (var i = 0; i < groupIds.length; i++) {
+        if (filter.groups.indexOf(groupIds[i]) !== -1) {
+          hit = true;
+          break;
+        }
+      }
+      if (!hit) return false;
+    }
+    return true;
+  }
+
+  function bindSortableTable(tableId, getRows, renderRow, defaultKey, defaultDir) {
     var table = document.getElementById(tableId);
     if (!table) {
-      return;
+      return null;
     }
     var tbody = table.querySelector('tbody');
     var state = { key: defaultKey, dir: defaultDir, type: 'number' };
 
     function paint() {
+      var rows = typeof getRows === 'function' ? getRows() : [];
       var sorted = sortRows(rows, state.key, state.type, state.dir);
       tbody.innerHTML = '';
       if (!sorted.length) {
@@ -198,7 +262,7 @@
     if (defaultTh) {
       state.type = defaultTh.getAttribute('data-type') || 'number';
     }
-    paint();
+    return { paint: paint };
   }
 
   function cellsWithLabels(tr, pairs) {
@@ -231,8 +295,36 @@
     ]);
   }
 
+  function filteredRows(all) {
+    var filter = readPersonFilter();
+    return all.filter(function (row) {
+      return rowMatchesPersonFilter(row, filter);
+    });
+  }
+
+  function repaintTables() {
+    if (rankingCtl) rankingCtl.paint();
+    if (inactiveCtl) inactiveCtl.paint();
+  }
+
+  function bindPersonFilter() {
+    var root = document.getElementById('evalPersonFilter');
+    if (!root) return;
+    root.addEventListener('click', function (ev) {
+      var btn = ev.target.closest('[data-eval-filter], [data-register-filter], [data-group-filter]');
+      if (!btn || !root.contains(btn)) return;
+      ev.preventDefault();
+      var on = !btn.classList.contains('is-active');
+      btn.classList.toggle('is-active', on);
+      btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+      repaintTables();
+    });
+  }
+
   drawAttendance();
   drawLog();
-  bindSortableTable('evalRanking', data.ranking || [], rankingRow, 'quote', 'desc');
-  bindSortableTable('evalInactive', data.inactive || [], inactiveRow, 'lastLogin', 'asc');
+  rankingCtl = bindSortableTable('evalRanking', function () { return filteredRows(rankingAll); }, rankingRow, 'quote', 'desc');
+  inactiveCtl = bindSortableTable('evalInactive', function () { return filteredRows(inactiveAll); }, inactiveRow, 'lastLogin', 'asc');
+  bindPersonFilter();
+  repaintTables();
 })();

--- a/libs/evaluateStats.php
+++ b/libs/evaluateStats.php
@@ -178,29 +178,33 @@ function evaluateTerminCount($days, $besetzungOnly = false) {
 }
 
 /**
- * Per-user attendance ranking in the window.
+ * Per-user attendance ranking in the window (all non-deleted users; filter client-side).
  *
  * @param int $days
  * @param bool $besetzungOnly
- * @return array<int,array{id:int,name:string,yes:int,no:int,maybe:int,termine:int,quote:float}>
+ * @return array<int,array<string,mixed>>
  */
 function evaluateAttendanceRanking($days, $besetzungOnly = false) {
     $days = evaluateNormalizeDays($days);
     $prefix = $GLOBALS['dbprefix'];
     $termineCount = evaluateTerminCount($days, $besetzungOnly);
     $window = evaluateTerminWindowSql($days, $besetzungOnly);
+    $groupMap = evaluateUserGroupIdsByUser();
 
     $sql = sprintf(
-        'SELECT `u`.`Index` AS `UserId`, `u`.`Vorname`, `u`.`Nachname`,'
+        'SELECT `u`.`Index` AS `UserId`, `u`.`Vorname`, `u`.`Nachname`, `u`.`Active`, `u`.`Mitglied`,'
+        .' COALESCE(`i`.`Register`, 0) AS `RegisterId`,'
         .' COALESCE(SUM(CASE WHEN `m`.`Wert` = 1 THEN 1 ELSE 0 END), 0) AS `Yes`,'
         .' COALESCE(SUM(CASE WHEN `m`.`Wert` = 2 THEN 1 ELSE 0 END), 0) AS `No`,'
         .' COALESCE(SUM(CASE WHEN `m`.`Wert` = 3 THEN 1 ELSE 0 END), 0) AS `Maybe`'
         .' FROM `%sUser` `u`'
+        .' LEFT JOIN `%sInstrument` `i` ON `i`.`Index` = `u`.`Instrument`'
         .' LEFT JOIN `%sMeldungen` `m` ON `m`.`User` = `u`.`Index`'
         .' AND `m`.`Termin` IN (SELECT `Index` FROM `%sTermine` WHERE %s)'
-        .' WHERE `u`.`Deleted` != 1 AND `u`.`Active` = 1 AND `u`.`Instrument` > 0'
-        .' GROUP BY `u`.`Index`, `u`.`Vorname`, `u`.`Nachname`'
+        .' WHERE `u`.`Deleted` != 1'
+        .' GROUP BY `u`.`Index`, `u`.`Vorname`, `u`.`Nachname`, `u`.`Active`, `u`.`Mitglied`, `i`.`Register`'
         .' ORDER BY `u`.`Nachname` ASC, `u`.`Vorname` ASC;',
+        $prefix,
         $prefix,
         $prefix,
         $prefix,
@@ -214,15 +218,24 @@ function evaluateAttendanceRanking($days, $besetzungOnly = false) {
     if($dbr) {
         while($row = mysqli_fetch_assoc($dbr)) {
             $yes = (int)$row['Yes'];
+            $uid = (int)$row['UserId'];
             $quote = $termineCount > 0 ? round($yes / $termineCount, 4) : 0.0;
-            $rows[] = array(
-                'id' => (int)$row['UserId'],
-                'name' => trim($row['Nachname'].', '.$row['Vorname']),
-                'yes' => $yes,
-                'no' => (int)$row['No'],
-                'maybe' => (int)$row['Maybe'],
-                'termine' => $termineCount,
-                'quote' => $quote,
+            $rows[] = array_merge(
+                array(
+                    'id' => $uid,
+                    'name' => trim($row['Nachname'].', '.$row['Vorname']),
+                    'yes' => $yes,
+                    'no' => (int)$row['No'],
+                    'maybe' => (int)$row['Maybe'],
+                    'termine' => $termineCount,
+                    'quote' => $quote,
+                ),
+                evaluatePersonFilterMeta(
+                    (int)$row['Active'],
+                    (int)$row['Mitglied'],
+                    (int)$row['RegisterId'],
+                    isset($groupMap[$uid]) ? $groupMap[$uid] : array()
+                )
             );
         }
     }
@@ -241,81 +254,24 @@ function evaluateAttendanceRanking($days, $besetzungOnly = false) {
 }
 
 /**
- * Parse inactive-list scope (MELD-161).
- * Values: musiker | users | register:<id> | group:<id>
+ * Register chips for evaluate person filter (MELD-161).
  *
- * @param mixed $raw
- * @return array{type:string,id:int}
+ * @return array<int,array{Index:int,Name:string,Color:string}>
  */
-function evaluateParseInactiveScope($raw) {
-    $raw = trim((string)$raw);
-    if($raw === 'users') {
-        return array('type' => 'users', 'id' => 0);
-    }
-    if(preg_match('/^register:(\d+)$/', $raw, $m)) {
-        return array('type' => 'register', 'id' => (int)$m[1]);
-    }
-    if(preg_match('/^group:(\d+)$/', $raw, $m)) {
-        return array('type' => 'group', 'id' => (int)$m[1]);
-    }
-    return array('type' => 'musiker', 'id' => 0);
-}
-
-/**
- * Canonical scope string for forms / GET.
- *
- * @param array{type:string,id:int} $scope
- * @return string
- */
-function evaluateInactiveScopeValue(array $scope) {
-    if($scope['type'] === 'users') {
-        return 'users';
-    }
-    if($scope['type'] === 'register' && (int)$scope['id'] > 0) {
-        return 'register:'.(int)$scope['id'];
-    }
-    if($scope['type'] === 'group' && (int)$scope['id'] > 0) {
-        return 'group:'.(int)$scope['id'];
-    }
-    return 'musiker';
-}
-
-/**
- * Select options for inactive scope (optgroups via group key).
- *
- * @return array<int,array{value:string,label:string,optgroup:?string}>
- */
-function evaluateInactiveScopeOptions() {
-    $opts = array(
-        array('value' => 'musiker', 'label' => 'Alle Musiker', 'optgroup' => null),
-        array('value' => 'users', 'label' => 'Alle User', 'optgroup' => null),
-    );
-    $prefix = $GLOBALS['dbprefix'];
+function evaluateRegisterFilterOptions() {
+    $opts = array();
     $sql = sprintf(
-        'SELECT `Index`, `Name` FROM `%sRegister` WHERE LOWER(TRIM(`Name`)) != "keins" ORDER BY `Sortierung`, `Name`;',
-        $prefix
+        'SELECT `Index`, `Name`, `Color` FROM `%sRegister` WHERE LOWER(TRIM(`Name`)) != "keins" ORDER BY `Sortierung`, `Name`;',
+        $GLOBALS['dbprefix']
     );
     $dbr = mysqli_query($GLOBALS['conn'], $sql);
     sqlerror();
     if($dbr) {
         while($row = mysqli_fetch_assoc($dbr)) {
             $opts[] = array(
-                'value' => 'register:'.(int)$row['Index'],
-                'label' => (string)$row['Name'],
-                'optgroup' => 'Register',
-            );
-        }
-    }
-    if(class_exists('Group')) {
-        Group::ensureSchema();
-        foreach(Group::listAll() as $g) {
-            if(!(int)$g->Index) {
-                continue;
-            }
-            $opts[] = array(
-                'value' => 'group:'.(int)$g->Index,
-                'label' => (string)$g->Name,
-                'optgroup' => 'Gruppen',
+                'Index' => (int)$row['Index'],
+                'Name' => (string)$row['Name'],
+                'Color' => isset($row['Color']) ? (string)$row['Color'] : '',
             );
         }
     }
@@ -323,70 +279,161 @@ function evaluateInactiveScopeOptions() {
 }
 
 /**
- * SQL WHERE on alias `u` for inactive scope.
+ * Named group chips for evaluate person filter.
  *
- * @param array{type:string,id:int} $scope
- * @return string
+ * @return array<int,array{Index:int,Name:string}>
  */
-function evaluateInactiveScopeWhereSql(array $scope) {
-    $prefix = $GLOBALS['dbprefix'];
-    if($scope['type'] === 'users') {
-        return '`u`.`Deleted` != 1';
+function evaluateGroupFilterOptions() {
+    $opts = array();
+    if(!class_exists('Group')) {
+        return $opts;
     }
-    if($scope['type'] === 'register' && (int)$scope['id'] > 0) {
-        return sprintf(
-            '`u`.`Deleted` != 1 AND `u`.`Active` = 1 AND `u`.`Instrument` IN ('
-            .'SELECT `Index` FROM `%sInstrument` WHERE `Register` = %d)',
-            $prefix,
-            (int)$scope['id']
+    Group::ensureSchema();
+    foreach(Group::listAll() as $g) {
+        if(!(int)$g->Index) {
+            continue;
+        }
+        $opts[] = array(
+            'Index' => (int)$g->Index,
+            'Name' => (string)$g->Name,
         );
     }
-    if($scope['type'] === 'group' && (int)$scope['id'] > 0) {
-        $g = new Group();
-        $g->load_by_id((int)$scope['id']);
-        $ids = array();
-        if((int)$g->Index > 0) {
-            foreach(AudienceSpec::resolveUserIds($g->getMemberSpecArray(), false) as $uid) {
-                $uid = (int)$uid;
-                if($uid > 0) {
-                    $ids[$uid] = $uid;
-                }
+    return $opts;
+}
+
+/**
+ * @return array<int,int[]>
+ */
+function evaluateUserGroupIdsByUser() {
+    $map = array();
+    if(!class_exists('Group') || !class_exists('AudienceSpec')) {
+        return $map;
+    }
+    Group::ensureSchema();
+    foreach(Group::listAll() as $g) {
+        $gid = (int)$g->Index;
+        if($gid < 1) {
+            continue;
+        }
+        foreach(AudienceSpec::resolveUserIds($g->getMemberSpecArray(), false) as $uid) {
+            $uid = (int)$uid;
+            if($uid < 1) {
+                continue;
+            }
+            if(!isset($map[$uid])) {
+                $map[$uid] = array();
+            }
+            if(!in_array($gid, $map[$uid], true)) {
+                $map[$uid][] = $gid;
             }
         }
-        if(!$ids) {
-            return '0 = 1';
-        }
-        return '`u`.`Deleted` != 1 AND `u`.`Index` IN ('.implode(',', $ids).')';
     }
-    return '`u`.`Deleted` != 1 AND `u`.`Active` = 1 AND `u`.`Instrument` > 0';
+    return $map;
+}
+
+/**
+ * @param int $active
+ * @param int $mitglied
+ * @param int $registerId
+ * @param int[] $groupIds
+ * @return array{active:int,mitglied:int,registerId:int,groupIds:int[]}
+ */
+function evaluatePersonFilterMeta($active, $mitglied, $registerId, array $groupIds) {
+    $gids = array();
+    foreach($groupIds as $gid) {
+        $gid = (int)$gid;
+        if($gid > 0) {
+            $gids[] = $gid;
+        }
+    }
+    return array(
+        'active' => ((int)$active) ? 1 : 0,
+        'mitglied' => ((int)$mitglied) ? 1 : 0,
+        'registerId' => max(0, (int)$registerId),
+        'groupIds' => $gids,
+    );
+}
+
+/**
+ * Same rules as Personenliste chips (+ optional group chips).
+ *
+ * @param array<string,mixed> $row
+ * @param array{showAktive:bool,showGaeste:bool,showMitglied:bool,showNoMitglied:bool,registers:string[],groups:string[]} $filter
+ * @return bool
+ */
+function evaluateRowMatchesPersonFilter(array $row, array $filter) {
+    $active = !empty($row['active']);
+    $mitglied = !empty($row['mitglied']);
+    $regId = (string)(isset($row['registerId']) ? (int)$row['registerId'] : 0);
+    $groupIds = array();
+    if(isset($row['groupIds']) && is_array($row['groupIds'])) {
+        foreach($row['groupIds'] as $gid) {
+            $groupIds[] = (string)(int)$gid;
+        }
+    }
+
+    if($active && empty($filter['showAktive'])) {
+        return false;
+    }
+    if(!$active && empty($filter['showGaeste'])) {
+        return false;
+    }
+    if($mitglied && empty($filter['showMitglied'])) {
+        return false;
+    }
+    if(!$mitglied && empty($filter['showNoMitglied'])) {
+        return false;
+    }
+
+    $regs = isset($filter['registers']) && is_array($filter['registers']) ? $filter['registers'] : array();
+    if(count($regs) > 0 && !in_array($regId, $regs, true)) {
+        return false;
+    }
+
+    $groups = isset($filter['groups']) && is_array($filter['groups']) ? $filter['groups'] : array();
+    if(count($groups) > 0) {
+        $hit = false;
+        foreach($groupIds as $gid) {
+            if(in_array($gid, $groups, true)) {
+                $hit = true;
+                break;
+            }
+        }
+        if(!$hit) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 /**
  * Users considered inactive by last login / last attendance (Wert=1).
+ * All non-deleted users; person chips filter client-side (MELD-161).
  *
  * @param int $thresholdDays
- * @param mixed $scopeRaw musiker|users|register:n|group:n
- * @return array<int,array{id:int,name:string,lastLogin:?string,lastAttend:?string,quote:float}>
+ * @return array<int,array<string,mixed>>
  */
-function evaluateInactiveUsers($thresholdDays, $scopeRaw = 'musiker') {
+function evaluateInactiveUsers($thresholdDays) {
     $thresholdDays = max(1, (int)$thresholdDays);
     $prefix = $GLOBALS['dbprefix'];
-    $scope = evaluateParseInactiveScope($scopeRaw);
-    $where = evaluateInactiveScopeWhereSql($scope);
+    $groupMap = evaluateUserGroupIdsByUser();
 
     $sql = sprintf(
         'SELECT `u`.`Index` AS `UserId`, `u`.`Vorname`, `u`.`Nachname`, `u`.`LastLogin`, `u`.`Joined`,'
+        .' `u`.`Active`, `u`.`Mitglied`, COALESCE(`i`.`Register`, 0) AS `RegisterId`,'
         .' ('
         .'   SELECT MAX(`t`.`Datum`) FROM `%sMeldungen` `m`'
         .'   INNER JOIN `%sTermine` `t` ON `t`.`Index` = `m`.`Termin`'
         .'   WHERE `m`.`User` = `u`.`Index` AND `m`.`Wert` = 1 AND `t`.`Datum` <= CURRENT_DATE()'
         .' ) AS `LastAttend`'
         .' FROM `%sUser` `u`'
-        .' WHERE %s;',
+        .' LEFT JOIN `%sInstrument` `i` ON `i`.`Index` = `u`.`Instrument`'
+        .' WHERE `u`.`Deleted` != 1;',
         $prefix,
         $prefix,
         $prefix,
-        $where
+        $prefix
     );
 
     $dbr = mysqli_query($GLOBALS['conn'], $sql);
@@ -417,19 +464,28 @@ function evaluateInactiveUsers($thresholdDays, $scopeRaw = 'musiker') {
                 continue;
             }
 
+            $uid = (int)$row['UserId'];
             $user = new User();
-            $user->load_by_id((int)$row['UserId']);
+            $user->load_by_id($uid);
             $quote = 0.0;
             if($user->Index) {
                 $quote = (float)$user->getMeldeQuote();
             }
 
-            $rows[] = array(
-                'id' => (int)$row['UserId'],
-                'name' => trim($row['Nachname'].', '.$row['Vorname']),
-                'lastLogin' => $lastLogin,
-                'lastAttend' => $lastAttend,
-                'quote' => $quote,
+            $rows[] = array_merge(
+                array(
+                    'id' => $uid,
+                    'name' => trim($row['Nachname'].', '.$row['Vorname']),
+                    'lastLogin' => $lastLogin,
+                    'lastAttend' => $lastAttend,
+                    'quote' => $quote,
+                ),
+                evaluatePersonFilterMeta(
+                    (int)$row['Active'],
+                    (int)$row['Mitglied'],
+                    (int)$row['RegisterId'],
+                    isset($groupMap[$uid]) ? $groupMap[$uid] : array()
+                )
             );
         }
     }

--- a/libs/evaluateStats.php
+++ b/libs/evaluateStats.php
@@ -241,14 +241,138 @@ function evaluateAttendanceRanking($days, $besetzungOnly = false) {
 }
 
 /**
+ * Parse inactive-list scope (MELD-161).
+ * Values: musiker | users | register:<id> | group:<id>
+ *
+ * @param mixed $raw
+ * @return array{type:string,id:int}
+ */
+function evaluateParseInactiveScope($raw) {
+    $raw = trim((string)$raw);
+    if($raw === 'users') {
+        return array('type' => 'users', 'id' => 0);
+    }
+    if(preg_match('/^register:(\d+)$/', $raw, $m)) {
+        return array('type' => 'register', 'id' => (int)$m[1]);
+    }
+    if(preg_match('/^group:(\d+)$/', $raw, $m)) {
+        return array('type' => 'group', 'id' => (int)$m[1]);
+    }
+    return array('type' => 'musiker', 'id' => 0);
+}
+
+/**
+ * Canonical scope string for forms / GET.
+ *
+ * @param array{type:string,id:int} $scope
+ * @return string
+ */
+function evaluateInactiveScopeValue(array $scope) {
+    if($scope['type'] === 'users') {
+        return 'users';
+    }
+    if($scope['type'] === 'register' && (int)$scope['id'] > 0) {
+        return 'register:'.(int)$scope['id'];
+    }
+    if($scope['type'] === 'group' && (int)$scope['id'] > 0) {
+        return 'group:'.(int)$scope['id'];
+    }
+    return 'musiker';
+}
+
+/**
+ * Select options for inactive scope (optgroups via group key).
+ *
+ * @return array<int,array{value:string,label:string,optgroup:?string}>
+ */
+function evaluateInactiveScopeOptions() {
+    $opts = array(
+        array('value' => 'musiker', 'label' => 'Alle Musiker', 'optgroup' => null),
+        array('value' => 'users', 'label' => 'Alle User', 'optgroup' => null),
+    );
+    $prefix = $GLOBALS['dbprefix'];
+    $sql = sprintf(
+        'SELECT `Index`, `Name` FROM `%sRegister` WHERE LOWER(TRIM(`Name`)) != "keins" ORDER BY `Sortierung`, `Name`;',
+        $prefix
+    );
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    if($dbr) {
+        while($row = mysqli_fetch_assoc($dbr)) {
+            $opts[] = array(
+                'value' => 'register:'.(int)$row['Index'],
+                'label' => (string)$row['Name'],
+                'optgroup' => 'Register',
+            );
+        }
+    }
+    if(class_exists('Group')) {
+        Group::ensureSchema();
+        foreach(Group::listAll() as $g) {
+            if(!(int)$g->Index) {
+                continue;
+            }
+            $opts[] = array(
+                'value' => 'group:'.(int)$g->Index,
+                'label' => (string)$g->Name,
+                'optgroup' => 'Gruppen',
+            );
+        }
+    }
+    return $opts;
+}
+
+/**
+ * SQL WHERE on alias `u` for inactive scope.
+ *
+ * @param array{type:string,id:int} $scope
+ * @return string
+ */
+function evaluateInactiveScopeWhereSql(array $scope) {
+    $prefix = $GLOBALS['dbprefix'];
+    if($scope['type'] === 'users') {
+        return '`u`.`Deleted` != 1';
+    }
+    if($scope['type'] === 'register' && (int)$scope['id'] > 0) {
+        return sprintf(
+            '`u`.`Deleted` != 1 AND `u`.`Active` = 1 AND `u`.`Instrument` IN ('
+            .'SELECT `Index` FROM `%sInstrument` WHERE `Register` = %d)',
+            $prefix,
+            (int)$scope['id']
+        );
+    }
+    if($scope['type'] === 'group' && (int)$scope['id'] > 0) {
+        $g = new Group();
+        $g->load_by_id((int)$scope['id']);
+        $ids = array();
+        if((int)$g->Index > 0) {
+            foreach(AudienceSpec::resolveUserIds($g->getMemberSpecArray(), false) as $uid) {
+                $uid = (int)$uid;
+                if($uid > 0) {
+                    $ids[$uid] = $uid;
+                }
+            }
+        }
+        if(!$ids) {
+            return '0 = 1';
+        }
+        return '`u`.`Deleted` != 1 AND `u`.`Index` IN ('.implode(',', $ids).')';
+    }
+    return '`u`.`Deleted` != 1 AND `u`.`Active` = 1 AND `u`.`Instrument` > 0';
+}
+
+/**
  * Users considered inactive by last login / last attendance (Wert=1).
  *
  * @param int $thresholdDays
+ * @param mixed $scopeRaw musiker|users|register:n|group:n
  * @return array<int,array{id:int,name:string,lastLogin:?string,lastAttend:?string,quote:float}>
  */
-function evaluateInactiveUsers($thresholdDays) {
+function evaluateInactiveUsers($thresholdDays, $scopeRaw = 'musiker') {
     $thresholdDays = max(1, (int)$thresholdDays);
     $prefix = $GLOBALS['dbprefix'];
+    $scope = evaluateParseInactiveScope($scopeRaw);
+    $where = evaluateInactiveScopeWhereSql($scope);
 
     $sql = sprintf(
         'SELECT `u`.`Index` AS `UserId`, `u`.`Vorname`, `u`.`Nachname`, `u`.`LastLogin`, `u`.`Joined`,'
@@ -258,10 +382,11 @@ function evaluateInactiveUsers($thresholdDays) {
         .'   WHERE `m`.`User` = `u`.`Index` AND `m`.`Wert` = 1 AND `t`.`Datum` <= CURRENT_DATE()'
         .' ) AS `LastAttend`'
         .' FROM `%sUser` `u`'
-        .' WHERE `u`.`Deleted` != 1 AND `u`.`Active` = 1 AND `u`.`Instrument` > 0;',
+        .' WHERE %s;',
         $prefix,
         $prefix,
-        $prefix
+        $prefix,
+        $where
     );
 
     $dbr = mysqli_query($GLOBALS['conn'], $sql);

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -687,6 +687,9 @@ function renderPermissionGroupColorCss($wrapStyleTag = true) {
             .',.w3-container.admin-list-hero--'.$id
             .'{background:'.$strong.';border-left-color:'.$accent.';--page-title-accent:'.$accent.';}';
 
+        $css .= '.eval-table-scroll thead th.admin-list-hero--'.$id
+            .'{background:'.$strong.';color:'.$fg.';}';
+
         $css .= '.perm-matrix thead th.perm-group--'.$id
             .'{background:'.$soft.';box-shadow:inset 0 -3px 0 '.$accent.';}';
 

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2933,6 +2933,14 @@ body.meld-cal-print {
   max-width: 6rem;
 }
 
+.eval-filter--inactive {
+  margin: 0 0 0.75rem;
+}
+
+.eval-filter--inactive select {
+  max-width: 16rem;
+}
+
 .eval-toc {
   display: flex;
   flex-wrap: wrap;

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2937,22 +2937,6 @@ body.meld-cal-print {
   margin: 0 0 1rem;
 }
 
-.eval-toc {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  position: sticky;
-  top: calc(var(--app-page-head-h, 0px) + var(--app-page-toolbar-h, 0px));
-  z-index: 5;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  background: inherit;
-}
-
-.eval-toc a {
-  text-decoration: none;
-}
-
 .eval-panel {
   margin-bottom: 1.25rem;
   scroll-margin-top: 3.5rem;

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2934,7 +2934,13 @@ body.meld-cal-print {
 }
 
 .eval-person-filter {
-  margin: 0 0 1rem;
+  margin: 0 0 0.75rem;
+  position: static;
+  top: auto;
+  z-index: auto;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .eval-panel {
@@ -3158,7 +3164,7 @@ body.meld-cal-print {
 
 @media (min-width: 993px) {
   .eval-charts,
-  .eval-tables {
+  .eval-tables-grid {
     grid-template-columns: 1fr 1fr;
     align-items: start;
   }

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2933,12 +2933,8 @@ body.meld-cal-print {
   max-width: 6rem;
 }
 
-.eval-filter--inactive {
-  margin: 0 0 0.75rem;
-}
-
-.eval-filter--inactive select {
-  max-width: 16rem;
+.eval-person-filter {
+  margin: 0 0 1rem;
 }
 
 .eval-toc {

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2979,8 +2979,16 @@ body.meld-cal-print {
 .eval-table-scroll thead th {
   position: sticky;
   top: 0;
-  z-index: 2;
+  z-index: 3;
+  background-color: #e8eef0;
+  background-clip: padding-box;
   box-shadow: 0 1px 0 rgba(0, 0, 0, 0.18);
+}
+
+.eval-table-scroll tbody td {
+  position: relative;
+  z-index: 0;
+  background-clip: padding-box;
 }
 
 .eval-sort {
@@ -3048,10 +3056,15 @@ body.meld-cal-print {
 }
 
 .eval-charts,
-.eval-tables {
+.eval-tables-grid {
   display: grid;
   grid-template-columns: 1fr;
   gap: 1rem;
+  min-width: 0;
+}
+
+.eval-tables {
+  display: block;
   min-width: 0;
 }
 

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -262,7 +262,7 @@ $sections[] = array(
 <li><b>Plattform / SSO</b> – <code>ssoRedirectAllowlist</code>, <code>urlNotenarchiv</code> und <code>urlMitgliederverwaltung</code> für einmalige SSO-Tickets zu Schwester-Modulen (Nav-Links erscheinen bei gesetzter URL)</li>
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
-<li><b>Statistik</b> – Auswertungen mit Abschnittsnavigation; auf breiten Bildschirmen Diagramme und Tabellen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking (Quote = Ja-Meldungen / Termine im Zeitraum; Spalten sortierbar) und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>)</li>
+<li><b>Statistik</b> – Auswertungen mit Abschnittsnavigation; auf breiten Bildschirmen Diagramme und Tabellen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking (Quote = Ja-Meldungen / Termine im Zeitraum; Spalten sortierbar) und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>; Kreis: Alle Musiker, Alle User, Register oder Gruppe)</li>
 <li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung); Chunk-Größe über <code>logListChunkSize</code> in der Konfiguration</li>
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -262,7 +262,7 @@ $sections[] = array(
 <li><b>Plattform / SSO</b> – <code>ssoRedirectAllowlist</code>, <code>urlNotenarchiv</code> und <code>urlMitgliederverwaltung</code> für einmalige SSO-Tickets zu Schwester-Modulen (Nav-Links erscheinen bei gesetzter URL)</li>
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
-<li><b>Statistik</b> – Auswertungen mit Abschnittsnavigation; auf breiten Bildschirmen Diagramme und Tabellen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking (Quote = Ja-Meldungen / Termine im Zeitraum; Spalten sortierbar) und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>; Kreis: Alle Musiker, Alle User, Register oder Gruppe)</li>
+<li><b>Statistik</b> – Auswertungen mit Abschnittsnavigation; auf breiten Bildschirmen Diagramme und Tabellen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>). Ranking und Inaktive teilen sich denselben Chip-Filter wie die Personenliste (Aktive/Gäste/Mitglieder, Register, Gruppen)</li>
 <li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung); Chunk-Größe über <code>logListChunkSize</code> in der Konfiguration</li>
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -262,7 +262,7 @@ $sections[] = array(
 <li><b>Plattform / SSO</b> – <code>ssoRedirectAllowlist</code>, <code>urlNotenarchiv</code> und <code>urlMitgliederverwaltung</code> für einmalige SSO-Tickets zu Schwester-Modulen (Nav-Links erscheinen bei gesetzter URL)</li>
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
-<li><b>Statistik</b> – Auswertungen mit Abschnittsnavigation; auf breiten Bildschirmen Diagramme und Tabellen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>). Ranking und Inaktive teilen sich denselben Chip-Filter wie die Personenliste (Aktive/Gäste/Mitglieder, Register, Gruppen)</li>
+<li><b>Statistik</b> – Auswertungen; auf breiten Bildschirmen Diagramme und Tabellen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>). Ranking und Inaktive teilen sich denselben Chip-Filter wie die Personenliste (Aktive/Gäste/Mitglieder, Register, Gruppen)</li>
 <li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung); Chunk-Größe über <code>logListChunkSize</code> in der Konfiguration</li>
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '


### PR DESCRIPTION
## Summary
- Gemeinsamer Chip-Filter (wie Personenliste) für Ranking und Inaktive: Aktive/Gäste/Mitglieder, Register, Gruppen
- Anker-Navigation entfernt; Filter außerhalb des Tabellen-Grids
- Sticky Tabellenköpfe mit deckendem Hintergrund

## Test plan
- [ ] Statistik: Chip-Filter wirkt auf Ranking und Inaktive gemeinsam
- [ ] Zweispaltiges Layout bleibt erhalten (Filter über den Tabellen)
- [ ] Tabellenköpfe bleiben beim Scrollen sichtbar
- [ ] PHPUnit `EvaluateStatsTest`

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-161