### PR TITLE
MELD-180: ICS-Download als GET-Link für Android WebView

### DIFF
--- a/download-ics.php
+++ b/download-ics.php
@@ -9,20 +9,35 @@ if(!loggedIn()) {
     die('forbidden');
 }
 
-if(!isset($_POST['appID'])) {
+$appId = 0;
+if(isset($_GET['appID'])) {
+    $appId = (int)$_GET['appID'];
+} elseif(isset($_POST['appID'])) {
+    // Legacy POST forms (pre-MELD-180)
+    $appId = (int)$_POST['appID'];
+}
+
+if($appId <= 0) {
     http_response_code(400);
     die('Error: Appointment not found.');
 }
 
 $n = new Termin;
-$n->load_by_id($_POST['appID']);
+$n->load_by_id($appId);
 if(!(int)$n->Index) {
     http_response_code(404);
     die('Error: Appointment not found.');
 }
 
+$rawName = preg_replace('/[^\w.\-]+/u', '_', (string)$n->Name);
+if($rawName === null || $rawName === '') {
+    $rawName = 'termin';
+}
+$filename = preg_replace('/[^\w.\-]+/u', '_', (string)$n->Datum).'_'.$rawName.'.ics';
+
 header('Content-Type: text/calendar; charset=utf-8');
-header('Content-Disposition: attachment; filename='.$n->Datum."_".$n->Name.'.ics');
+header('Content-Disposition: attachment; filename="'.$filename.'"');
+header('X-Content-Type-Options: nosniff');
 
 date_default_timezone_set('Europe/Berlin');
 if($n->EndDatum) {

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -1750,11 +1750,10 @@ class Termin
 
         $str .= '<div class="melde-actions" data-melde-stop>';
         if(!empty($GLOBALS['optionsDB']['showAddToCalendarButton'])) {
-            $str .= '<form id="icalform'.$tid.'" method="post" action="download-ics.php" class="melde-ical">';
-            $str .= '<input type="hidden" name="appID" value="'.$tid.'">';
-            $str .= '<button type="submit" class="melde-ical-btn" title="In Kalender" aria-label="In Kalender eintragen">'
-                .'<i class="fa fa-calendar-plus" aria-hidden="true"></i></button>';
-            $str .= '</form>';
+            // GET link so Android WebView can intercept/download (MELD-180); POST still accepted server-side
+            $str .= '<a id="icalform'.$tid.'" class="melde-ical melde-ical-btn" href="download-ics.php?appID='.$tid.'"'
+                .' title="In Kalender" aria-label="In Kalender eintragen" download>'
+                .'<i class="fa fa-calendar-plus" aria-hidden="true"></i></a>';
         }
 
         $str .= $this->makeListMetaHtml($user);


### PR DESCRIPTION
## Summary
- Einzeltermin-ICS als GET-Link (`download-ics.php?appID=`), damit die Android-App den Download abfangen kann
- POST bleibt serverseitig kompatibel; Content-Disposition mit sicherem Dateinamen
- Begleitend: MVDApp DownloadListener (separates Repo)

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-180

## Test plan
- [ ] Browser: ICS-Button lädt `.ics` herunter
- [ ] Android App (nach App-Update): ICS-Button startet DownloadManager-Benachrichtigung
- [x] `composer test -- --filter DownloadIcsTest`