### PR TITLE
MELD-165: Live-Log in Chunks statt einzeln nachladen

### DIFF
--- a/config/ConfigDefaults.php
+++ b/config/ConfigDefaults.php
@@ -585,7 +585,7 @@ function getConfigDefaults() {
             'Parameter' => 'logListChunkSize',
             'Value' => '100',
             'Type' => 'int',
-            'Description' => 'Log-Liste: Einträge pro AJAX-Nachladen (1–500)',
+            'Description' => 'Log-Liste / Live-Poll: Einträge pro Nachladen (1–500)',
         ),
         array(
             'Parameter' => 'SchemaVersion',

--- a/getLog.php
+++ b/getLog.php
@@ -24,5 +24,8 @@ if($topTimestamp === null) {
     $topTimestamp = '';
 }
 
-echo logPollNextHtml((int)$maxIndex, (string)$topTimestamp);
+$limit = meldeRequest('limit');
+$limit = ($limit !== null && is_numeric($limit)) ? (int)$limit : 0;
+
+echo logPollNextHtml((int)$maxIndex, (string)$topTimestamp, $limit);
 ?>

--- a/libs/log.php
+++ b/libs/log.php
@@ -247,34 +247,47 @@ class Log
 };
 
 /**
- * Live-Poll HTML for the log page (MELD-160).
- * Returns a new row when Index > $maxIndex, or the same row when its Timestamp
- * was bumped by Log dedupe (identical Message+User → UPDATE Timestamp only).
+ * Live-Poll HTML for the log page (MELD-160 / MELD-165).
+ * Returns newer rows (Index > $maxIndex) in batches of up to logListChunkSize
+ * (newest first), or the same top row when its Timestamp was bumped by Log
+ * dedupe (identical Message+User → UPDATE Timestamp only).
  *
- * @return string HTML of one log row, or empty string
+ * @param int $limit 0 = configured logListChunkSize (clamped via listChunkLogLimit)
+ * @return string HTML of one or more log rows, or empty string
  */
-function logPollNextHtml($maxIndex, $topTimestamp = '') {
+function logPollNextHtml($maxIndex, $topTimestamp = '', $limit = 0) {
     $maxIndex = (int)$maxIndex;
     if($maxIndex < 1) {
         return '';
     }
+    $limit = listChunkLogLimit($limit);
     $sql = sprintf(
-        'SELECT `Index` FROM `%sLog` WHERE `Index` > %d ORDER BY `Timestamp` ASC LIMIT 1;',
+        'SELECT `Index` FROM `%sLog` WHERE `Index` > %d ORDER BY `Index` ASC LIMIT %d;',
         $GLOBALS['dbprefix'],
-        $maxIndex
+        $maxIndex,
+        $limit
     );
     $dbr = mysqli_query($GLOBALS['conn'], $sql);
     sqlerror();
-    if($dbr && ($row = mysqli_fetch_array($dbr))) {
-        $M = new Log;
-        $M->load_by_id((int)$row['Index']);
-        if($M->Index > 0) {
-            ob_start();
-            $M->printTableLine();
-            $html = ob_get_clean();
-            return $html === false ? '' : $html;
+    $ids = array();
+    if($dbr) {
+        while($row = mysqli_fetch_array($dbr)) {
+            $ids[] = (int)$row['Index'];
         }
-        return '';
+    }
+    if(count($ids) > 0) {
+        // Newest first so the client can prepend the fragment as-is
+        $ids = array_reverse($ids);
+        ob_start();
+        foreach($ids as $id) {
+            $M = new Log;
+            $M->load_by_id($id);
+            if($M->Index > 0) {
+                $M->printTableLine();
+            }
+        }
+        $html = ob_get_clean();
+        return $html === false ? '' : $html;
     }
 
     $topTimestamp = trim((string)$topTimestamp);

--- a/log.php
+++ b/log.php
@@ -52,10 +52,18 @@ function getLogTopTimestamp() {
     return top.getAttribute('data-timestamp') || '';
 }
 
+function getLogPollLimit() {
+    var sentinel = document.getElementById("listSentinel");
+    if(!sentinel) return 0;
+    var n = parseInt(sentinel.getAttribute("data-limit") || "0", 10);
+    return n > 0 ? n : 0;
+}
+
 function getLog() {
     var maxIndex = getLogMaxIndex();
     if(!(maxIndex > 0)) return;
     var topTimestamp = getLogTopTimestamp();
+    var limit = getLogPollLimit();
 
     var xmlhttp;
     if (window.XMLHttpRequest) {
@@ -69,22 +77,36 @@ function getLog() {
             var parent = document.getElementById("Liste");
             if(!parent) return;
             var doc = new DOMParser().parseFromString(xmlhttp.responseText, 'text/html');
-            var div = doc.body.firstElementChild;
-            if(!div || !div.id) return;
-            var existing = document.getElementById(div.id);
-            if(existing) {
-                // Deduped log: same Index, newer Timestamp — refresh in place (MELD-160)
-                existing.parentNode.replaceChild(div, existing);
+            var nodes = [];
+            for(var c = doc.body.firstElementChild; c; c = c.nextElementSibling) {
+                if(c.id) nodes.push(c);
             }
-            else {
+            if(!nodes.length) return;
+
+            var frag = document.createDocumentFragment();
+            var hasNew = false;
+            for(var i = 0; i < nodes.length; i++) {
+                var div = nodes[i];
+                var existing = document.getElementById(div.id);
+                if(existing) {
+                    // Deduped log: same Index, newer Timestamp — refresh in place (MELD-160)
+                    existing.parentNode.replaceChild(div, existing);
+                }
+                else {
+                    frag.appendChild(div);
+                    hasNew = true;
+                }
+            }
+            if(hasNew) {
+                // MELD-165: batch prepend (HTML is newest-first)
                 var first = parent.querySelector(":scope > div[id]:not(#listSentinel)");
                 if(first) {
-                    parent.insertBefore(div, first);
+                    parent.insertBefore(frag, first);
                 }
                 else {
                     var sentinel = document.getElementById("listSentinel");
-                    if(sentinel) parent.insertBefore(div, sentinel);
-                    else parent.appendChild(div);
+                    if(sentinel) parent.insertBefore(frag, sentinel);
+                    else parent.appendChild(frag);
                 }
             }
             // MELD-164: live prepend/refresh must respect active filter
@@ -95,7 +117,8 @@ function getLog() {
 	}
     }
     var body = "maxIndex="+encodeURIComponent(maxIndex)
-        +"&topTimestamp="+encodeURIComponent(topTimestamp);
+        +"&topTimestamp="+encodeURIComponent(topTimestamp)
+        +"&limit="+encodeURIComponent(limit);
     xmlhttp.open("POST", "getLog.php", true);
     xmlhttp.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
     xmlhttp.send(body);

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -263,7 +263,7 @@ $sections[] = array(
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Statistik</b> – Auswertungen; auf breiten Bildschirmen Diagramme und Tabellen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>). Ranking und Inaktive teilen sich denselben Chip-Filter wie die Personenliste (Aktive/Gäste/Mitglieder, Register, Gruppen)</li>
-<li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung); Chunk-Größe über <code>logListChunkSize</code> in der Konfiguration</li>
+<li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung); Chunk-Größe für Scroll und Live-Nachladen über <code>logListChunkSize</code></li>
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '
 <li><b>Backup</b> – Datenbank-ZIP herunterladen (inkl. Versionsinfo) oder wieder einspielen; im Browser über <code>Backup</code>, per CLI mit <code>php cron.php CRONID backup</code>; automatisiert remote nur mit eigenem <code>$backupToken</code> in <code>config.php</code> (mind. 32 Zeichen) über <code>cron.php?id=…&amp;cmd=backup</code> — nicht mit dem allgemeinen Cron-ID. Erfolgreiche Downloads erscheinen im <b>Log</b> als Info, fehlgeschlagene als Fehler</li>


### PR DESCRIPTION
## Summary
- Live-Log lädt neue Einträge in Chunks statt einzeln nach (`getLog`/Polling).
- Konfigurierbare Chunk-Größe über ConfigDefaults; Hilfe-Text angepasst.
- Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-165

## Test plan
- [ ] Live-Log öffnen und prüfen, dass neue Einträge in Batches erscheinen
- [ ] Polling ohne neue Einträge bleibt ruhig
- [ ] `meldeliste-tests`: LogPoll-Tests (Branch `MELD-165-Mehr-neue-Logs`) grün