### PR TITLE
gitignore: nested Uploads (Leih-PDFs) lokal halten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 common/config.php
-uploads/*
+# Nested uploads (loan scans, …) stay local; only keep dir placeholders + htaccess.
+uploads/**
 !uploads/README
 !uploads/.htaccess
 !uploads/loans/


### PR DESCRIPTION
## Summary
- `uploads/*` ignoriert nur eine Ebene; `!uploads/loans/` hat nested Leih-PDFs wieder unignored.
- Wechsel auf `uploads/**`, Platzhalter (`README`, `.htaccess`, `uploads/loans/.htaccess`) bleiben getrackt.

## Test plan
- [ ] `git status` zeigt keine Dateien unter `uploads/loans/*.pdf`
- [ ] `uploads/loans/.htaccess` bleibt getrackt