### PR TITLE
MELD-189 MELD-179: serverseitige Log-Suche und Mehrwort-UND

### DIFF
--- a/getList.php
+++ b/getList.php
@@ -30,7 +30,8 @@ case 'log':
     if(!isset($_GET['limit']) || (int)$_GET['limit'] < 1) {
         $limit = listChunkLogConfiguredLimit();
     }
-    $result = listChunkLog($cursor !== '' ? (int)$cursor : 0, $limit);
+    $q = isset($_GET['q']) ? (string)$_GET['q'] : '';
+    $result = listChunkLog($cursor !== '' ? (int)$cursor : 0, $limit, $q);
     break;
 
 case 'termine':

--- a/js/filterInstruments.js
+++ b/js/filterInstruments.js
@@ -23,7 +23,9 @@ function filterMusiker() {
         var txtValue = (typeof listRowSearchText === "function"
             ? listRowSearchText(row)
             : (row.textContent || row.innerText || ""));
-        var textOk = filter === "" || txtValue.toUpperCase().indexOf(filter) > -1;
+        var textOk = typeof listRowMatchesQuery === "function"
+            ? listRowMatchesQuery(txtValue, input ? input.value : "")
+            : (filter === "" || txtValue.toUpperCase().indexOf(filter) > -1);
         var insuredOk = !insuredOnly || row.getAttribute("data-insured") === "1";
         if (textOk && insuredOk) {
             row.style.display = "";

--- a/js/filterLog.js
+++ b/js/filterLog.js
@@ -1,7 +1,7 @@
 function filterLog() {
     var input, filter, table, i, row, txtValue;
     input = document.getElementById("filterString");
-    filter = input.value.toUpperCase();
+    filter = input ? input.value : '';
     table = document.getElementById("Liste");
     // Only direct list rows (not nested log-time / log-message divs) — O(rows), not O(descendants)
     for (i = 0; i < table.children.length; i++) {
@@ -10,7 +10,7 @@ function filterLog() {
 	if(row.id === "listSentinel") continue;
 	if(row.className=="w3-modal" || row.className=="w3-modal-content") continue;
 	txtValue = (typeof listRowSearchText === 'function' ? listRowSearchText(row) : (row.textContent || row.innerText));
-	if (txtValue.toUpperCase().indexOf(filter) > -1) {
+	if (typeof listRowMatchesQuery === 'function' ? listRowMatchesQuery(txtValue, filter) : String(txtValue).toUpperCase().indexOf(String(filter).toUpperCase()) > -1) {
 	    row.style.display = "";
 	    row.classList.remove("list-filtered-out");
 	} else {

--- a/js/filterMail.js
+++ b/js/filterMail.js
@@ -12,7 +12,7 @@ function filterMail() {
 	if(tr[i].parentNode !== table) continue;
 	if(!tr[i].classList || !tr[i].classList.contains("mail-list-item")) continue;
 	txtValue = (typeof listRowSearchText === 'function' ? listRowSearchText(tr[i]) : (tr[i].textContent || tr[i].innerText));
-	if (txtValue.toUpperCase().indexOf(filter) > -1) {
+	if (typeof listRowMatchesQuery === 'function' ? listRowMatchesQuery(txtValue, input.value) : txtValue.toUpperCase().indexOf(filter) > -1) {
 	    tr[i].style.display = "";
 	    tr[i].classList.remove("list-filtered-out");
 	} else {

--- a/js/filterMusiker.js
+++ b/js/filterMusiker.js
@@ -9,7 +9,7 @@ function filterMusiker() {
 	if(tr[i].className=="w3-modal" || tr[i].className=="w3-modal-content") continue;
 	if(tr[i].parentNode !== table) continue;
 	txtValue = (typeof listRowSearchText === 'function' ? listRowSearchText(tr[i]) : (tr[i].textContent || tr[i].innerText));
-	if (txtValue.toUpperCase().indexOf(filter) > -1) {
+	if (typeof listRowMatchesQuery === 'function' ? listRowMatchesQuery(txtValue, input.value) : txtValue.toUpperCase().indexOf(filter) > -1) {
 	    tr[i].style.display = "";
 	    tr[i].classList.remove("list-filtered-out");
 	} else {

--- a/js/filterPersonen.js
+++ b/js/filterPersonen.js
@@ -56,7 +56,10 @@
                 var txt = typeof listRowSearchText === 'function'
                     ? listRowSearchText(row)
                     : (row.getAttribute('data-search') || row.textContent || '');
-                if (String(txt).toUpperCase().indexOf(filter) === -1) {
+                var ok = typeof listRowMatchesQuery === 'function'
+                    ? listRowMatchesQuery(txt, input ? input.value : '')
+                    : String(txt).toUpperCase().indexOf(filter) !== -1;
+                if (!ok) {
                     visible = false;
                 }
             }

--- a/js/filterTermine.js
+++ b/js/filterTermine.js
@@ -13,7 +13,7 @@ function filterTermine() {
         txtValue = (typeof listRowSearchText === 'function'
             ? listRowSearchText(tr[i])
             : ((dataSearch = tr[i].getAttribute("data-search")) || tr[i].textContent || tr[i].innerText || ""));
-        if (txtValue.toUpperCase().indexOf(filter) > -1) {
+        if (typeof listRowMatchesQuery === 'function' ? listRowMatchesQuery(txtValue, input.value) : txtValue.toUpperCase().indexOf(filter) > -1) {
             tr[i].style.display = "";
             tr[i].classList.remove("list-filtered-out");
         } else {

--- a/js/infiniteScroll.js
+++ b/js/infiniteScroll.js
@@ -11,11 +11,16 @@
  * (sparse hits like „Adventskonzert“). Chain via timeout — not only IntersectionObserver —
  * because a collapsed filter list keeps the sentinel in view. Optional Stoppen;
  * no manual Weiter required. (MELD-162 hard pause after 2 empties removed.)
+ *
+ * MELD-189: Lists with data-server-q="1" (Log) send q to getList.php and reload from
+ * cursor 0 on search change — no client scan of the full table.
  */
 (function() {
     var loading = false;
     var observer = null;
     var pausedByUser = false;
+    var serverQReloadTimer = null;
+    var loadGeneration = 0;
     var MSG_LOADING = 'Weitere Einträge werden geladen…';
     var MSG_FILTER_SCAN = 'Suche…';
     var MSG_END = 'Keine weiteren Einträge';
@@ -30,9 +35,18 @@
         return document.getElementById('Liste');
     }
 
-    function filterActive() {
+    function usesServerQ() {
+        var sentinel = getSentinel();
+        return !!(sentinel && sentinel.getAttribute('data-server-q') === '1');
+    }
+
+    function filterQuery() {
         var input = document.getElementById('filterString');
-        if(input && String(input.value).trim() !== '') return true;
+        return input ? String(input.value).trim() : '';
+    }
+
+    function filterActive() {
+        if(filterQuery() !== '') return true;
         // Inventory "Versichert" chip (MELD-177) — keep scanning while sparse
         var insured = document.getElementById('filterInsured');
         if(insured && insured.classList.contains('is-active')) return true;
@@ -47,6 +61,12 @@
             if(document.querySelector('[data-register-filter].is-active')) return true;
         }
         return false;
+    }
+
+    /** Client-side sparse scan only — not for server-q lists (would dump all matches). */
+    function shouldAutoChainFilter() {
+        if(usesServerQ()) return false;
+        return filterActive();
     }
 
     function setBarVisible(visible) {
@@ -132,7 +152,7 @@
         pausedByUser = false;
         var sentinel = getSentinel();
         if(!sentinel || sentinel.getAttribute('data-has-more') !== '1') return;
-        if(filterActive()) {
+        if(shouldAutoChainFilter()) {
             chainFilterLoadSoon();
             return;
         }
@@ -149,7 +169,12 @@
     function onClientFilterChanged() {
         pausedByUser = false;
         var sentinel = getSentinel();
-        if(!sentinel || sentinel.getAttribute('data-has-more') !== '1') return;
+        if(!sentinel) return;
+        if(usesServerQ()) {
+            scheduleServerQReload();
+            return;
+        }
+        if(sentinel.getAttribute('data-has-more') !== '1') return;
         if(!filterActive()) {
             setStatus('', false);
             reobserveSoon();
@@ -160,6 +185,27 @@
             onClick: pauseByUser
         });
         chainFilterLoadSoon();
+    }
+
+    function scheduleServerQReload() {
+        if(serverQReloadTimer) {
+            clearTimeout(serverQReloadTimer);
+        }
+        var sentinel = getSentinel();
+        var list = getList();
+        if(list && sentinel) {
+            if(observer) observer.unobserve(sentinel);
+            loadGeneration++;
+            loading = false;
+            clearRows(list, sentinel);
+            sentinel.setAttribute('data-cursor', '0');
+            sentinel.setAttribute('data-has-more', '1');
+        }
+        setStatus(MSG_FILTER_SCAN, true);
+        serverQReloadTimer = setTimeout(function() {
+            serverQReloadTimer = null;
+            reloadFromStart();
+        }, 300);
     }
 
     window.listInfiniteFilterChanged = onClientFilterChanged;
@@ -227,6 +273,10 @@
         var dir = sentinel.getAttribute('data-dir');
         if(sort) url += '&sort=' + encodeURIComponent(sort);
         if(dir) url += '&dir=' + encodeURIComponent(dir);
+        if(sentinel.getAttribute('data-server-q') === '1') {
+            var q = filterQuery();
+            if(q !== '') url += '&q=' + encodeURIComponent(q);
+        }
         return url;
     }
 
@@ -256,6 +306,10 @@
                 reobserveSoon();
                 return;
             }
+            if(!shouldAutoChainFilter()) {
+                reobserveSoon();
+                return;
+            }
             loadMore();
         }, 0);
     }
@@ -271,16 +325,20 @@
         var cursor = sentinel.getAttribute('data-cursor') || '';
         if(!type || cursor === '') return;
 
-        var filtering = filterActive();
+        var filtering = shouldAutoChainFilter();
         var seekingFirstMatch = filtering && countVisibleInList(list, sentinel) === 0;
 
         loading = true;
+        var requestGen = loadGeneration;
         if(observer) observer.unobserve(sentinel);
         if(filtering) {
             setStatus(seekingFirstMatch ? MSG_FILTER_SCAN : MSG_LOADING, true, {
                 label: 'Stoppen',
                 onClick: pauseByUser
             });
+        }
+        else if(usesServerQ() && filterQuery() !== '') {
+            setStatus(MSG_LOADING, true);
         }
         else {
             setStatus(MSG_LOADING, true);
@@ -295,6 +353,9 @@
         }
         xhr.onreadystatechange = function() {
             if(xhr.readyState !== 4) return;
+            if(requestGen !== loadGeneration) {
+                return;
+            }
             loading = false;
             if(xhr.status < 200 || xhr.status >= 300) {
                 setStatus(MSG_ERROR, false);
@@ -331,7 +392,7 @@
                 return;
             }
 
-            if(filterActive()) {
+            if(shouldAutoChainFilter()) {
                 // Keep scanning automatically until end or Stoppen (no Weiter).
                 var visibleTotal = countVisibleInList(list, sentinel);
                 setStatus(visibleTotal === 0 ? MSG_FILTER_SCAN : MSG_LOADING, true, {
@@ -354,6 +415,7 @@
         var list = getList();
         if(!sentinel || !list) return;
         if(observer) observer.unobserve(sentinel);
+        loadGeneration++;
         loading = false;
         pausedByUser = false;
         if(sort) sentinel.setAttribute('data-sort', sort);

--- a/js/listRowSearch.js
+++ b/js/listRowSearch.js
@@ -19,3 +19,34 @@ function listRowSearchText(el) {
     parts.push(el.textContent || el.innerText || '');
     return parts.join(' ');
 }
+
+/**
+ * Whitespace tokens for multi-term AND search (MELD-179).
+ * @return {string[]}
+ */
+function listRowSearchTokens(query) {
+    var q = String(query || '').trim();
+    if (!q) {
+        return [];
+    }
+    return q.split(/\s+/).filter(Boolean).slice(0, 8);
+}
+
+/**
+ * True if haystack contains every whitespace token (case-insensitive).
+ * Empty query matches everything.
+ */
+function listRowMatchesQuery(haystack, query) {
+    var tokens = listRowSearchTokens(query);
+    if (!tokens.length) {
+        return true;
+    }
+    var h = String(haystack || '').toUpperCase();
+    var i;
+    for (i = 0; i < tokens.length; i++) {
+        if (h.indexOf(String(tokens[i]).toUpperCase()) === -1) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/libs/listChunk.php
+++ b/libs/listChunk.php
@@ -34,24 +34,167 @@ function listChunkLogLimit($requested = 0) {
     return $n;
 }
 
-function listChunkLog($beforeIndex, $limit) {
-    $limit = listChunkLogLimit($limit);
-    $beforeIndex = (int)$beforeIndex;
-    if($beforeIndex > 0) {
-        $sql = sprintf(
-            'SELECT `Index` FROM `%sLog` WHERE `Index` < %d ORDER BY `Index` DESC LIMIT %d;',
-            $GLOBALS['dbprefix'],
-            $beforeIndex,
-            $limit + 1
-        );
+/**
+ * Escape a single search token for SQL LIKE (MELD-189 / MELD-179).
+ * @return string Empty if no usable query; otherwise already mysqli-escaped needle (no %).
+ */
+function listChunkLogSearchNeedle($q) {
+    $q = trim((string)$q);
+    if($q === '') {
+        return '';
+    }
+    if(function_exists('mb_substr')) {
+        $q = mb_substr($q, 0, 64, 'UTF-8');
     }
     else {
+        $q = substr($q, 0, 64);
+    }
+    $q = str_replace(array('\\', '%', '_'), array('\\\\', '\\%', '\\_'), $q);
+    return mysqli_real_escape_string($GLOBALS['conn'], $q);
+}
+
+/**
+ * Split query into whitespace tokens (AND semantics, MELD-179).
+ * @return list<array{raw:string,needle:string}>
+ */
+function listChunkLogSearchTokens($q) {
+    $q = trim((string)$q);
+    if($q === '') {
+        return array();
+    }
+    if(function_exists('mb_substr')) {
+        $q = mb_substr($q, 0, 120, 'UTF-8');
+    }
+    else {
+        $q = substr($q, 0, 120);
+    }
+    $parts = preg_split('/\s+/u', $q, -1, PREG_SPLIT_NO_EMPTY);
+    if(!is_array($parts)) {
+        $parts = preg_split('/\s+/', $q, -1, PREG_SPLIT_NO_EMPTY);
+    }
+    $out = array();
+    foreach($parts as $part) {
+        if(count($out) >= 8) {
+            break;
+        }
+        $needle = listChunkLogSearchNeedle($part);
+        if($needle === '') {
+            continue;
+        }
+        $out[] = array('raw' => (string)$part, 'needle' => $needle);
+    }
+    return $out;
+}
+
+/**
+ * Map free-text search to Log.Type ids when the query looks like a type chip label.
+ * @return int[]
+ */
+function listChunkLogTypeIdsForQuery($q) {
+    $q = trim((string)$q);
+    if($q === '') {
+        return array();
+    }
+    $u = function_exists('mb_strtoupper') ? mb_strtoupper($q, 'UTF-8') : strtoupper($q);
+    if(function_exists('mb_strlen')) {
+        if(mb_strlen($u, 'UTF-8') < 3) {
+            return array();
+        }
+    }
+    elseif(strlen($u) < 3) {
+        return array();
+    }
+    $labels = array(
+        0 => 'FATAL',
+        1 => 'ERROR',
+        2 => 'WARNING',
+        3 => 'DB DELETE',
+        4 => 'DB INSERT',
+        5 => 'DB UPDATE',
+        6 => 'EMAIL',
+        7 => 'INFO',
+    );
+    $ids = array();
+    foreach($labels as $id => $label) {
+        if($u === $label || strpos($label, $u) !== false) {
+            $ids[] = (int)$id;
+        }
+    }
+    return array_values(array_unique($ids));
+}
+
+/**
+ * One token must match Message, user name, SYSTEM, or type label.
+ * @param array{raw:string,needle:string} $token
+ */
+function listChunkLogTokenSqlCondition(array $token) {
+    $like = '\'%'.$token['needle'].'%\'';
+    $conds = array(
+        'l.`Message` LIKE '.$like.' ESCAPE \'\\\\\'',
+        'u.`Vorname` LIKE '.$like.' ESCAPE \'\\\\\'',
+        'u.`Nachname` LIKE '.$like.' ESCAPE \'\\\\\'',
+        'CONCAT(u.`Vorname`, \' \', u.`Nachname`) LIKE '.$like.' ESCAPE \'\\\\\'',
+    );
+    $raw = (string)$token['raw'];
+    if(stripos('SYSTEM', $raw) !== false) {
+        $conds[] = 'l.`User` = 0';
+    }
+    $typeIds = listChunkLogTypeIdsForQuery($raw);
+    if($typeIds) {
+        $conds[] = 'l.`Type` IN ('.implode(',', array_map('intval', $typeIds)).')';
+    }
+    return '('.implode(' OR ', $conds).')';
+}
+
+/**
+ * @param int $beforeIndex
+ * @param int $limit
+ * @param string $q Server-side search; whitespace tokens are AND (MELD-179)
+ * @return array{html:string,nextCursor:string,hasMore:bool}
+ */
+function listChunkLog($beforeIndex, $limit, $q = '') {
+    $limit = listChunkLogLimit($limit);
+    $beforeIndex = (int)$beforeIndex;
+    $tokens = listChunkLogSearchTokens($q);
+    $prefix = $GLOBALS['dbprefix'];
+
+    if(!$tokens) {
+        if($beforeIndex > 0) {
+            $sql = sprintf(
+                'SELECT `Index` FROM `%sLog` WHERE `Index` < %d ORDER BY `Index` DESC LIMIT %d;',
+                $prefix,
+                $beforeIndex,
+                $limit + 1
+            );
+        }
+        else {
+            $sql = sprintf(
+                'SELECT `Index` FROM `%sLog` ORDER BY `Index` DESC LIMIT %d;',
+                $prefix,
+                $limit + 1
+            );
+        }
+    }
+    else {
+        $tokenSql = array();
+        foreach($tokens as $token) {
+            $tokenSql[] = listChunkLogTokenSqlCondition($token);
+        }
+        $whereSearch = implode(' AND ', $tokenSql);
+        $whereIdx = $beforeIndex > 0 ? ('l.`Index` < '.(int)$beforeIndex.' AND ') : '';
         $sql = sprintf(
-            'SELECT `Index` FROM `%sLog` ORDER BY `Index` DESC LIMIT %d;',
-            $GLOBALS['dbprefix'],
+            'SELECT l.`Index` FROM `%sLog` l'
+            .' LEFT JOIN `%sUser` u ON u.`Index` = l.`User`'
+            .' WHERE %s%s'
+            .' ORDER BY l.`Index` DESC LIMIT %d;',
+            $prefix,
+            $prefix,
+            $whereIdx,
+            $whereSearch,
             $limit + 1
         );
     }
+
     $dbr = mysqli_query($GLOBALS['conn'], $sql);
     sqlerror();
     $ids = array();

--- a/log.php
+++ b/log.php
@@ -19,11 +19,11 @@ if($leak !== false && $leak !== '') {
 ?>
 <?php
 adminListPageBegin('System', 'Log');
-adminListSearchField('Log durchsuchen…', array('onkeyup' => 'filterLog()'));
+adminListSearchField('Log durchsuchen…');
 ?>
 <div id="Liste" style="clear:both;">
 <?php echo $chunk['html']; ?>
-<?php echo listChunkRenderSentinel('log', $chunk['nextCursor'], $chunk['hasMore'], 'filterLog', ' data-limit="'.(int)$logChunkLimit.'"'); ?>
+<?php echo listChunkRenderSentinel('log', $chunk['nextCursor'], $chunk['hasMore'], 'filterLog', ' data-limit="'.(int)$logChunkLimit.'" data-server-q="1"'); ?>
 </div>
 <?php adminListPageEnd(); ?>
 <script>

--- a/scripts/seedLogSearchFixture.php
+++ b/scripts/seedLogSearchFixture.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Lokale Log-Fixture für MELD-189/179-Suche (~12k Einträge + Adventskonzert 2019).
+ *
+ *   php scripts/seedLogSearchFixture.php
+ *   php scripts/seedLogSearchFixture.php --delete
+ *
+ * Markierung: Message beginnt mit [seed-log-search]
+ * Reihenfolge: zuerst Adventskonzert (niedriger Index), danach Filler → ohne Suche
+ * weit unten; mit Suche „Adventskonzert 2019“ sofort treffbar.
+ */
+declare(strict_types=1);
+
+if(PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "Nur CLI.\n");
+    exit(1);
+}
+
+require dirname(__DIR__).'/common/config.php';
+mysqli_set_charset($GLOBALS['conn'], 'utf8mb4');
+mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($GLOBALS['conn']));
+
+$prefix = $GLOBALS['dbprefix'];
+$table = '`'.$prefix.'Log`';
+$marker = '[seed-log-search]';
+$delete = in_array('--delete', $argv, true);
+$fillerCount = 12000;
+
+if($delete) {
+    $sqlDel = sprintf(
+        'DELETE FROM %s WHERE `Message` LIKE \'%s%%\'',
+        $table,
+        mysqli_real_escape_string($GLOBALS['conn'], $marker)
+    );
+    if(!mysqli_query($GLOBALS['conn'], $sqlDel)) {
+        fwrite(STDERR, mysqli_error($GLOBALS['conn'])."\n");
+        exit(1);
+    }
+    printf("Gelöscht: %d Zeilen mit %s\n", mysqli_affected_rows($GLOBALS['conn']), $marker);
+    exit(0);
+}
+
+$existing = mysqli_query($GLOBALS['conn'], "SELECT COUNT(*) AS c FROM {$table} WHERE `Message` LIKE '".mysqli_real_escape_string($GLOBALS['conn'], $marker)."%'");
+$row = $existing ? mysqli_fetch_assoc($existing) : null;
+if($row && (int)$row['c'] > 0) {
+    fwrite(STDERR, "Bereits ".(int)$row['c']." Seed-Zeilen vorhanden. Zuerst: php scripts/seedLogSearchFixture.php --delete\n");
+    exit(1);
+}
+
+$userId = 0;
+$ur = mysqli_query($GLOBALS['conn'], "SELECT `Index` FROM `{$prefix}User` WHERE `Deleted` = 0 ORDER BY `Index` ASC LIMIT 1");
+if($ur && ($u = mysqli_fetch_assoc($ur))) {
+    $userId = (int)$u['Index'];
+}
+
+$advent = array(
+    array('2019-12-01 10:15:00', 7, 'Adventskonzert 2019: Termin angelegt (Kirche Duisdorf)'),
+    array('2019-12-08 18:30:00', 7, 'Adventskonzert 2019: Probe im Proberaum'),
+    array('2019-12-14 19:00:00', 7, 'Adventskonzert 2019: Generalprobe'),
+    array('2019-12-15 16:45:00', 6, 'Adventskonzert 2019: Einladung an Mitglieder versendet'),
+    array('2019-12-15 17:20:00', 4, 'Adventskonzert 2019: Meldung Ralf Cimiotti = ja'),
+    array('2019-12-15 20:05:00', 7, 'Adventskonzert 2019: Konzert erfolgreich, 87 Zuschauer'),
+    array('2019-12-16 09:10:00', 5, 'Adventskonzert 2019: Termin-Status auf archiviert gesetzt'),
+);
+
+mysqli_begin_transaction($GLOBALS['conn']);
+
+foreach($advent as $entry) {
+    list($ts, $type, $msg) = $entry;
+    $full = $marker.' '.$msg;
+    $sqlIns = sprintf(
+        'INSERT INTO %s (`Timestamp`, `User`, `Type`, `Message`) VALUES (\'%s\', %d, %d, \'%s\')',
+        $table,
+        mysqli_real_escape_string($GLOBALS['conn'], $ts),
+        $userId,
+        (int)$type,
+        mysqli_real_escape_string($GLOBALS['conn'], $full)
+    );
+    if(!mysqli_query($GLOBALS['conn'], $sqlIns)) {
+        mysqli_rollback($GLOBALS['conn']);
+        fwrite(STDERR, mysqli_error($GLOBALS['conn'])."\n");
+        exit(1);
+    }
+}
+
+$batchSize = 500;
+$types = array(1, 2, 4, 5, 6, 7, 7, 7, 7);
+// Nur Tages-Offsets + feste Tageszeiten (10–17 Uhr), vermeidet ungültige DST-Stunden.
+$day0 = new DateTimeImmutable('2019-01-01', new DateTimeZone('Europe/Berlin'));
+$daySpan = (int)$day0->diff(new DateTimeImmutable('2026-08-14', new DateTimeZone('Europe/Berlin')))->days;
+
+$inserted = 0;
+for($offset = 0; $offset < $fillerCount; $offset += $batchSize) {
+    $n = min($batchSize, $fillerCount - $offset);
+    $values = array();
+    for($i = 0; $i < $n; $i++) {
+        $idx = $offset + $i;
+        $frac = ($idx + 1) / ($fillerCount + 1);
+        $dayOffset = (int)round($frac * $daySpan);
+        $hour = 10 + ($idx % 8);
+        $minute = ($idx * 7) % 60;
+        $second = ($idx * 13) % 60;
+        $when = $day0->modify('+'.$dayOffset.' days')->setTime($hour, $minute, $second);
+        $type = $types[$idx % count($types)];
+        $msg = sprintf(
+            '%s Noise #%05d Login/Sync/Mail filler (kein Advent)',
+            $marker,
+            $idx + 1
+        );
+        $values[] = sprintf(
+            '(\'%s\', %d, %d, \'%s\')',
+            $when->format('Y-m-d H:i:s'),
+            $userId,
+            $type,
+            mysqli_real_escape_string($GLOBALS['conn'], $msg)
+        );
+    }
+    $sqlBatch = 'INSERT INTO '.$table.' (`Timestamp`, `User`, `Type`, `Message`) VALUES '.implode(',', $values);
+    if(!mysqli_query($GLOBALS['conn'], $sqlBatch)) {
+        mysqli_rollback($GLOBALS['conn']);
+        fwrite(STDERR, mysqli_error($GLOBALS['conn'])."\n");
+        exit(1);
+    }
+    $inserted += $n;
+    fwrite(STDOUT, "Filler: {$inserted}/{$fillerCount}\r");
+}
+
+mysqli_commit($GLOBALS['conn']);
+fwrite(STDOUT, "\n");
+
+$check = mysqli_query(
+    $GLOBALS['conn'],
+    "SELECT COUNT(*) AS c FROM {$table} WHERE `Message` LIKE '%Adventskonzert 2019%'"
+);
+$adventCount = $check ? (int)mysqli_fetch_assoc($check)['c'] : 0;
+$total = mysqli_query($GLOBALS['conn'], "SELECT COUNT(*) AS c FROM {$table}");
+$totalC = $total ? (int)mysqli_fetch_assoc($total)['c'] : 0;
+
+printf(
+    "OK: %d Adventskonzert-Zeilen, %d Filler, Log gesamt jetzt %d.\nSuche in der UI: Adventskonzert 2019\nLöschen: php scripts/seedLogSearchFixture.php --delete\n",
+    $adventCount,
+    $inserted,
+    $totalC
+);

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -157,7 +157,7 @@ $sections[] = array(
     'visible' => isAdmin() && requirePermission('perm_showUsers'),
     'body' => '
 <ul class="help-list">
-<li><b>Personenliste</b> – alle Nutzer an einem Ort; die Liste lädt beim Scrollen nach, Sortier-Chips sortieren serverseitig (Standard: Register-Prio), Suche und Filter-Chips (Aktive/Gäste, Mitglieder/Nicht-Mitglieder, Register) filtern die bereits geladenen Einträge (bei aktiver Filterung wird weiter nachgeladen). Klick öffnet Details im Modal. Zeilen in Registerfarbe; Instrument, Gruppen und Rechte als Chips (Rechte über Gruppe gestrichelt). Orchestergrafik ist aufklappbar (standardmäßig offen)</li>
+<li><b>Personenliste</b> – alle Nutzer an einem Ort; die Liste lädt beim Scrollen nach, Sortier-Chips sortieren serverseitig (Standard: Register-Prio), Suche (mehrere Wörter = UND) und Filter-Chips (Aktive/Gäste, Mitglieder/Nicht-Mitglieder, Register) filtern die bereits geladenen Einträge (bei aktiver Filterung wird weiter nachgeladen). Klick öffnet Details im Modal. Zeilen in Registerfarbe; Instrument, Gruppen und Rechte als Chips (Rechte über Gruppe gestrichelt). Orchestergrafik ist aufklappbar (standardmäßig offen)</li>
 '.(requirePermission('perm_editUsers') ? '<li><b>Musiker anlegen</b> – Person anlegen inkl. Benachrichtigungen, Haken <b>aktiv</b> (aus = Gastmusiker), Mitglied-Status, Instrument, Gruppen-Chips und Rechte (persönlich editierbar; über Gruppen vererbte Rechte erscheinen mit gestricheltem Rahmen und sind hier nicht entfernbar); <b>Deaktivieren</b> setzt Gastmusiker; <b>Löschen</b> prüft zuerst Inventar (Eigentum/aktive Ausleihe blockiert das Löschen mit Hinweis), entfernt danach zukünftige Meldungen/Schichtmeldungen und soft-löscht die Person – zurückliegende Meldungen bleiben für Statistik/Archiv; <b>Automatisch</b> zeigt die abgeleitete Zugehörigkeit</li>' : '').'
 '.(requirePermission('perm_editUsers') && !empty($optionsDB['urlNotenarchiv']) ? '<li><b>Stimme / Fallbacks</b> – primäre Stimme und Fallback-Instrumente für das Notenarchiv (Stimmsatz); Priorität zuerst Primär, dann Fallbacks in Reihenfolge; im Profil verlinkt oder <code>user-voice.php</code></li>' : '').'
 </ul>
@@ -224,7 +224,7 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 '.(requirePermission('perm_showInventories') ? '
-<li><b>Inventar</b> – Vereinsbesitz (Bestände, Details und Ausleihen); die Liste lädt beim Scrollen nach, Sortier-Chips sortieren serverseitig, Suche und Chip <b>Versichert</b> filtern die bereits geladenen Einträge (bei aktiver Filterung wird weiter nachgeladen); Klick öffnet Details im Modal; „Übersicht für Versicherung“ öffnet eine druck-/PDF-fähige Tabelle (Spalten per Checkbox wählen, dann kopieren oder als PDF speichern)</li>
+<li><b>Inventar</b> – Vereinsbesitz (Bestände, Details und Ausleihen); die Liste lädt beim Scrollen nach, Sortier-Chips sortieren serverseitig, Suche (mehrere Wörter = UND, z. B. <code>marsch Ralf</code>) und Chip <b>Versichert</b> filtern die bereits geladenen Einträge (bei aktiver Filterung wird weiter nachgeladen); Klick öffnet Details im Modal; „Übersicht für Versicherung“ öffnet eine druck-/PDF-fähige Tabelle (Spalten per Checkbox wählen, dann kopieren oder als PDF speichern)</li>
 ' : '').'
 '.(requirePermission('perm_editInventories') ? '
 <li><b>Inventar anlegen</b> – neue Stücke über die eigene Seite (Plus in der Inventarliste oder Admin → Inventar anlegen)</li>
@@ -264,7 +264,7 @@ $sections[] = array(
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Statistik</b> – Auswertungen; auf breiten Bildschirmen Diagramme und Listen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>). Ranking und Inaktive teilen sich denselben Chip-Filter wie die Personenliste (Aktive/Gäste/Mitglieder, Register, Gruppen) und nutzen denselben Zeilen-Stil inkl. Sortier-Chips</li>
-<li><b>Log</b> – Anwendungsprotokoll (Filter, Live-Aktualisierung); Chunk-Größe für Scroll und Live-Nachladen über <code>logListChunkSize</code></li>
+<li><b>Log</b> – Anwendungsprotokoll (Suche serverseitig; mehrere Wörter = UND, z. B. <code>ERROR Meier</code>; Live-Aktualisierung); Chunk-Größe für Scroll und Live-Nachladen über <code>logListChunkSize</code></li>
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '
 <li><b>Backup</b> – Datenbank-ZIP herunterladen (inkl. Versionsinfo) oder wieder einspielen; im Browser über <code>Backup</code>, per CLI mit <code>php cron.php CRONID backup</code>; automatisiert remote nur mit eigenem <code>$backupToken</code> in <code>config.php</code> (mind. 32 Zeichen) über <code>cron.php?id=…&amp;cmd=backup</code> — nicht mit dem allgemeinen Cron-ID. Erfolgreiche Downloads erscheinen im <b>Log</b> als Info, fehlgeschlagene als Fehler</li>


### PR DESCRIPTION
## Summary
- Log-Suche serverseitig (`q` in `listChunkLog`/`getList`); Scroll lädt gefilterte Chunks
- Mehrwort-UND (MELD-179) für Log und Client-Listenfilter (`listRowMatchesQuery`)
- Hilfe + Seed-Skript für lokale Suchtests; Tests in meldeliste-tests

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-189 · https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-179

## Test plan
- [ ] Log: Suche `Adventskonzert 2019` findet Seed-Einträge unter ~12k Zeilen
- [ ] Log: `Adventskonzert Ralf` = UND; leeres Feld = normale Chronik
- [ ] Inventar: `marsch Name` filtert geladene Zeilen mit UND
- [ ] `composer test -- --filter ListChunkLogTest` grün