### PR TITLE
MELD-177: Inventarliste per Infinite Scroll nachladen

### DIFF
--- a/getList.php
+++ b/getList.php
@@ -109,6 +109,15 @@ case 'meineMails':
     $result = listChunkUserMails((int)$_SESSION['userid'], $cursor, $limit);
     break;
 
+case 'inventories':
+    if(!requirePermission('perm_showInventories')) {
+        http_response_code(403);
+        header('X-Has-More: 0');
+        exit;
+    }
+    $result = listChunkInventories($cursor !== '' ? (int)$cursor : 0, $limit, $sort, $dir);
+    break;
+
 default:
     http_response_code(400);
     header('X-Has-More: 0');

--- a/inventories.php
+++ b/inventories.php
@@ -23,6 +23,8 @@ if(requirePermission("perm_showInventories")) {
     sqlerror();
     $row = mysqli_fetch_array($dbr);
     $nInventories = $row['Count'];
+
+    $chunk = listChunkInventories(0, 50);
 ?>
 <?php
 $filterInsured = isset($_GET['versichert']) && (string)$_GET['versichert'] === '1';
@@ -55,27 +57,15 @@ adminListSearchField('Nach Inventar suchen…', array(
   </div>
 </div>
 <div id="Liste" class="inv-list">
-<?php
-    $sql = sprintf(
-        'SELECT `Index` FROM `%sInventories` INNER JOIN (SELECT `Index` AS `iIndex`, `Typ` AS `iTyp`, `Sortierung` AS `iSort` FROM `%sInventory`) `%sInventory` ON `Inventory` = `iIndex` ORDER BY `iSort`;',
-        $GLOBALS['dbprefix'],
-        $GLOBALS['dbprefix'],
-        $GLOBALS['dbprefix']
-    );
-    $dbr = mysqli_query($conn, $sql);
-    sqlerror();
-    while($row = mysqli_fetch_array($dbr)) {
-        $M = new Inventories;
-        $M->load_by_id($row['Index']);
-        echo $M->printTableLine();
-    }
-?>
+<?php echo $chunk['html']; ?>
+<?php echo listChunkRenderSentinel('inventories', $chunk['nextCursor'], $chunk['hasMore'], 'filterMusiker'); ?>
 </div>
 <?php adminListPageEnd(); ?>
 <script src="<?php echo assetUrl('js/filterInstruments.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/sortList.js'); ?>"></script>
+<script src="<?php echo assetUrl('js/infiniteScroll.js'); ?>"></script>
 <script>
-bindListSort({ headerId: 'listHeader', listId: 'Liste', mode: 'client' });
+bindListSort({ headerId: 'listHeader', listId: 'Liste', mode: 'server' });
 (function () {
   var chip = document.getElementById('filterInsured');
   if (chip) {

--- a/js/filterInstruments.js
+++ b/js/filterInstruments.js
@@ -51,6 +51,9 @@ function setInsuredFilter(on, updateUrl) {
         window.history.replaceState({}, "", url.pathname + url.search + url.hash);
     }
     filterMusiker();
+    if (typeof window.listInfiniteFilterChanged === "function") {
+        window.listInfiniteFilterChanged();
+    }
 }
 
 function toggleInsuredFilter() {

--- a/js/infiniteScroll.js
+++ b/js/infiniteScroll.js
@@ -32,7 +32,11 @@
 
     function filterActive() {
         var input = document.getElementById('filterString');
-        return !!(input && String(input.value).trim() !== '');
+        if(input && String(input.value).trim() !== '') return true;
+        // Inventory "Versichert" chip (MELD-177) — keep scanning while sparse
+        var insured = document.getElementById('filterInsured');
+        if(insured && insured.classList.contains('is-active')) return true;
+        return false;
     }
 
     function setBarVisible(visible) {
@@ -128,11 +132,27 @@
     function applyFilter(sentinel) {
         var filterFn = sentinel.getAttribute('data-filter-fn');
         if(!filterFn || typeof window[filterFn] !== 'function') return;
-        var input = document.getElementById('filterString');
-        if(input && input.value) {
-            window[filterFn]();
-        }
+        // Always re-run (text search and/or chips like Versichert)
+        window[filterFn]();
     }
+
+    function onClientFilterChanged() {
+        pausedByUser = false;
+        var sentinel = getSentinel();
+        if(!sentinel || sentinel.getAttribute('data-has-more') !== '1') return;
+        if(!filterActive()) {
+            setStatus('', false);
+            reobserveSoon();
+            return;
+        }
+        setStatus(MSG_FILTER_SCAN, true, {
+            label: 'Stoppen',
+            onClick: pauseByUser
+        });
+        chainFilterLoadSoon();
+    }
+
+    window.listInfiniteFilterChanged = onClientFilterChanged;
 
     function isRowVisible(el) {
         if(!el || el.nodeType !== 1) return false;
@@ -340,21 +360,7 @@
         var input = document.getElementById('filterString');
         if(!input || input.getAttribute('data-infinite-bound') === '1') return;
         input.setAttribute('data-infinite-bound', '1');
-        input.addEventListener('input', function() {
-            pausedByUser = false;
-            var sentinel = getSentinel();
-            if(!sentinel || sentinel.getAttribute('data-has-more') !== '1') return;
-            if(!filterActive()) {
-                setStatus('', false);
-                reobserveSoon();
-                return;
-            }
-            setStatus(MSG_FILTER_SCAN, true, {
-                label: 'Stoppen',
-                onClick: pauseByUser
-            });
-            chainFilterLoadSoon();
-        });
+        input.addEventListener('input', onClientFilterChanged);
     }
 
     function init() {

--- a/libs/listChunk.php
+++ b/libs/listChunk.php
@@ -420,6 +420,140 @@ function listChunkUsers($kind, $offset, $limit, $sort = '', $dir = 'asc') {
 }
 
 /**
+ * Admin inventory list chunks (MELD-177).
+ * Cursor = OFFSET; default order matches inventories.php (Inventory.Sortierung).
+ *
+ * @param int    $offset
+ * @param int    $limit
+ * @param string $sort regnumber|typ|vendor|model|description|comment|purchasedate|purchaseprize|loan|owner|''
+ * @param string $dir  asc|desc
+ * @return array{html:string,nextCursor:string,hasMore:bool}
+ */
+function listChunkInventories($offset, $limit, $sort = '', $dir = 'asc') {
+    $limit = listChunkLimit($limit);
+    $offset = max(0, (int)$offset);
+    $dirSql = (strtolower((string)$dir) === 'desc') ? 'DESC' : 'ASC';
+    $sort = strtolower(trim((string)$sort));
+    $p = $GLOBALS['dbprefix'];
+
+    $activeLoanCond = "(`EndDate` IS NULL OR `EndDate` = '' OR `EndDate` = '0000-00-00' OR `EndDate` > CURDATE())";
+    $loanJoin = sprintf(
+        'LEFT JOIN (
+            SELECT l.`Inventory` AS `loanInvId`,
+                   CONCAT(COALESCE(u.`Vorname`, \'\'), \' \', COALESCE(u.`Nachname`, \'\')) AS `loanName`
+            FROM `%sInventoriesLoan` l
+            INNER JOIN `%sUser` u ON u.`Index` = l.`User`
+            INNER JOIN (
+                SELECT `Inventory`, MAX(`Index`) AS `maxLoan`
+                FROM `%sInventoriesLoan`
+                WHERE %s
+                GROUP BY `Inventory`
+            ) latest ON latest.`maxLoan` = l.`Index`
+        ) `loan` ON `loan`.`loanInvId` = `%sInventories`.`Index`',
+        $p,
+        $p,
+        $p,
+        $activeLoanCond,
+        $p
+    );
+    $ownerJoin = sprintf(
+        'LEFT JOIN `%sUser` `owner` ON `owner`.`Index` = `%sInventories`.`Owner`',
+        $p,
+        $p
+    );
+    $typExpr = 'COALESCE(NULLIF(`instName`, \'\'), `iTyp`)';
+
+    $needLoan = ($sort === 'loan');
+    $needOwner = ($sort === 'owner');
+
+    switch($sort) {
+    case 'regnumber':
+        $orderBy = '`RegNumber` '.$dirSql.', `%sInventories`.`Index` ASC';
+        break;
+    case 'typ':
+        $orderBy = $typExpr.' '.$dirSql.', `RegNumber` ASC, `%sInventories`.`Index` ASC';
+        break;
+    case 'vendor':
+        $orderBy = '`Vendor` '.$dirSql.', `RegNumber` ASC, `%sInventories`.`Index` ASC';
+        break;
+    case 'model':
+        $orderBy = '`Model` '.$dirSql.', `RegNumber` ASC, `%sInventories`.`Index` ASC';
+        break;
+    case 'description':
+        $orderBy = '`Description` '.$dirSql.', `RegNumber` ASC, `%sInventories`.`Index` ASC';
+        break;
+    case 'comment':
+        $orderBy = '`Comment` '.$dirSql.', `RegNumber` ASC, `%sInventories`.`Index` ASC';
+        break;
+    case 'purchasedate':
+        $orderBy = '`PurchaseDate` '.$dirSql.', `RegNumber` ASC, `%sInventories`.`Index` ASC';
+        break;
+    case 'purchaseprize':
+        $orderBy = '`PurchasePrize` '.$dirSql.', `RegNumber` ASC, `%sInventories`.`Index` ASC';
+        break;
+    case 'loan':
+        $orderBy = '`loanName` '.$dirSql.', `RegNumber` ASC, `%sInventories`.`Index` ASC';
+        break;
+    case 'owner':
+        $orderBy = 'CONCAT(COALESCE(`owner`.`Vorname`, \'\'), \' \', COALESCE(`owner`.`Nachname`, \'\')) '.$dirSql
+            .', `RegNumber` ASC, `%sInventories`.`Index` ASC';
+        break;
+    default:
+        $orderBy = '`iSort` ASC, `RegNumber` ASC, `%sInventories`.`Index` ASC';
+        break;
+    }
+    $orderBy = sprintf($orderBy, $p);
+
+    $sql = sprintf(
+        'SELECT `%sInventories`.`Index` FROM `%sInventories`
+         INNER JOIN (SELECT `Index` AS `iIndex`, `Typ` AS `iTyp`, `Sortierung` AS `iSort` FROM `%sInventory`) `%sInventory`
+           ON `Inventory` = `iIndex`
+         LEFT JOIN (SELECT `Index` AS `instIndex`, `Name` AS `instName` FROM `%sInstrument`) `%sInstrument`
+           ON `Instrument` = `instIndex`
+         %s
+         %s
+         ORDER BY %s
+         LIMIT %d OFFSET %d;',
+        $p,
+        $p,
+        $p,
+        $p,
+        $p,
+        $p,
+        $needLoan ? $loanJoin : '',
+        $needOwner ? $ownerJoin : '',
+        $orderBy,
+        $limit + 1,
+        $offset
+    );
+
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    $ids = array();
+    if($dbr) {
+        while($row = mysqli_fetch_array($dbr)) {
+            $ids[] = (int)$row['Index'];
+        }
+    }
+    $hasMore = count($ids) > $limit;
+    if($hasMore) {
+        $ids = array_slice($ids, 0, $limit);
+    }
+    $html = '';
+    foreach($ids as $id) {
+        $M = new Inventories;
+        $M->load_by_id($id);
+        $html .= $M->printTableLine();
+    }
+    $nextOffset = $offset + count($ids);
+    return array(
+        'html' => $html,
+        'nextCursor' => (string)$nextOffset,
+        'hasMore' => $hasMore,
+    );
+}
+
+/**
  * Compact Created/list timestamps for mail list meta (short weekday + date).
  */
 function mailListFormatDate($raw) {

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -224,7 +224,7 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 '.(requirePermission('perm_showInventories') ? '
-<li><b>Inventar</b> – Vereinsbesitz (Bestände, Details und Ausleihen); Sortier-Chips und Suche filtern die Liste; Chip <b>Versichert</b> zeigt nur versicherte Stücke; „Übersicht für Versicherung“ öffnet eine druck-/PDF-fähige Tabelle (Spalten per Checkbox wählen, dann kopieren oder als PDF speichern)</li>
+<li><b>Inventar</b> – Vereinsbesitz (Bestände, Details und Ausleihen); die Liste lädt beim Scrollen nach, Sortier-Chips sortieren serverseitig, Suche und Chip <b>Versichert</b> filtern die bereits geladenen Einträge (bei aktiver Filterung wird weiter nachgeladen); Klick öffnet Details im Modal; „Übersicht für Versicherung“ öffnet eine druck-/PDF-fähige Tabelle (Spalten per Checkbox wählen, dann kopieren oder als PDF speichern)</li>
 ' : '').'
 '.(requirePermission('perm_editInventories') ? '
 <li><b>Inventar anlegen</b> – neue Stücke über die eigene Seite (Plus in der Inventarliste oder Admin → Inventar anlegen)</li>


### PR DESCRIPTION
## Summary
- Inventarliste lädt Chunks per Infinite Scroll nach (Filter/Suche bleiben konsistent).
- Hilfe-Guide und Listen-Chunk-Logik angepasst.

## Test plan
- [ ] Inventarliste öffnen und nach unten scrollen — weitere Einträge laden
- [ ] Filter/Suche setzen und prüfen, dass nur passende Chunks nachgeladen werden
- [ ] PHPUnit in meldeliste-tests (`MELD-177` Inventar-Listenchunks)

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-177