### PR TITLE
MELD-185: Inventar-Sortierung Ausleihe ohne SQL-Fehler

### DIFF
--- a/libs/listChunk.php
+++ b/libs/listChunk.php
@@ -434,16 +434,16 @@ function listChunkInventories($offset, $limit, $sort = '', $dir = 'asc') {
     $sort = strtolower(trim((string)$sort));
     $p = $GLOBALS['dbprefix'];
 
-    $activeLoanCond = "(`EndDate` IS NULL OR `EndDate` = '' OR `EndDate` = '0000-00-00' OR `EndDate` > CURDATE())";
+    $activeLoanCond = '(`EndDate` IS NULL OR `EndDate` > CURDATE())';
     $loanJoin = sprintf(
         'LEFT JOIN (
             SELECT l.`Inventory` AS `loanInvId`,
                    CONCAT(COALESCE(u.`Vorname`, \'\'), \' \', COALESCE(u.`Nachname`, \'\')) AS `loanName`
-            FROM `%sInventoriesLoan` l
+            FROM `%sInventoriesLoans` l
             INNER JOIN `%sUser` u ON u.`Index` = l.`User`
             INNER JOIN (
                 SELECT `Inventory`, MAX(`Index`) AS `maxLoan`
-                FROM `%sInventoriesLoan`
+                FROM `%sInventoriesLoans`
                 WHERE %s
                 GROUP BY `Inventory`
             ) latest ON latest.`maxLoan` = l.`Index`


### PR DESCRIPTION
## Summary
- Chip **Ausleihe** in der Inventarliste joinet wieder `InventoriesLoans` (nicht `InventoriesLoan`)
- Offene Leihe ohne `EndDate = ''` (DATE-Vergleich war der 500er: „Laden fehlgeschlagen“)
- Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-185

## Test plan
- [ ] Inventar → Chip **Ausleihe**: Liste lädt, Sortierung nach Leihnehmer
- [ ] Chip erneut: Richtung wechselt, kein leeres Ergebnis
- [ ] PHPUnit `ListChunkInventoriesTest::testListChunkInventoriesSortByLoan`