### PR TITLE
MELD-168: Uhrzeiten ohne Sekunden in Log und Time-Inputs

### DIFF
--- a/config-menu.php
+++ b/config-menu.php
@@ -238,7 +238,9 @@ while($row = mysqli_fetch_array($dbr)) {
         echo "</div>\n";
         break;
     case 'time':
-        echo "<input class=\"w3-col l4 m4 s12 w3-center\" type=\"time\" name=\"".$row['Parameter']."\" value=\"".$row['Value']."\" />\n";
+        echo '<input class="w3-col l4 m4 s12 w3-center" type="time" step="60" name="'
+            .htmlspecialchars((string)$row['Parameter'], ENT_QUOTES, 'UTF-8')
+            .'" value="'.htmlspecialchars(sql2timeRaw($row['Value']), ENT_QUOTES, 'UTF-8').'" />'."\n";
         break;
     case 'int':
         echo "<input class=\"w3-col l4 m4 s12 w3-center\" type=\"number\" name=\"".$row['Parameter']."\" value=\"".$row['Value']."\" />\n";

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -1217,7 +1217,11 @@ function sql2time($time) {
 }
 
 function sql2timeRaw($time) {
-    return substr($time, 0, 5);
+    if($time === null || $time === '') {
+        return '';
+    }
+    // Log payloads and UI: HH:MM without seconds (MELD-168)
+    return substr((string)$time, 0, 5);
 }
 
 function sqlerror() {

--- a/libs/meldung.php
+++ b/libs/meldung.php
@@ -51,7 +51,7 @@ class Meldung
         $this->Termin,
         $t->Name,
         medDate($t->Datum),
-        $t->Uhrzeit,
+        sql2timeRaw($t->Uhrzeit),
         $u->getName()
         );
         if($this->Wert != $old->Wert) $str.=meldeSymbol($this->Wert)." (vorher:".meldeWert($old->Wert)."), ";
@@ -93,7 +93,7 @@ class Meldung
         $this->Termin,
         $t->Name,
         medDate($t->Datum),
-        $t->Uhrzeit,
+        sql2timeRaw($t->Uhrzeit),
         $u->getName(),
         $instr->Name
         );

--- a/libs/shiftmeldung.php
+++ b/libs/shiftmeldung.php
@@ -48,7 +48,7 @@ class Shiftmeldung
         $s->Index,
         $s->Name,
                        medDate($t->Datum),
-        $s->Start,
+        Shift::formatTimeLog($s->Start),
         $u->getName()
         );
 
@@ -70,7 +70,7 @@ class Shiftmeldung
         $s->Index,
         $s->Name,
         medDate($t->Datum),
-        $s->Start,
+        Shift::formatTimeLog($s->Start),
         $u->getName(),
         meldeSymbol($this->Wert)
         );

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -97,11 +97,11 @@ class Termin
         );
         if($this->Datum != $old->Datum) $str.=", Datum: ".$old->getDate()." &rArr; <b>".$this->getDate()."</b>";
         if($this->EndDatum != $old->EndDatum) $str.=", Enddatum: ".medDate($old->EndDatum)." &rArr; <b>".medDate($this->EndDatum)."</b>";
-        if($this->Uhrzeit != $old->Uhrzeit) $str.=", Uhrzeit: ".$old->Uhrzeit." &rArr; <b>".$this->Uhrzeit."</b>";
-        if($this->Uhrzeit2 != $old->Uhrzeit2) $str.=", Uhrzeit2: ".$old->Uhrzeit2." &rArr; <b>".$this->Uhrzeit2."</b>";
+        if($this->Uhrzeit != $old->Uhrzeit) $str.=", Uhrzeit: ".sql2timeRaw($old->Uhrzeit)." &rArr; <b>".sql2timeRaw($this->Uhrzeit)."</b>";
+        if($this->Uhrzeit2 != $old->Uhrzeit2) $str.=", Uhrzeit2: ".sql2timeRaw($old->Uhrzeit2)." &rArr; <b>".sql2timeRaw($this->Uhrzeit2)."</b>";
         if($this->Capacity != $old->Capacity) $str.=", Capacity: ".$old->Capacity." &rArr; <b>".$this->Capacity."</b>";
         if(!empty($GLOBALS['optionsDB']['showTravelTime']) && $this->Abfahrt != $old->Abfahrt) {
-            $str.=", Abfahrt: ".$old->Abfahrt." &rArr; <b>".$this->Abfahrt."</b>";
+            $str.=", Abfahrt: ".sql2timeRaw($old->Abfahrt)." &rArr; <b>".sql2timeRaw($this->Abfahrt)."</b>";
         }
         if(!empty($GLOBALS['optionsDB']['showVehicle']) && $this->Vehicle != $old->Vehicle) {
             $str.=", Vehicle: ".$old->Vehicle." &rArr; <b>".$this->Vehicle."</b>";
@@ -163,13 +163,13 @@ class Termin
             $parts[] = sprintf("Datum: <b>%s</b>", $dateStr);
         }
         if($this->Uhrzeit !== null && $this->Uhrzeit !== '') {
-            $parts[] = sprintf("Beginn: <b>%s</b>", $this->Uhrzeit);
+            $parts[] = sprintf("Beginn: <b>%s</b>", sql2timeRaw($this->Uhrzeit));
         }
         if($this->Uhrzeit2 !== null && $this->Uhrzeit2 !== '') {
-            $parts[] = sprintf("Ende: <b>%s</b>", $this->Uhrzeit2);
+            $parts[] = sprintf("Ende: <b>%s</b>", sql2timeRaw($this->Uhrzeit2));
         }
         if(!empty($GLOBALS['optionsDB']['showTravelTime']) && $this->Abfahrt !== null && $this->Abfahrt !== '') {
-            $parts[] = sprintf("Abfahrt: <b>%s</b>", $this->Abfahrt);
+            $parts[] = sprintf("Abfahrt: <b>%s</b>", sql2timeRaw($this->Abfahrt));
         }
         if(!empty($GLOBALS['optionsDB']['showVehicle']) && $this->vName !== null && $this->vName !== '') {
             $parts[] = sprintf("mit: <b>%s</b>", $this->vName);

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -1097,13 +1097,13 @@ class Termin
         $str .= '</td>';
         $str .= '<td data-label="Beginn">';
         $str .= '<div class="shift-edit-time-wrap">';
-        $str .= '<input id="shift-start-'.$h($key).'" class="w3-input w3-border profile-control '.$h($inputBg).'" name="'.$prefix.'[Start]" type="time"'.$startAttr.'>';
+        $str .= '<input id="shift-start-'.$h($key).'" class="w3-input w3-border profile-control '.$h($inputBg).'" name="'.$prefix.'[Start]" type="time" step="60"'.$startAttr.'>';
         $str .= '<button type="button" class="termin-form-clear shift-edit-clear" title="Beginn leeren" aria-label="Beginn leeren">&#10006;</button>';
         $str .= '</div>';
         $str .= '</td>';
         $str .= '<td data-label="Ende">';
         $str .= '<div class="shift-edit-time-wrap">';
-        $str .= '<input id="shift-end-'.$h($key).'" class="w3-input w3-border profile-control '.$h($inputBg).'" name="'.$prefix.'[End]" type="time"'.$endAttr.'>';
+        $str .= '<input id="shift-end-'.$h($key).'" class="w3-input w3-border profile-control '.$h($inputBg).'" name="'.$prefix.'[End]" type="time" step="60"'.$endAttr.'>';
         $str .= '<button type="button" class="termin-form-clear shift-edit-clear" title="Ende leeren" aria-label="Ende leeren">&#10006;</button>';
         $str .= '</div>';
         $str .= '</td>';

--- a/new-termin.php
+++ b/new-termin.php
@@ -131,11 +131,11 @@ if($fill && $n) {
       <div class="termin-field-pair">
         <div class="profile-field">
           <label class="profile-label" for="termin-uhrzeit">Beginn <b class="termin-form-clear" onclick="clearInput('Uhrzeit')" title="leeren">&#10006;</b></label>
-          <input id="termin-uhrzeit" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" name="Uhrzeit" type="time" <?php if($fill) echo 'value="'.htmlspecialchars((string)$n->Uhrzeit, ENT_QUOTES, 'UTF-8').'"'; ?>>
+          <input id="termin-uhrzeit" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" name="Uhrzeit" type="time" step="60" <?php if($fill) echo 'value="'.htmlspecialchars(sql2timeRaw($n->Uhrzeit), ENT_QUOTES, 'UTF-8').'"'; ?>>
         </div>
         <div class="profile-field">
           <label class="profile-label" for="termin-uhrzeit2">Ende <b class="termin-form-clear" onclick="clearInput('Uhrzeit2')" title="leeren">&#10006;</b></label>
-          <input id="termin-uhrzeit2" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" name="Uhrzeit2" type="time" <?php if($fill) echo 'value="'.htmlspecialchars((string)$n->Uhrzeit2, ENT_QUOTES, 'UTF-8').'"'; ?>>
+          <input id="termin-uhrzeit2" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" name="Uhrzeit2" type="time" step="60" <?php if($fill) echo 'value="'.htmlspecialchars(sql2timeRaw($n->Uhrzeit2), ENT_QUOTES, 'UTF-8').'"'; ?>>
         </div>
       </div>
 <?php if($GLOBALS['optionsDB']['showVehicle'] || $GLOBALS['optionsDB']['showTravelTime']) { ?>
@@ -157,7 +157,7 @@ if($fill && $n) {
 <?php if($GLOBALS['optionsDB']['showTravelTime']) { ?>
         <div class="profile-field">
           <label class="profile-label" for="termin-abfahrt">Abfahrt</label>
-          <input id="termin-abfahrt" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" name="Abfahrt" type="time" <?php if($fill) echo 'value="'.htmlspecialchars((string)$n->Abfahrt, ENT_QUOTES, 'UTF-8').'"'; ?>>
+          <input id="termin-abfahrt" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" name="Abfahrt" type="time" step="60" <?php if($fill) echo 'value="'.htmlspecialchars(sql2timeRaw($n->Abfahrt), ENT_QUOTES, 'UTF-8').'"'; ?>>
         </div>
 <?php } ?>
       </div>


### PR DESCRIPTION
## Summary
- Log-Payload formatiert Uhrzeiten ohne Sekunden (HH:MM).
- Time-Inputs nutzen `step=60` und speichern/anzeigen HH:MM statt HH:MM:SS.
- Regressionstests im Sibling-Repo `meldeliste-tests` (Branch `MELD-168-Uhrzeiten-Log`).

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-168

## Test plan
- [ ] Termin anlegen/bearbeiten: Uhrzeit-Felder ohne Sekunden, Speichern ok
- [ ] Log-Einträge zu Terminänderungen zeigen HH:MM ohne `:00`-Sekunden
- [ ] `cd ../meldeliste-tests && composer test` grün (MELD-168-Tests)