### PR TITLE
MELD-187: native alert/confirm durch App-Modals ersetzen

### DIFF
--- a/backup.php
+++ b/backup.php
@@ -104,7 +104,7 @@ adminListPageBegin('System', 'Backup & Restore', array('permKey' => 'perm_editCo
   <div class="w3-card w3-padding w3-margin-bottom w3-pale-red">
     <h3>Restore (destruktiv)</h3>
     <p><b>Achtung:</b> Überschreibt die Datenbanktabellen mit dem Prefix. Vorher ein aktuelles Backup ziehen.</p>
-    <form method="post" enctype="multipart/form-data" action="backup.php" onsubmit="return confirm('Wirklich Restore ausführen? Die aktuelle Datenbank wird überschrieben.');">
+    <form method="post" enctype="multipart/form-data" action="backup.php" data-confirm="Wirklich Restore ausführen? Die aktuelle Datenbank wird überschrieben." data-confirm-ok="Restore">
       <?php echo csrf_field(); ?>
       <input type="hidden" name="restore_confirm" value="1">
       <label>Backup-ZIP</label>

--- a/common/footer.php
+++ b/common/footer.php
@@ -16,8 +16,33 @@ if(!empty($GLOBALS['mlDeferredToasts'])) {
 <div id="ajaxModalHost" class="w3-modal" onclick="if(event.target===this)closeModal();">
   <div id="ajaxModalContent" class="w3-modal-content"></div>
 </div>
+<div id="appConfirmModal" class="w3-modal" role="dialog" aria-modal="true" aria-labelledby="appConfirmTitle" style="display:none;">
+  <div class="w3-modal-content">
+    <div class="profile-shell modal-shell confirm-delete-modal">
+      <header class="profile-hero">
+        <div class="profile-hero-text">
+          <p class="profile-kicker" id="appConfirmKicker" style="display:none;"></p>
+          <h2 class="profile-title" id="appConfirmTitle">Bestätigen</h2>
+        </div>
+        <div class="profile-hero-actions">
+          <button type="button" class="modal-close w3-button" id="appConfirmClose" aria-label="Schließen">&times;</button>
+        </div>
+      </header>
+      <div class="confirm-delete-body">
+        <p class="profile-value" id="appConfirmMessage"></p>
+        <div class="profile-actions profile-actions--confirm">
+          <div class="profile-actions-primary">
+            <button type="button" class="w3-btn profile-btn-primary w3-border w3-mobile" id="appConfirmOk">OK</button>
+          </div>
+          <button type="button" class="w3-btn w3-border w3-mobile" id="appConfirmCancel">Abbrechen</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 <script src="<?php echo assetUrl('js/listRowSearch.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/modal.js'); ?>"></script>
+<script src="<?php echo assetUrl('js/appDialog.js'); ?>"></script>
 <script src="<?php echo assetUrl('js/toast.js'); ?>"></script>
   </body>
 </html>

--- a/config-menu.php
+++ b/config-menu.php
@@ -97,7 +97,9 @@ function savePara(Parameter, Value, reload) {
 	        if(xmlhttp.status >= 200 && xmlhttp.status < 300 && xmlhttp.responseText.indexOf('ok') !== -1) {
 	            window.location.reload();
 	        } else {
-	            alert('Farbschema konnte nicht übernommen werden: ' + xmlhttp.responseText);
+	            if(typeof window.appAlert === 'function') {
+	                window.appAlert('Farbschema konnte nicht übernommen werden: ' + xmlhttp.responseText, { title: 'Farbschema' });
+	            }
 	        }
 	    }
 	};
@@ -129,22 +131,33 @@ function renameColorScheme(name) {
 	xmlhttp.send(body);
 }
 function resetColorScheme() {
-    if(!confirm('Aktives Farbschema auf Werkseinstellung zurücksetzen?')) return;
-    if (window.XMLHttpRequest) {
-	    xmlhttp=new XMLHttpRequest();
-	}
-	else {
-	    xmlhttp=new ActiveXObject("Microsoft.XMLHTTP");
-	}
-	xmlhttp.onreadystatechange = function() {
-	    if(xmlhttp.readyState === 4) {
-	        window.location.reload();
-	    }
-	};
-	var body = "cmd=schemeReset";
-	xmlhttp.open("POST", "savePara.php", true);
-	xmlhttp.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
-	xmlhttp.send(body);
+    var run = function() {
+        if (window.XMLHttpRequest) {
+            xmlhttp=new XMLHttpRequest();
+        }
+        else {
+            xmlhttp=new ActiveXObject("Microsoft.XMLHTTP");
+        }
+        xmlhttp.onreadystatechange = function() {
+            if(xmlhttp.readyState === 4) {
+                window.location.reload();
+            }
+        };
+        var body = "cmd=schemeReset";
+        xmlhttp.open("POST", "savePara.php", true);
+        xmlhttp.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
+        xmlhttp.send(body);
+    };
+    if(typeof window.appConfirm === 'function') {
+        window.appConfirm('Aktives Farbschema auf Werkseinstellung zurücksetzen?', {
+            title: 'Farbschema',
+            okLabel: 'Zurücksetzen'
+        }).then(function(ok) {
+            if(ok) run();
+        });
+        return;
+    }
+    run();
 }
 </script>
 <?php adminListPageBegin('System', 'globale Einstellungen', array('permKey' => 'perm_editConfig')); ?>

--- a/groups.php
+++ b/groups.php
@@ -77,7 +77,7 @@ foreach($groups as $g) {
       <div class="mail-list-status"><?php echo $count; ?> <span class="w3-small w3-text-gray">(<?php echo $countMail; ?> mit Mail)</span></div>
       <div class="mail-list-actions">
         <a class="w3-button w3-small w3-blue" href="group-edit.php?id=<?php echo $id; ?>">Bearbeiten</a>
-        <form method="post" style="display:inline;" onsubmit="return confirm('Gruppe wirklich löschen?');">
+        <form method="post" style="display:inline;" data-confirm="Gruppe wirklich löschen?" data-confirm-ok="Löschen">
           <input type="hidden" name="Index" value="<?php echo $id; ?>" />
           <button class="w3-button w3-small w3-red" type="submit" name="delete" value="1">Löschen</button>
         </form>

--- a/instrument-types.php
+++ b/instrument-types.php
@@ -127,7 +127,7 @@ while($row = mysqli_fetch_array($dbr)) {
     <div class="type-edit-field type-edit-field--actions">
       <button class="w3-button w3-blue" type="submit" name="update" value="1">Speichern</button>
       <?php if($t->canDelete()) { ?>
-      <button class="w3-button w3-red" type="submit" name="delete" value="1" onclick="return confirm('Instrument-Typ wirklich löschen?');">Löschen</button>
+      <button class="w3-button w3-red" type="submit" name="delete" value="1" data-confirm="Instrument-Typ wirklich löschen?" data-confirm-ok="Löschen">Löschen</button>
       <?php } ?>
     </div>
   </form>

--- a/inventory-types.php
+++ b/inventory-types.php
@@ -104,7 +104,7 @@ while($row = mysqli_fetch_array($dbr)) {
     <div class="w3-col l3 m3 s12">
       <button class="w3-button w3-blue" type="submit" name="update" value="1">Speichern</button>
       <?php if($t->canDelete()) { ?>
-      <button class="w3-button w3-red" type="submit" name="delete" value="1" onclick="return confirm('Typ wirklich löschen?');">Löschen</button>
+      <button class="w3-button w3-red" type="submit" name="delete" value="1" data-confirm="Typ wirklich löschen?" data-confirm-ok="Löschen">Löschen</button>
       <?php } ?>
     </div>
   </form>

--- a/js/appDialog.js
+++ b/js/appDialog.js
@@ -1,0 +1,194 @@
+/**
+ * Custom confirm/alert modals (MELD-187). Native window.confirm/alert
+ * do not work in the Android WebView app.
+ */
+(function () {
+  var resolvePending = null;
+  var mode = 'confirm';
+  var lastSubmitter = null;
+
+  function el(id) {
+    return document.getElementById(id);
+  }
+
+  function setVisible(node, on) {
+    if (!node) return;
+    node.style.display = on ? '' : 'none';
+  }
+
+  function finish(ok) {
+    var modal = el('appConfirmModal');
+    if (modal) modal.style.display = 'none';
+    var fn = resolvePending;
+    resolvePending = null;
+    if (fn) fn(ok);
+  }
+
+  function openDialog(message, opts) {
+    opts = opts || {};
+    mode = opts.mode === 'alert' ? 'alert' : 'confirm';
+    var modal = el('appConfirmModal');
+    var msgEl = el('appConfirmMessage');
+    var titleEl = el('appConfirmTitle');
+    var kickerEl = el('appConfirmKicker');
+    var okBtn = el('appConfirmOk');
+    var cancelBtn = el('appConfirmCancel');
+    if (!modal || !msgEl || !okBtn) {
+      return Promise.resolve(mode === 'alert');
+    }
+    if (resolvePending) {
+      finish(false);
+    }
+    msgEl.textContent = message || '';
+    if (titleEl) {
+      titleEl.textContent = opts.title || (mode === 'alert' ? 'Hinweis' : 'Bestätigen');
+    }
+    if (kickerEl) {
+      kickerEl.textContent = opts.kicker || '';
+      setVisible(kickerEl, !!opts.kicker);
+    }
+    okBtn.textContent = opts.okLabel || 'OK';
+    okBtn.className = opts.okClass || 'w3-btn profile-btn-primary w3-border w3-mobile';
+    setVisible(cancelBtn, mode === 'confirm');
+    if (cancelBtn) {
+      cancelBtn.textContent = opts.cancelLabel || 'Abbrechen';
+    }
+    modal.style.display = 'block';
+    try {
+      okBtn.focus();
+    } catch (e) {}
+    return new Promise(function (resolve) {
+      resolvePending = resolve;
+    });
+  }
+
+  window.appConfirm = function (message, opts) {
+    opts = opts || {};
+    opts.mode = 'confirm';
+    return openDialog(message, opts);
+  };
+
+  window.appAlert = function (message, opts) {
+    opts = opts || {};
+    opts.mode = 'alert';
+    return openDialog(message, opts).then(function () {
+      return undefined;
+    });
+  };
+
+  function bindChrome() {
+    var modal = el('appConfirmModal');
+    if (!modal || modal.getAttribute('data-app-dialog-bound') === '1') return;
+    modal.setAttribute('data-app-dialog-bound', '1');
+    var okBtn = el('appConfirmOk');
+    var cancelBtn = el('appConfirmCancel');
+    var closeBtn = el('appConfirmClose');
+    if (okBtn) {
+      okBtn.addEventListener('click', function () {
+        finish(true);
+      });
+    }
+    if (cancelBtn) {
+      cancelBtn.addEventListener('click', function () {
+        finish(false);
+      });
+    }
+    if (closeBtn) {
+      closeBtn.addEventListener('click', function () {
+        finish(false);
+      });
+    }
+    modal.addEventListener('click', function (e) {
+      if (e.target === modal) finish(false);
+    });
+    document.addEventListener('keydown', function (e) {
+      if (e.key !== 'Escape') return;
+      if (!modal || modal.style.display !== 'block') return;
+      finish(false);
+    });
+  }
+
+  function confirmAttr(node) {
+    if (!node || !node.getAttribute) return '';
+    return node.getAttribute('data-confirm') || '';
+  }
+
+  function confirmOptsFrom(node) {
+    if (!node) return {};
+    var opts = {};
+    var ok = node.getAttribute('data-confirm-ok');
+    var title = node.getAttribute('data-confirm-title');
+    var okClass = node.getAttribute('data-confirm-ok-class');
+    if (ok) opts.okLabel = ok;
+    if (title) opts.title = title;
+    if (okClass) opts.okClass = okClass;
+    return opts;
+  }
+
+  function resolveSubmitter(form, eventSubmitter) {
+    if (eventSubmitter && form.contains(eventSubmitter)) return eventSubmitter;
+    if (lastSubmitter && form.contains(lastSubmitter)) return lastSubmitter;
+    return null;
+  }
+
+  function submitFormConfirmed(form, submitter) {
+    form.setAttribute('data-confirm-pass', '1');
+    if (submitter && typeof form.requestSubmit === 'function') {
+      form.requestSubmit(submitter);
+      return;
+    }
+    if (submitter && submitter.name) {
+      var hidden = document.createElement('input');
+      hidden.type = 'hidden';
+      hidden.name = submitter.name;
+      hidden.value = submitter.value;
+      hidden.setAttribute('data-confirm-temp', '1');
+      form.appendChild(hidden);
+    }
+    HTMLFormElement.prototype.submit.call(form);
+  }
+
+  document.addEventListener(
+    'click',
+    function (e) {
+      var t = e.target && e.target.closest
+        ? e.target.closest('button, input[type="submit"], input[type="image"]')
+        : null;
+      if (t) lastSubmitter = t;
+    },
+    true
+  );
+
+  document.addEventListener(
+    'submit',
+    function (e) {
+      var form = e.target;
+      if (!form || form.nodeName !== 'FORM') return;
+      if (form.getAttribute('data-confirm-pass') === '1') {
+        form.removeAttribute('data-confirm-pass');
+        var temps = form.querySelectorAll('[data-confirm-temp="1"]');
+        for (var i = 0; i < temps.length; i++) {
+          temps[i].parentNode.removeChild(temps[i]);
+        }
+        return;
+      }
+      var submitter = resolveSubmitter(form, e.submitter || null);
+      var msg = confirmAttr(form) || confirmAttr(submitter);
+      if (!msg) return;
+      e.preventDefault();
+      e.stopPropagation();
+      var optsNode = confirmAttr(submitter) ? submitter : form;
+      window.appConfirm(msg, confirmOptsFrom(optsNode)).then(function (ok) {
+        if (!ok) return;
+        submitFormConfirmed(form, submitter);
+      });
+    },
+    true
+  );
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bindChrome);
+  } else {
+    bindChrome();
+  }
+})();

--- a/js/calendarMelde.js
+++ b/js/calendarMelde.js
@@ -63,10 +63,19 @@ function calendarFormatDeDate(iso) {
 function calendarOfferNewTermin(dateIso) {
     if(!dateIso) return;
     var label = calendarFormatDeDate(dateIso);
-    if(!window.confirm('Neuen Termin am ' + label + ' anlegen?')) {
+    var go = function() {
+        window.location.href = 'new-termin.php?Datum=' + encodeURIComponent(dateIso);
+    };
+    if(typeof window.appConfirm === 'function') {
+        window.appConfirm('Neuen Termin am ' + label + ' anlegen?', {
+            title: 'Termin',
+            okLabel: 'Anlegen'
+        }).then(function(ok) {
+            if(ok) go();
+        });
         return;
     }
-    window.location.href = 'new-termin.php?Datum=' + encodeURIComponent(dateIso);
+    go();
 }
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/libs/inventories.php
+++ b/libs/inventories.php
@@ -626,7 +626,7 @@ class Inventories
         if($canEdit) {
             $str .= '<div class="inventory-loan-action-group inventory-loan-action-group--danger">';
             $str .= '<form method="POST" action="" class="inventory-loan-delete" '
-                .'onsubmit="return confirm(\'Diese Leih-Information wirklich löschen?\');">'
+                .'data-confirm="Diese Leih-Information wirklich löschen?" data-confirm-ok="Löschen">'
                 .'<input type="hidden" name="LoanIndex" value="'.$loanId.'">'
                 .'<button type="submit" name="deleteLoan" value="1" class="inventory-loan-btn inventory-loan-btn--danger '.$btnDelete.'">Löschen</button>'
                 .'</form>';

--- a/libs/listChunk.php
+++ b/libs/listChunk.php
@@ -617,7 +617,7 @@ function mailOutboxRenderListItemHtml(array $row, &$userNameCache = null) {
     $html .= '<div class="mail-list-status">'.$neu.$mailFail.'</div>';
     $html .= '<div class="mail-list-actions">';
     $html .= '<a class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnEdit'].'" href="meine-mails.php?id='.$id.'">Anzeigen</a>';
-    $html .= '<form method="post" action="meine-mails.php" onsubmit="return confirm(\'Nachricht ausblenden?\');">';
+    $html .= '<form method="post" action="meine-mails.php" data-confirm="Nachricht ausblenden?" data-confirm-ok="Ausblenden">';
     $html .= '<input type="hidden" name="id" value="'.$id.'" />';
     $html .= '<button type="submit" name="delete" value="1" class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnNo'].'">Ausblenden</button>';
     $html .= '</form>';

--- a/libs/mailJob.php
+++ b/libs/mailJob.php
@@ -747,7 +747,7 @@ class MailJob
         }
         if($this->canCancel()) {
             $html .= '<span class="mail-cancel-wrap">';
-            $html .= '<form method="post" action="mail.php" onsubmit="return confirm(\'Versand von Email-ID '.$id.' wirklich abbrechen?\');">';
+            $html .= '<form method="post" action="mail.php" data-confirm="Versand von Email-ID '.$id.' wirklich abbrechen?" data-confirm-ok="Abbrechen">';
             $html .= '<input type="hidden" name="id" value="'.$id.'" />';
             $html .= '<button type="submit" name="cancel_job" value="1" class="w3-button w3-small '.$GLOBALS['optionsDB']['colorWarning'].'">Abbrechen</button>';
             $html .= '</form>';
@@ -758,7 +758,7 @@ class MailJob
                 ? 'Entwurf #'.$id.' wirklich löschen?'
                 : 'Email-ID '.$id.' wirklich löschen? (noch an niemanden per PHPMailer versendet)';
             $html .= '<span class="mail-delete-wrap">';
-            $html .= '<form method="post" action="mail.php" onsubmit="return confirm(\''.htmlspecialchars($delConfirm, ENT_QUOTES, 'UTF-8').'\');">';
+            $html .= '<form method="post" action="mail.php" data-confirm="'.htmlspecialchars($delConfirm, ENT_QUOTES, 'UTF-8').'" data-confirm-ok="Löschen">';
             $html .= '<input type="hidden" name="id" value="'.$id.'" />';
             $html .= '<button type="submit" name="delete_job" value="1" class="w3-button w3-small '.$GLOBALS['optionsDB']['colorBtnNo'].'">Löschen</button>';
             $html .= '</form>';

--- a/mail.php
+++ b/mail.php
@@ -468,7 +468,7 @@ window.syncDiscordDefault = function() {};
   })();
   </script>
 
-  <form method="post" action="mail.php?id=<?php echo (int)$job->Index; ?>" onsubmit="return confirm('Entwurf #<?php echo (int)$job->Index; ?> wirklich löschen?');">
+  <form method="post" action="mail.php?id=<?php echo (int)$job->Index; ?>" data-confirm="Entwurf #<?php echo (int)$job->Index; ?> wirklich löschen?" data-confirm-ok="Löschen">
     <input type="hidden" name="id" value="<?php echo (int)$job->Index; ?>" />
     <div class="mail-compose-actions">
     <button class="w3-btn <?php echo $GLOBALS['optionsDB']['colorBtnNo']; ?> w3-margin" name="delete_job" value="1">Entwurf löschen</button>
@@ -586,13 +586,13 @@ function delFile(hash) {
     <div class="w3-padding-16 mail-detail-actions">
       <a class="w3-button <?php echo $GLOBALS['optionsDB']['colorBtnSubmit']; ?>" href="mail.php?copy=<?php echo (int)$job->Index; ?>">Als Entwurf kopieren</a>
       <?php if($job->canCancel()) { ?>
-      <form method="post" action="mail.php" onsubmit="return confirm('Versand von Email-ID <?php echo (int)$job->Index; ?> wirklich abbrechen?');">
+      <form method="post" action="mail.php" data-confirm="Versand von Email-ID <?php echo (int)$job->Index; ?> wirklich abbrechen?" data-confirm-ok="Abbrechen">
         <input type="hidden" name="id" value="<?php echo (int)$job->Index; ?>" />
         <button type="submit" name="cancel_job" value="1" class="w3-button <?php echo $GLOBALS['optionsDB']['colorWarning']; ?>">Abbrechen</button>
       </form>
       <?php } ?>
       <?php if($job->canDelete()) { ?>
-      <form method="post" action="mail.php" onsubmit="return confirm('Email-ID <?php echo (int)$job->Index; ?> wirklich löschen?');">
+      <form method="post" action="mail.php" data-confirm="Email-ID <?php echo (int)$job->Index; ?> wirklich löschen?" data-confirm-ok="Löschen">
         <input type="hidden" name="id" value="<?php echo (int)$job->Index; ?>" />
         <button type="submit" name="delete_job" value="1" class="w3-button <?php echo $GLOBALS['optionsDB']['colorBtnNo']; ?>">Löschen</button>
       </form>

--- a/meine-mails.php
+++ b/meine-mails.php
@@ -73,7 +73,7 @@ adminListPageBegin('Kommunikation', 'Meine Nachrichten');
     <div class="w3-padding-16 mail-body-content"><?php echo $body; ?></div>
     <div class="w3-padding-16 mail-detail-actions">
       <a class="w3-button <?php echo $GLOBALS['optionsDB']['colorBtnSubmit']; ?>" href="meine-mails.php">Zur Übersicht</a>
-      <form method="post" action="meine-mails.php" onsubmit="return confirm('Nachricht ausblenden?');">
+      <form method="post" action="meine-mails.php" data-confirm="Nachricht ausblenden?" data-confirm-ok="Ausblenden">
         <input type="hidden" name="id" value="<?php echo (int)$viewMail->Index; ?>" />
         <button type="submit" name="delete" value="1" class="w3-button <?php echo $GLOBALS['optionsDB']['colorBtnNo']; ?>">Ausblenden</button>
       </form>

--- a/register-types.php
+++ b/register-types.php
@@ -129,7 +129,7 @@ while($row = mysqli_fetch_array($dbr)) {
     <div class="type-edit-field type-edit-field--actions">
       <button class="w3-button w3-blue" type="submit" name="update" value="1">Speichern</button>
       <?php if($t->canDelete()) { ?>
-      <button class="w3-button w3-red" type="submit" name="delete" value="1" onclick="return confirm('Register wirklich löschen?');">Löschen</button>
+      <button class="w3-button w3-red" type="submit" name="delete" value="1" data-confirm="Register wirklich löschen?" data-confirm-ok="Löschen">Löschen</button>
       <?php } ?>
     </div>
   </form>

--- a/seedOrchestraTestUsers.php
+++ b/seedOrchestraTestUsers.php
@@ -78,7 +78,7 @@ if($_SERVER['REQUEST_METHOD'] === 'POST') {
     <?php echo csrf_field(); ?>
     <button class="w3-button w3-green" type="submit" name="action" value="create">50 Test-User anlegen</button>
   </form>
-  <form method="post" class="w3-margin-bottom" style="display:inline-block;" onsubmit="return confirm('Alle OrchesterTest-User soft-löschen?');">
+  <form method="post" class="w3-margin-bottom" style="display:inline-block;" data-confirm="Alle OrchesterTest-User soft-löschen?" data-confirm-ok="Löschen">
     <?php echo csrf_field(); ?>
     <button class="w3-button w3-orange" type="submit" name="action" value="delete">Test-User löschen</button>
   </form>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -4310,7 +4310,8 @@ body.loan-form-print {
 
 /* Page-local profile-shell modals (outside .app-main): same chrome as #ajaxModalContent */
 #calSubscribeModal .w3-modal-content,
-#delmodal .w3-modal-content {
+#delmodal .w3-modal-content,
+#appConfirmModal .w3-modal-content {
   background: transparent;
   box-shadow: none;
   width: auto !important;
@@ -4318,13 +4319,15 @@ body.loan-form-print {
   margin: 4vh auto;
 }
 
-#delmodal .w3-modal-content {
+#delmodal .w3-modal-content,
+#appConfirmModal .w3-modal-content {
   max-width: min(32rem, calc(100vw - 1.5rem));
   margin: 8vh auto;
 }
 
 #calSubscribeModal .calendar-subscribe-modal,
-#delmodal .confirm-delete-modal {
+#delmodal .confirm-delete-modal,
+#appConfirmModal .confirm-delete-modal {
   margin: 0.75rem;
   background: #fff;
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.18);
@@ -4459,7 +4462,8 @@ body.loan-form-print {
 
 @media (max-width: 600px) {
   #calSubscribeModal .calendar-subscribe-modal,
-  #delmodal .confirm-delete-modal {
+  #delmodal .confirm-delete-modal,
+  #appConfirmModal .confirm-delete-modal {
     margin: 0.35rem 0.5rem;
   }
 


### PR DESCRIPTION
## Summary
- Native `alert`/`confirm` durch gemeinsames profile-shell-Modal (`appConfirm` / `appAlert`, `#appConfirmModal`) ersetzt — nötig für die Android-WebView.
- Formulare/Buttons nutzen `data-confirm` (+ optional `data-confirm-ok`); Kalender und Farbschema rufen die JS-API.
- Äußerer `w3-modal-content`-Chrome transparent (wie Lösch-Modal), damit keine doppelte Box entsteht.

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-187

## Test plan
- [ ] Kalender: Tag tippen → Bestätigungs-Modal → Anlegen / Abbrechen
- [ ] Mail oder Meine Mails: Löschen/Ausblenden → Modal, Abbrechen bricht ab
- [ ] Modal ohne äußere eckige Box (nur abgerundete Shell)
- [ ] `composer test` in meldeliste-tests (AppDialogConfirmTest)