### PR TITLE
MELD-173: Tablet-Layout — untere Nav bis 992px

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -135,8 +135,8 @@ a.w3-button.meld-cal-step {
   padding-left: 0;
   padding-right: 0;
 }
-/* Smartphone / narrow: Info+Druck | Heute on row 1; month+year full width on row 2 */
-@media (max-width: 720px) {
+/* Smartphone / tablet: Info+Druck | Heute on row 1; month+year full width on row 2 */
+@media (max-width: 900px) {
   .meld-cal-toolbar {
     grid-template-columns: auto 1fr;
     grid-template-areas:

--- a/js/app-nav.js
+++ b/js/app-nav.js
@@ -1,6 +1,6 @@
 (function () {
   function isNarrow() {
-    return window.matchMedia && window.matchMedia('(max-width: 600px)').matches;
+    return window.matchMedia && window.matchMedia('(max-width: 992px)').matches;
   }
 
   /** Close open admin accordion groups; on desktop keep the active-page section open. */

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -697,7 +697,7 @@ function renderPermissionGroupColorCss($wrapStyleTag = true) {
         $css .= '.perm-matrix td.perm-group--'.$id.'.perm-on{background:'.$strong.';}';
     }
 
-    $css .= '@media (max-width:600px){';
+    $css .= '@media (max-width:992px){';
     foreach($palettes as $id => $tone) {
         $accent = $tone['accent'];
         $css .= '.app-nav>.app-nav-primary>.app-nav-item.admin-nav-perm--'.$id

--- a/mail.php
+++ b/mail.php
@@ -418,7 +418,7 @@ window.syncDiscordDefault = function() {};
   <script src="js/tinymce/tinymce.min.js?<?php echo isset($GLOBALS['version']['Hash']) ? htmlspecialchars($GLOBALS['version']['Hash'], ENT_QUOTES, 'UTF-8') : '0'; ?>-<?php echo @filemtime(__DIR__.'/js/tinymce/tinymce.min.js'); ?>"></script>
   <script>
   (function() {
-    var isNarrow = window.matchMedia && window.matchMedia('(max-width: 600px)').matches;
+    var isNarrow = window.matchMedia && window.matchMedia('(max-width: 900px)').matches;
     tinymce.init({
     selector: '#mail-body',
     license_key: 'gpl',

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2,7 +2,7 @@
   color: #111;
 }
 
-/* —— App navigation (MELD-139): sidebar ≥601px, bottom bar ≤600px —— */
+/* —— App navigation (MELD-173): sidebar ≥993px, bottom bar ≤992px (tablet+phone) —— */
 html {
   height: 100%;
 }
@@ -91,7 +91,7 @@ a.app-titlebar-logo {
   text-align: left;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 992px) {
   .app-titlebar {
     padding-right: 4rem;
   }
@@ -479,7 +479,7 @@ a.app-titlebar-logo {
   background: #fff;
 }
 
-@media (min-width: 601px) {
+@media (min-width: 993px) {
   .app-nav {
     width: 15rem;
     align-self: stretch;
@@ -503,7 +503,7 @@ a.app-titlebar-logo {
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 992px) {
   .app-shell {
     flex-direction: column;
   }
@@ -917,7 +917,7 @@ a.app-titlebar-logo {
   padding: 0.65rem 0.85rem;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   .updater-actions form {
     flex: 1 1 100%;
   }
@@ -1143,8 +1143,8 @@ a.app-titlebar-logo {
 }
 
 /* w3.css opens ALL nested .w3-dropdown-content on ancestor hover — reset that.
-   Desktop (MELD-139): Akkordeon nach unten in der Sidebar, nicht als Flyout über dem Content. */
-@media (min-width: 601px) {
+   Desktop (MELD-139/173): Akkordeon nach unten in der Sidebar, nicht als Flyout über dem Content. */
+@media (min-width: 993px) {
   .admin-nav:hover .admin-nav-group > .w3-dropdown-content,
   .admin-nav .admin-nav-group:hover > .w3-dropdown-content {
     display: none;
@@ -1182,7 +1182,7 @@ a.app-titlebar-logo {
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 992px) {
   .admin-nav:hover .admin-nav-group > .w3-dropdown-content {
     display: none;
   }
@@ -1237,7 +1237,7 @@ a.app-titlebar-logo {
   filter: brightness(0.96);
 }
 
-@media (max-width: 600px) {
+@media (max-width: 992px) {
   .app-nav > .app-nav-primary > .app-nav-item.admin-nav-perm,
   .app-nav > .app-nav-primary > .app-nav-form > .app-nav-item.admin-nav-perm,
   .app-nav > .app-nav-more-wrap > .app-nav-more-toggle.admin-nav-perm {
@@ -1270,7 +1270,7 @@ a.app-titlebar-logo {
   white-space: nowrap;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 992px) {
   /* Admin accordion inside Mehr-Sheet */
   .admin-nav .admin-nav-group > .w3-dropdown-content {
     position: static !important;
@@ -1317,7 +1317,7 @@ a.app-titlebar-logo {
   display: none !important;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   .list-row {
     display: block;
     float: none !important;
@@ -1497,7 +1497,7 @@ a.app-titlebar-logo {
   margin: 0;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   .mail-list {
     display: flex;
     flex-direction: column;
@@ -4001,6 +4001,12 @@ body.meld-cal-print {
 
 @media (min-width: 720px) {
   .profile-grid--3 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1100px) {
+  .profile-grid--3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
@@ -4219,7 +4225,7 @@ select.profile-control {
   padding: 0 0 0.85rem 1.1em;
 }
 
-@media (max-width: 719px) {
+@media (max-width: 992px) {
   .profile-prefs--grid {
     grid-template-columns: 1fr;
   }
@@ -4678,7 +4684,7 @@ select.profile-control {
   text-decoration: underline;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   /* Body bleibt rechts vom Strich (nicht margin-left: 0) */
   .melde-response-row .melde-actions {
     grid-column: 1 / -1;
@@ -4698,7 +4704,7 @@ select.profile-control {
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   .melde-row {
     --melde-pad-x: 0.75rem;
     --melde-date-col-w: max-content;
@@ -5033,7 +5039,7 @@ select.profile-control {
   margin-right: 0.25rem;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   .inv-sort-bar {
     flex-direction: column;
     align-items: stretch;
@@ -5198,7 +5204,7 @@ select.profile-control {
   font-style: normal;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   .log-row {
     --log-id-col-w: max-content;
     --log-row-pad-y: 0.25rem;
@@ -5423,7 +5429,7 @@ select.profile-control {
   color: #fff;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   .user-row {
     --user-id-col-w: 8.5rem;
     --user-row-pad-y: 0.75rem;

--- a/views/calendar/month.php
+++ b/views/calendar/month.php
@@ -33,7 +33,7 @@ $gridEnd = DateTimeImmutable::createFromFormat('Y-m-d', $bounds['gridEnd']);
 .meld-cal-events { max-height: 6.5rem; overflow-y: auto; }
 .meld-cal-cell--create { cursor: pointer; }
 .meld-cal-cell--create:hover { filter-color: #345A95; }
-@media (max-width: 600px) {
+@media (max-width: 900px) {
   .meld-cal-cell { min-height: 4.2rem; padding: 2px; }
   .meld-cal-chip { font-size: 0.6em; padding: 1px 2px; }
   .meld-cal-head { font-size: 0.75em; }

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -30,7 +30,7 @@ $sections[] = array(
     'title' => 'Einführung',
     'body' => '
 <p>Die Meldeliste ist die zentrale Plattform für Termine, Rückmeldungen und (je nach Rechten) Verwaltung im Verein.</p>
-<p>Über die Navigation erreichst du die Bereiche, die für dich freigeschaltet sind: auf breiten Bildschirmen links mit Text, auf dem Smartphone unten als Leiste (weitere Einträge und Admin unter <b>Mehr</b>). Diese Hilfe zeigt nur Abschnitte, die zu deinen aktuellen Rechten passen.</p>
+<p>Über die Navigation erreichst du die Bereiche, die für dich freigeschaltet sind: auf dem Desktop links mit Text, auf Tablet und Smartphone unten als Leiste (weitere Einträge und Admin unter <b>Mehr</b>). Diese Hilfe zeigt nur Abschnitte, die zu deinen aktuellen Rechten passen.</p>
 <p>Bitte melde dich möglichst vollständig zu Terminen an (ja / nein / vielleicht) – das erleichtert die Planung enorm.</p>
 '
 );
@@ -39,18 +39,18 @@ $sections[] = array(
     'id' => 'navigation',
     'title' => 'Navigation',
     'body' => '
-<p>Auf dem Desktop steht die Navigation links (Icons mit Beschriftung). Auf dem Smartphone unten; unter <b>Mehr</b> findest du weitere Einträge (u.&nbsp;a. Mein Profil), Admin und Ausloggen.</p>
+<p>Auf dem Desktop steht die Navigation links (Icons mit Beschriftung). Auf Tablet und Smartphone unten; unter <b>Mehr</b> findest du weitere Einträge (u.&nbsp;a. Mein Profil), Admin und Ausloggen.</p>
 <ul class="help-list">
 <li><i class="far fa-calendar-alt"></i> <b>Termine</b> – bevorstehende Termine und schnelles Melden</li>
 <li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details); Info-Button für Abo-Link, Drucken für alle kommenden Termine als Tabelle</li>
 <li><i class="fas fa-envelope"></i> <b>Meine Nachrichten</b> – empfangene Mails aus der Meldeliste (Badge bei ungelesenen)</li>
-<li><i class="fas fa-users"></i> <b>Mein Register</b> – Rückmeldungen deines Registers (auf dem Smartphone dauerhaft in der unteren Leiste)</li>
+<li><i class="fas fa-users"></i> <b>Mein Register</b> – Rückmeldungen deines Registers (auf Tablet/Smartphone dauerhaft in der unteren Leiste)</li>
 '.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir gehörendes oder an dich ausgeliehenes Inventar</li>' : '').'
-<li><i class="fas fa-user"></i> <b>Mein Profil</b> – eigene Stammdaten und Einstellungen (Desktop in der Seitenleiste, Smartphone unter <b>Mehr</b>)</li>
+<li><i class="fas fa-user"></i> <b>Mein Profil</b> – eigene Stammdaten und Einstellungen (Desktop in der Seitenleiste, Tablet/Smartphone unter <b>Mehr</b>)</li>
 <li><i class="fas fa-photo-film"></i> <b>Medien</b> – Links zu Aufnahmen und Social Media (konfigurierbar)</li>
 <li>Logo oben rechts – öffnet die <b>Vereinshomepage</b> in einem neuen Tab</li>
 <li><i class="fas fa-circle-question"></i> <b>Hilfe</b> – diese Seite inkl. Changelog</li>
-'.(isAdmin() ? '<li><i class="fas fa-wrench"></i> <b>Admin</b> – Verwaltungsmenü in der Reihenfolge Personen → Termine → Meldungen → Kommunikation → Inventar → Register → System; Einträge sind in denselben Farben wie die Rechte-Chips eingefärbt (Desktop links unten, mobil unter Mehr)</li>' : '').'
+'.(isAdmin() ? '<li><i class="fas fa-wrench"></i> <b>Admin</b> – Verwaltungsmenü in der Reihenfolge Personen → Termine → Meldungen → Kommunikation → Inventar → Register → System; Einträge sind in denselben Farben wie die Rechte-Chips eingefärbt (Desktop links unten, Tablet/Smartphone unter Mehr)</li>' : '').'
 <li><i class="fas fa-sign-out-alt"></i> <b>Ausloggen</b> – Sitzung beenden</li>
 </ul>
 '


### PR DESCRIPTION
## Summary
- Bottom nav for tablet+phone (≤992px); left sidebar only on desktop (≥993px)
- Dense list/calendar/profile breakpoints raised so medium widths no longer crush/overlap
- Help text updated; regression tests in meldeliste-tests

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-173

## Test plan
- [ ] iPad/tablet portrait (~768px): bottom nav, no sidebar; Termine/Kalender/Listen ohne Überlappung
- [ ] Tablet landscape / ~900px: Kalender-Toolbar stapelt; Meldezeilen/Mails als Kartenlayout
- [ ] Desktop ≥993px: linke Nav mit Labels unverändert
- [ ] Hero-Aktionen und Profil-Grid auf Tablet ohne Überlappung