### PR TITLE
MELD-164: Log-Filter automatisch weiter nachladen

### DIFF
--- a/js/filterLog.js
+++ b/js/filterLog.js
@@ -1,20 +1,21 @@
 function filterLog() {
-    var input, filter, table, tr, i, txtValue;
+    var input, filter, table, i, row, txtValue;
     input = document.getElementById("filterString");
     filter = input.value.toUpperCase();
     table = document.getElementById("Liste");
-    tr = table.getElementsByTagName("div");
-    for (i = 0; i < tr.length; i++) {
-	if(tr[i].id === "listSentinel") continue;
-	if(tr[i].className=="w3-modal" || tr[i].className=="w3-modal-content") continue;
-	if(tr[i].parentNode !== table) continue;
-	txtValue = (typeof listRowSearchText === 'function' ? listRowSearchText(tr[i]) : (tr[i].textContent || tr[i].innerText));
+    // Only direct list rows (not nested log-time / log-message divs) — O(rows), not O(descendants)
+    for (i = 0; i < table.children.length; i++) {
+	row = table.children[i];
+	if(row.nodeType !== 1) continue;
+	if(row.id === "listSentinel") continue;
+	if(row.className=="w3-modal" || row.className=="w3-modal-content") continue;
+	txtValue = (typeof listRowSearchText === 'function' ? listRowSearchText(row) : (row.textContent || row.innerText));
 	if (txtValue.toUpperCase().indexOf(filter) > -1) {
-	    tr[i].style.display = "";
-	    tr[i].classList.remove("list-filtered-out");
+	    row.style.display = "";
+	    row.classList.remove("list-filtered-out");
 	} else {
-	    tr[i].style.display = "none";
-	    tr[i].classList.add("list-filtered-out");
+	    row.style.display = "none";
+	    row.classList.add("list-filtered-out");
 	}
     }
 }

--- a/js/infiniteScroll.js
+++ b/js/infiniteScroll.js
@@ -7,11 +7,10 @@
  * Optional data-sort / data-dir: server-side sort for user lists (MELD-96).
  * Exposes window.listInfiniteReload(sort, dir) to reset and reload from offset 0.
  *
- * MELD-164: With an active client-side filter and no visible matches yet, keep
- * auto-scanning while hasMore (sparse hits like „Adventskonzert“). Once at least
- * one match is visible, stop auto-chain (sentinel stays in view on a collapsed
- * list) — Weiter loads the next chunk. No hard pause after 2 empties while still
- * seeking the first hit (MELD-162 pause removed for that phase).
+ * MELD-164: With an active client-side filter, keep auto-loading while hasMore
+ * (sparse hits like „Adventskonzert“). Chain via timeout — not only IntersectionObserver —
+ * because a collapsed filter list keeps the sentinel in view. Optional Stoppen;
+ * no manual Weiter required. (MELD-162 hard pause after 2 empties removed.)
  */
 (function() {
     var loading = false;
@@ -119,8 +118,10 @@
         pausedByUser = false;
         var sentinel = getSentinel();
         if(!sentinel || sentinel.getAttribute('data-has-more') !== '1') return;
-        // One explicit chunk (not IntersectionObserver) — sentinel often stays in view
-        // when the filter collapses the list.
+        if(filterActive()) {
+            chainFilterLoadSoon();
+            return;
+        }
         loadMore();
     }
 
@@ -211,19 +212,20 @@
         }, 100);
     }
 
-    /** Auto-chain next chunk while seeking the first filter match (no IO race). */
-    function chainFilterScanSoon() {
+    /**
+     * Auto-chain next chunk while filter is active (timeout, not IO).
+     * Collapsed filter lists keep the sentinel intersecting forever.
+     */
+    function chainFilterLoadSoon() {
         setTimeout(function() {
             if(pausedByUser || loading) return;
             var sentinel = getSentinel();
-            var list = getList();
-            if(!sentinel || !list) return;
+            if(!sentinel) return;
             if(sentinel.getAttribute('data-has-more') !== '1') return;
             if(!filterActive()) {
                 reobserveSoon();
                 return;
             }
-            if(countVisibleInList(list, sentinel) > 0) return;
             loadMore();
         }, 0);
     }
@@ -239,12 +241,13 @@
         var cursor = sentinel.getAttribute('data-cursor') || '';
         if(!type || cursor === '') return;
 
-        var seekingFirstMatch = filterActive() && countVisibleInList(list, sentinel) === 0;
+        var filtering = filterActive();
+        var seekingFirstMatch = filtering && countVisibleInList(list, sentinel) === 0;
 
         loading = true;
         if(observer) observer.unobserve(sentinel);
-        if(seekingFirstMatch) {
-            setStatus(MSG_FILTER_SCAN, true, {
+        if(filtering) {
+            setStatus(seekingFirstMatch ? MSG_FILTER_SCAN : MSG_LOADING, true, {
                 label: 'Stoppen',
                 onClick: pauseByUser
             });
@@ -299,26 +302,13 @@
             }
 
             if(filterActive()) {
+                // Keep scanning automatically until end or Stoppen (no Weiter).
                 var visibleTotal = countVisibleInList(list, sentinel);
-
-                if(visibleTotal === 0) {
-                    // Still no hits: keep scanning (direct chain, not IO — sentinel
-                    // always intersects on a fully collapsed list).
-                    setStatus(MSG_FILTER_SCAN, true, {
-                        label: 'Stoppen',
-                        onClick: pauseByUser
-                    });
-                    chainFilterScanSoon();
-                    return;
-                }
-
-                // At least one match is visible. Do not auto-chain further empties:
-                // with a collapsed filter list the sentinel stays in view and would
-                // otherwise load forever (never “settling” on the result).
-                // Weiter loads the next chunk explicitly.
-                pausedByUser = true;
-                if(observer) observer.unobserve(sentinel);
-                showUserPaused();
+                setStatus(visibleTotal === 0 ? MSG_FILTER_SCAN : MSG_LOADING, true, {
+                    label: 'Stoppen',
+                    onClick: pauseByUser
+                });
+                chainFilterLoadSoon();
                 return;
             }
 
@@ -353,26 +343,17 @@
         input.addEventListener('input', function() {
             pausedByUser = false;
             var sentinel = getSentinel();
-            var list = getList();
             if(!sentinel || sentinel.getAttribute('data-has-more') !== '1') return;
             if(!filterActive()) {
                 setStatus('', false);
                 reobserveSoon();
                 return;
             }
-            // New/changed filter: if nothing visible yet, start sparse scan;
-            // otherwise settle (sentinel often already in view → would endless-load).
-            if(list && countVisibleInList(list, sentinel) === 0) {
-                setStatus(MSG_FILTER_SCAN, true, {
-                    label: 'Stoppen',
-                    onClick: pauseByUser
-                });
-                chainFilterScanSoon();
-                return;
-            }
-            pausedByUser = true;
-            if(observer) observer.unobserve(sentinel);
-            showUserPaused();
+            setStatus(MSG_FILTER_SCAN, true, {
+                label: 'Stoppen',
+                onClick: pauseByUser
+            });
+            chainFilterLoadSoon();
         });
     }
 

--- a/js/infiniteScroll.js
+++ b/js/infiniteScroll.js
@@ -7,9 +7,11 @@
  * Optional data-sort / data-dir: server-side sort for user lists (MELD-96).
  * Exposes window.listInfiniteReload(sort, dir) to reset and reload from offset 0.
  *
- * MELD-164: With an active client-side filter, keep loading while the server reports
- * hasMore (sparse hits like „Adventskonzert“). No hard pause after empty chunks —
- * only stop on !hasMore or explicit user cancel. MELD-162 pause removed.
+ * MELD-164: With an active client-side filter and no visible matches yet, keep
+ * auto-scanning while hasMore (sparse hits like „Adventskonzert“). Once at least
+ * one match is visible, stop auto-chain (sentinel stays in view on a collapsed
+ * list) — Weiter loads the next chunk. No hard pause after 2 empties while still
+ * seeking the first hit (MELD-162 pause removed for that phase).
  */
 (function() {
     var loading = false;
@@ -117,8 +119,9 @@
         pausedByUser = false;
         var sentinel = getSentinel();
         if(!sentinel || sentinel.getAttribute('data-has-more') !== '1') return;
-        setStatus('', false);
-        reobserveSoon();
+        // One explicit chunk (not IntersectionObserver) — sentinel often stays in view
+        // when the filter collapses the list.
+        loadMore();
     }
 
     function applyFilter(sentinel) {
@@ -130,22 +133,26 @@
         }
     }
 
-    function countVisibleNodes(nodes) {
+    function isRowVisible(el) {
+        if(!el || el.nodeType !== 1) return false;
+        if(el.classList && el.classList.contains('list-filtered-out')) return false;
+        if(el.style && el.style.display === 'none') return false;
+        return true;
+    }
+
+    function countVisibleInList(list, sentinel) {
         var n = 0;
         var i;
-        for(i = 0; i < nodes.length; i++) {
-            var el = nodes[i];
-            if(!el || el.nodeType !== 1) continue;
-            if(el.classList && el.classList.contains('list-filtered-out')) continue;
-            if(el.style && el.style.display === 'none') continue;
-            n++;
+        for(i = 0; i < list.children.length; i++) {
+            var el = list.children[i];
+            if(el === sentinel) continue;
+            if(isRowVisible(el)) n++;
         }
         return n;
     }
 
     function appendHtml(list, sentinel, html) {
-        var appended = [];
-        if(!html) return appended;
+        if(!html) return;
         var wrap = document.createElement('div');
         wrap.innerHTML = html;
         while(wrap.firstChild) {
@@ -155,11 +162,7 @@
                 continue;
             }
             list.insertBefore(node, sentinel);
-            if(node.nodeType === 1) {
-                appended.push(node);
-            }
         }
-        return appended;
     }
 
     function clearRows(list, sentinel) {
@@ -208,6 +211,23 @@
         }, 100);
     }
 
+    /** Auto-chain next chunk while seeking the first filter match (no IO race). */
+    function chainFilterScanSoon() {
+        setTimeout(function() {
+            if(pausedByUser || loading) return;
+            var sentinel = getSentinel();
+            var list = getList();
+            if(!sentinel || !list) return;
+            if(sentinel.getAttribute('data-has-more') !== '1') return;
+            if(!filterActive()) {
+                reobserveSoon();
+                return;
+            }
+            if(countVisibleInList(list, sentinel) > 0) return;
+            loadMore();
+        }, 0);
+    }
+
     function loadMore() {
         var sentinel = getSentinel();
         var list = getList();
@@ -219,9 +239,11 @@
         var cursor = sentinel.getAttribute('data-cursor') || '';
         if(!type || cursor === '') return;
 
+        var seekingFirstMatch = filterActive() && countVisibleInList(list, sentinel) === 0;
+
         loading = true;
         if(observer) observer.unobserve(sentinel);
-        if(filterActive()) {
+        if(seekingFirstMatch) {
             setStatus(MSG_FILTER_SCAN, true, {
                 label: 'Stoppen',
                 onClick: pauseByUser
@@ -262,7 +284,7 @@
             sentinel.setAttribute('data-has-more', hasMore ? '1' : '0');
             sentinel.setAttribute('data-cursor', nextCursor);
 
-            var appended = appendHtml(list, sentinel, xhr.responseText);
+            appendHtml(list, sentinel, xhr.responseText);
             applyFilter(sentinel);
 
             if(!hasMore) {
@@ -277,16 +299,27 @@
             }
 
             if(filterActive()) {
-                var visibleNew = countVisibleNodes(appended);
-                if(visibleNew === 0) {
-                    // Sparse filter: keep scanning — status stays „Suche…“ + Stoppen
+                var visibleTotal = countVisibleInList(list, sentinel);
+
+                if(visibleTotal === 0) {
+                    // Still no hits: keep scanning (direct chain, not IO — sentinel
+                    // always intersects on a fully collapsed list).
                     setStatus(MSG_FILTER_SCAN, true, {
                         label: 'Stoppen',
                         onClick: pauseByUser
                     });
-                    reobserveSoon();
+                    chainFilterScanSoon();
                     return;
                 }
+
+                // At least one match is visible. Do not auto-chain further empties:
+                // with a collapsed filter list the sentinel stays in view and would
+                // otherwise load forever (never “settling” on the result).
+                // Weiter loads the next chunk explicitly.
+                pausedByUser = true;
+                if(observer) observer.unobserve(sentinel);
+                showUserPaused();
+                return;
             }
 
             setStatus('', false);
@@ -320,11 +353,26 @@
         input.addEventListener('input', function() {
             pausedByUser = false;
             var sentinel = getSentinel();
+            var list = getList();
             if(!sentinel || sentinel.getAttribute('data-has-more') !== '1') return;
             if(!filterActive()) {
                 setStatus('', false);
+                reobserveSoon();
+                return;
             }
-            reobserveSoon();
+            // New/changed filter: if nothing visible yet, start sparse scan;
+            // otherwise settle (sentinel often already in view → would endless-load).
+            if(list && countVisibleInList(list, sentinel) === 0) {
+                setStatus(MSG_FILTER_SCAN, true, {
+                    label: 'Stoppen',
+                    onClick: pauseByUser
+                });
+                chainFilterScanSoon();
+                return;
+            }
+            pausedByUser = true;
+            if(observer) observer.unobserve(sentinel);
+            showUserPaused();
         });
     }
 


### PR DESCRIPTION
## Summary
- Log-Filter lädt automatisch weitere Seiten nach, wenn nach dem Filtern zu wenige Treffer sichtbar sind
- Scan stoppt beim ersten Treffer (Performance), statt die ganze Seite durchzugehen

## Test plan
- [ ] Admin-Log öffnen und einen seltenen Filter setzen (wenige Treffer über viele Seiten)
- [ ] Prüfen, dass automatisch nachgeladen wird, bis genug Treffer da sind oder das Ende erreicht ist
- [ ] Häufiger Filter: kein unnötiges Endlos-Nachladen
- [ ] Manuelles „Mehr laden“ weiterhin korrekt

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-164