### PR TITLE
MELD-167: klickbare Entity-Chips (User, Termin, Inventar, Email)

### DIFF
--- a/.cursor/rules/ui-chips.mdc
+++ b/.cursor/rules/ui-chips.mdc
@@ -1,0 +1,42 @@
+---
+description: Chip-Darstellung (mail-recipient-chip) und klickbare Entities
+alwaysApply: true
+---
+
+# UI-Chips
+
+## Basis (MELD-60)
+
+Wiederverwendetes Chip-System in `styles/custom.css`:
+
+- Container: `mail-recipient-chips` (flex, wrap, gap)
+- Chip: `mail-recipient-chip` (+ optional `profile-perm-tile` teilt Basisstil)
+- Typ-Modifier (Farben):
+  - `--user` — Person
+  - `--termin` — Termin
+  - `--namedGroup` / `--mailGroup` — Gruppe
+  - `--register` — Register
+  - `--instrument` — Instrument / Inventar-Bezug
+  - `--insured` / `--loaned` — Inventar-Status
+  - `--guestMusician` / `--member` / `--nomember` / `--audience` / `--group`
+
+Chips für Labels und Auswahl (Mail-Verteiler, Profil-Gruppen, Inventar-Status). Keine neuen Chip-Familien ohne Not — bestehende Modifier nutzen.
+
+## Klickbare Entities (MELD-167)
+
+Wo ein verwaltetes Objekt referenziert wird und ein Detail-Modal existiert:
+
+1. PHP: `entityOpenHtml($type, $id, $label)` (`libs/helpers.php`)
+2. Markup: `mail-recipient-chip mail-recipient-chip--{mod} entity-open` + `data-entity-type` / `data-entity-id`
+3. Mapping: `user`→`--user`, `termin`→`--termin`, `inventar`→`--instrument`, `mail`→`--mailGroup`
+4. Klick: Event-Delegation (capture) in `js/modal.js` auf `.entity-open` → `openModal` (async XHR + Cache)
+5. Optionaler 4. Parameter: Chip-Modifier-Override (z. B. `guestMusician` bei User-Modal)
+6. Kein Modal-HTML in Listen/Log-Chunks; kein Prefetch beim Rendern; kein Inline-`onclick` pro Zeile
+
+## Log-Payload
+
+Beim Anzeigen: `logMessageLinkEntities()` wandelt bekannte Fragmente (`Termin: (id) <b>…</b>`, `User: (id) …`, `User: <b>Name</b>` per Melde-ID/Namensauflösung, `Inventory: (id) <b>…</b>`, `Email-ID: <b>N</b>` / `Email: (id) <b>…</b>`) in Entity-Chips um — nur Anzeige, Speicherung unverändert. Neue Melde-Logs schreiben `User: (id) <b>…</b>`.
+
+- Unterstrichene Textlinks statt Chips für Entity-Referenzen
+- Modal-Inhalt in Listenzeilen einbetten
+- Neue Chip-Farbfamilien erfinden, wenn ein Modifier passt

--- a/getModal.php
+++ b/getModal.php
@@ -125,6 +125,23 @@ case 'inventory': // alias
     }
     break;
 
+case 'mail':
+    if(!requirePermission('perm_sendEmail')) {
+        http_response_code(403);
+        echo '<div class="w3-container w3-padding"><p>Keine Berechtigung.</p><button class="w3-button" onclick="closeModal()">Schließen</button></div>';
+        exit;
+    }
+    MailJob::ensureSchema();
+    $job = new MailJob;
+    $job->load_by_id($id);
+    if(!(int)$job->Index) {
+        http_response_code(404);
+        echo '<div class="w3-container w3-padding"><p>Email nicht gefunden.</p><button class="w3-button" onclick="closeModal()">Schließen</button></div>';
+        exit;
+    }
+    echo $job->getModalHtml();
+    break;
+
 default:
     http_response_code(400);
     echo '<div class="w3-container w3-padding"><p>Unbekannter Modal-Typ.</p></div>';

--- a/js/modal.js
+++ b/js/modal.js
@@ -59,13 +59,45 @@ document.addEventListener('keydown', function(e) {
 });
 
 /**
+ * MELD-167: Entity chips (.entity-open) open detail modals asynchronously.
+ * Markup carries data-entity-type / data-entity-id only — no inline modal HTML.
+ */
+function openEntityFromEl(el) {
+    if(!el) return false;
+    var type = el.getAttribute('data-entity-type') || '';
+    var id = parseInt(el.getAttribute('data-entity-id'), 10);
+    if(!type || !(id > 0)) return false;
+    if(type === 'inventory') type = 'inventar';
+    if(type !== 'user' && type !== 'termin' && type !== 'inventar' && type !== 'mail') return false;
+    openModal(type, id);
+    return true;
+}
+
+document.addEventListener('click', function(e) {
+    var ent = e.target.closest ? e.target.closest('.entity-open') : null;
+    if(!ent) return;
+    e.preventDefault();
+    e.stopPropagation();
+    openEntityFromEl(ent);
+}, true);
+
+document.addEventListener('keydown', function(e) {
+    if(e.key !== 'Enter' && e.key !== ' ') return;
+    var ent = e.target.closest ? e.target.closest('.entity-open') : null;
+    if(!ent || e.target !== ent) return;
+    e.preventDefault();
+    e.stopPropagation();
+    openEntityFromEl(ent);
+}, true);
+
+/**
  * Melde-Zeile (Hauptseite): Klick auf die Karte öffnet Termin-Modal.
  * Buttons/Formulare mit [data-melde-stop] bleiben ausgenommen.
  */
 document.addEventListener('click', function(e) {
     var row = e.target.closest ? e.target.closest('.melde-row[data-termin-id]') : null;
     if(!row) return;
-    if(e.target.closest && e.target.closest('[data-melde-stop], button, a, input, select, textarea, label, form')) {
+    if(e.target.closest && e.target.closest('[data-melde-stop], .entity-open, button, a, input, select, textarea, label, form')) {
         return;
     }
     var id = parseInt(row.getAttribute('data-termin-id'), 10);

--- a/libs/audienceSpec.php
+++ b/libs/audienceSpec.php
@@ -791,18 +791,21 @@ class AudienceSpec
                 $label = $u->getName();
                 if((int)$u->Active === 0) {
                     $label = 'Gast: '.$label;
-                    $chips[] = array('type' => 'guestMusician', 'label' => $label);
+                    $chips[] = array('type' => 'guestMusician', 'label' => $label, 'entityType' => 'user', 'entityId' => (int)$u->Index);
                 }
                 else {
-                    $chips[] = array('type' => 'user', 'label' => $label);
+                    $chips[] = array('type' => 'user', 'label' => $label, 'entityType' => 'user', 'entityId' => (int)$u->Index);
                 }
             }
         }
         if($allowTermine) {
             foreach($norm['termine'] as $tid) {
+                $tid = (int)$tid;
                 $chips[] = array(
                     'type' => 'termin',
-                    'label' => self::terminParticipantLabel((int)$tid),
+                    'label' => self::terminParticipantLabel($tid),
+                    'entityType' => 'termin',
+                    'entityId' => $tid,
                 );
             }
         }
@@ -826,9 +829,18 @@ class AudienceSpec
         $aria = isset($opts['ariaLabel']) ? (string)$opts['ariaLabel'] : 'Auswahl';
         $html = '<div class="mail-recipient-chips" aria-label="'.htmlspecialchars($aria, ENT_QUOTES, 'UTF-8').'">';
         foreach($chips as $chip) {
-            $type = htmlspecialchars((string)$chip['type'], ENT_QUOTES, 'UTF-8');
-            $label = htmlspecialchars((string)$chip['label'], ENT_QUOTES, 'UTF-8');
-            $html .= '<span class="mail-recipient-chip mail-recipient-chip--'.$type.'">'.$label.'</span>';
+            $type = (string)$chip['type'];
+            $label = (string)$chip['label'];
+            $entityType = isset($chip['entityType']) ? (string)$chip['entityType'] : '';
+            $entityId = isset($chip['entityId']) ? (int)$chip['entityId'] : 0;
+            if($entityId > 0 && $entityType !== '' && function_exists('entityOpenHtml')) {
+                $html .= entityOpenHtml($entityType, $entityId, $label, $type);
+            }
+            else {
+                $html .= '<span class="mail-recipient-chip mail-recipient-chip--'
+                    .htmlspecialchars($type, ENT_QUOTES, 'UTF-8').'">'
+                    .htmlspecialchars($label, ENT_QUOTES, 'UTF-8').'</span>';
+            }
         }
         $html .= '</div>';
         return $html;

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -475,6 +475,356 @@ function getOwner($index) {
     return $user->getName();
 }
 
+/**
+ * Clickable entity chip (MELD-167). Markup only — modal loads async via openModal.
+ *
+ * @param string $type user|termin|inventar
+ * @param int $id
+ * @param string $label
+ * @param string $chipMod Optional visual modifier (default from type map)
+ * @return string HTML (escaped label); plain escaped text if type/id invalid
+ */
+function entityOpenHtml($type, $id, $label, $chipMod = '') {
+    $type = strtolower(trim((string)$type));
+    if($type === 'inventory') {
+        $type = 'inventar';
+    }
+    $id = (int)$id;
+    $label = trim((string)$label);
+    $h = function ($s) {
+        return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
+    };
+    if($label === '') {
+        return '';
+    }
+    $chipMods = array(
+        'user' => 'user',
+        'termin' => 'termin',
+        'inventar' => 'instrument',
+        'mail' => 'mailGroup',
+    );
+    if($id < 1 || !isset($chipMods[$type])) {
+        return $h($label);
+    }
+    $mod = trim((string)$chipMod);
+    if($mod === '' || !preg_match('/^[a-zA-Z][a-zA-Z0-9_-]*$/', $mod)) {
+        $mod = $chipMods[$type];
+    }
+    return '<span class="mail-recipient-chip mail-recipient-chip--'.$mod.' entity-open"'
+        .' role="button" tabindex="0"'
+        .' data-entity-type="'.$h($type).'"'
+        .' data-entity-id="'.$id.'">'
+        .$h($label)
+        .'</span>';
+}
+
+/**
+ * Resolve user id for legacy log fragments "User: <b>Name</b>" (no id).
+ * Prefers Melde-ID in the same message (Meldung vs Schichtmeldung).
+ *
+ * @return int 0 if unknown
+ */
+function logResolveUserIdFromMessage($html, $nameHint = '') {
+    $html = (string)$html;
+    $nameHint = trim((string)$nameHint);
+    if(preg_match('/\bMelde-ID:\s*(\d+)/i', $html, $m)) {
+        $mid = (int)$m[1];
+        if($mid > 0) {
+            if(stripos($html, 'Schicht/Aufgabe:') !== false && class_exists('Shiftmeldung')) {
+                $sm = new Shiftmeldung;
+                $sm->load_by_id($mid);
+                if((int)$sm->Index === $mid && (int)$sm->User > 0) {
+                    return (int)$sm->User;
+                }
+            }
+            if(class_exists('Meldung')) {
+                $melde = new Meldung;
+                $melde->load_by_id($mid);
+                if((int)$melde->Index === $mid && (int)$melde->User > 0) {
+                    return (int)$melde->User;
+                }
+            }
+            if(class_exists('Shiftmeldung')) {
+                $sm = new Shiftmeldung;
+                $sm->load_by_id($mid);
+                if((int)$sm->Index === $mid && (int)$sm->User > 0) {
+                    return (int)$sm->User;
+                }
+            }
+        }
+    }
+    if($nameHint === '' || !isset($GLOBALS['conn']) || !isset($GLOBALS['dbprefix'])) {
+        return 0;
+    }
+    // Unique Vorname+Nachname match (legacy fallback)
+    $parts = preg_split('/\s+/u', $nameHint, 2);
+    if(!is_array($parts) || count($parts) < 2) {
+        return 0;
+    }
+    $sql = sprintf(
+        'SELECT `Index` FROM `%sUser` WHERE `Vorname` = "%s" AND `Nachname` = "%s" AND `Deleted` != 1 LIMIT 2;',
+        $GLOBALS['dbprefix'],
+        mysqli_real_escape_string($GLOBALS['conn'], $parts[0]),
+        mysqli_real_escape_string($GLOBALS['conn'], $parts[1])
+    );
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    if(!$dbr) {
+        return 0;
+    }
+    $ids = array();
+    while($row = mysqli_fetch_array($dbr)) {
+        $ids[] = (int)$row['Index'];
+    }
+    return count($ids) === 1 ? $ids[0] : 0;
+}
+
+/**
+ * Enrich stored log HTML with entity chips (MELD-167).
+ * Matches common "Label: (id) <b>name</b>" fragments; safe to run on each display.
+ *
+ * @param string $html Log.Message (may already contain <b> etc.)
+ * @return string
+ */
+function logMessageLinkEntities($html) {
+    $html = (string)$html;
+    if($html === '' || !function_exists('entityOpenHtml')) {
+        return $html;
+    }
+    // Skip if already enriched (avoid nested chips on re-process)
+    if(strpos($html, 'entity-open') !== false && strpos($html, 'data-entity-type') !== false) {
+        return $html;
+    }
+
+    $source = $html;
+    $plainLabel = function ($raw) {
+        $t = trim(html_entity_decode(strip_tags((string)$raw), ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        return preg_replace('/\s+/u', ' ', $t);
+    };
+    $chip = function ($type, $id, $labelRaw) use ($plainLabel) {
+        $label = $plainLabel($labelRaw);
+        if($label === '') {
+            $label = '#'.(int)$id;
+        }
+        return entityOpenHtml($type, (int)$id, $label);
+    };
+
+    // Termin: (12) <b>Probe</b>
+    $html = preg_replace_callback(
+        '/\bTermin:\s*\((\d+)\)\s*<b>(.*?)<\/b>/si',
+        function ($m) use ($chip) {
+            return 'Termin: '.$chip('termin', $m[1], $m[2]);
+        },
+        $html
+    );
+
+    // Legacy termin edit: Termin-ID: 6, <b>Probe</b>
+    $html = preg_replace_callback(
+        '/\bTermin-ID:\s*(\d+)\s*,\s*<b>(.*?)<\/b>/si',
+        function ($m) use ($chip) {
+            return 'Termin-ID: '.$chip('termin', $m[1], $m[2]);
+        },
+        $html
+    );
+
+    // Legacy insert-ish: Termin-ID: <b>6</b> (id only in bold)
+    $html = preg_replace_callback(
+        '/\bTermin-ID:\s*<b>(\d+)<\/b>/si',
+        function ($m) use ($chip) {
+            return 'Termin-ID: '.$chip('termin', $m[1], 'Termin #'.$m[1]);
+        },
+        $html
+    );
+
+    // Inventory: (9) <b>Marsch</b> optional RegNumber… (loan / edit with both headers)
+    $html = preg_replace_callback(
+        '/\bInventory:\s*\((\d+)\)\s*<b>(.*?)<\/b>(?:\s*([^,<]*?))?(?=(?:\s*&rArr;|\s*,|\s*$))/si',
+        function ($m) use ($chip, $plainLabel) {
+            $extra = isset($m[3]) ? $plainLabel($m[3]) : '';
+            $label = $plainLabel($m[2]);
+            if($extra !== '') {
+                $label = trim($label.' '.$extra);
+            }
+            return 'Inventory: '.$chip('inventar', $m[1], $label);
+        },
+        $html
+    );
+
+    // Drop redundant Inventory-ID: N, when Inventory: chip already follows
+    $html = preg_replace('/\bInventory-ID:\s*\d+\s*,\s*(?=Inventory:)/i', '', $html);
+
+    // Legacy inventory edit header: Inventory-ID: 4, <b>Flöte</b> INSTR-001 → Inventory: chip
+    $html = preg_replace_callback(
+        '/\bInventory-ID:\s*(\d+)\s*,\s*<b>(.*?)<\/b>(?:\s*([^,<]*?))?(?=,|$)/si',
+        function ($m) use ($chip, $plainLabel) {
+            $extra = isset($m[3]) ? $plainLabel($m[3]) : '';
+            $label = $plainLabel($m[2]);
+            if($extra !== '') {
+                $label = trim($label.' '.$extra);
+            }
+            if($label === '') {
+                $label = '#'.$m[1];
+            }
+            return 'Inventory: '.$chip('inventar', $m[1], $label);
+        },
+        $html
+    );
+
+    // Legacy insert: Inventory-ID: N … Inventory: <b>name</b> (no id on Inventory:)
+    if(preg_match('/\bInventory-ID:\s*(\d+)/i', $source, $im)) {
+        $invId = (int)$im[1];
+        if($invId > 0) {
+            $html = preg_replace_callback(
+                '/\bInventory:\s*<b>(.*?)<\/b>/si',
+                function ($m) use ($chip, $invId) {
+                    return 'Inventory: '.$chip('inventar', $invId, $m[1]);
+                },
+                $html
+            );
+            $html = preg_replace('/\bInventory-ID:\s*'.$invId.'\s*,\s*(?=Inventory:)/i', '', $html);
+        }
+    }
+
+    // User: (5) <b>Name</b>
+    $html = preg_replace_callback(
+        '/\bUser:\s*\((\d+)\)\s*<b>(.*?)<\/b>/si',
+        function ($m) use ($chip) {
+            return 'User: '.$chip('user', $m[1], $m[2]);
+        },
+        $html
+    );
+
+    // Drop redundant User-ID: N, when User: chip already follows
+    $html = preg_replace('/\bUser-ID:\s*\d+\s*,\s*(?=User:)/i', '', $html);
+
+    // User-ID: 9 <b>Name</b> → User: chip
+    $html = preg_replace_callback(
+        '/\bUser-ID:\s*(\d+)\s*,?\s*<b>(.*?)<\/b>/si',
+        function ($m) use ($chip) {
+            return 'User: '.$chip('user', $m[1], $m[2]);
+        },
+        $html
+    );
+
+    // User-ID: <b>2</b> → User: #2
+    $html = preg_replace_callback(
+        '/\bUser-ID:\s*<b>(\d+)<\/b>/si',
+        function ($m) use ($chip) {
+            return 'User: '.$chip('user', $m[1], '#'.$m[1]);
+        },
+        $html
+    );
+
+    // Create-style: User-ID: 34, Vorname/Nachname → User: chip; drop duplicate name fields
+    $userCreateLinked = false;
+    $html = preg_replace_callback(
+        '/\bUser-ID:\s*(\d+)(?=\s*,)/si',
+        function ($m) use ($chip, $plainLabel, $source, &$userCreateLinked) {
+            $label = '';
+            if(preg_match('/\bVorname:\s*<b>(.*?)<\/b>/si', $source, $v)
+                && preg_match('/\bNachname:\s*<b>(.*?)<\/b>/si', $source, $n)) {
+                $label = trim($plainLabel($v[1]).' '.$plainLabel($n[1]));
+            }
+            if($label === '') {
+                $label = '#'.$m[1];
+            }
+            else {
+                $userCreateLinked = true;
+            }
+            return 'User: '.$chip('user', $m[1], $label);
+        },
+        $html
+    );
+    if($userCreateLinked) {
+        $html = preg_replace('/,?\s*Vorname:\s*<b>.*?<\/b>/si', '', $html, 1);
+        $html = preg_replace('/,?\s*Nachname:\s*<b>.*?<\/b>/si', '', $html, 1);
+    }
+
+    // Email: (23) <b>Betreff</b>
+    $html = preg_replace_callback(
+        '/\bEmail:\s*\((\d+)\)\s*<b>(.*?)<\/b>/si',
+        function ($m) use ($chip) {
+            return 'Email: '.$chip('mail', $m[1], $m[2]);
+        },
+        $html
+    );
+
+    // Email-ID: <b>23</b> → Email: chip (Betreff as label when present; drop duplicate Betreff field)
+    $emailBetreff = '';
+    if(preg_match('/\bBetreff:\s*<b>(.*?)<\/b>/si', $source, $eb)) {
+        $emailBetreff = $plainLabel($eb[1]);
+    }
+    $emailIdLinked = false;
+    $html = preg_replace_callback(
+        '/\bEmail-ID:\s*<b>(\d+)<\/b>/si',
+        function ($m) use ($chip, $emailBetreff, &$emailIdLinked) {
+            $emailIdLinked = true;
+            $label = $emailBetreff !== '' ? $emailBetreff : ('#'.$m[1]);
+            return 'Email: '.$chip('mail', $m[1], $label);
+        },
+        $html
+    );
+    if($emailIdLinked && $emailBetreff !== '') {
+        $html = preg_replace('/,?\s*Betreff:\s*<b>.*?<\/b>/si', '', $html, 1);
+    }
+
+    // Eigentümer: (5) <b>Name</b>
+    $html = preg_replace_callback(
+        '/\bEigentümer:\s*\((\d+)\)\s*<b>(.*?)<\/b>/si',
+        function ($m) use ($chip) {
+            return 'Eigentümer: '.$chip('user', $m[1], $m[2]);
+        },
+        $html
+    );
+
+    // Eigentümer: (5) PlainName &rArr;
+    $html = preg_replace_callback(
+        '/\bEigentümer:\s*\((\d+)\)\s+(?!<)([^,<]+?)(?=\s*&rArr;|\s*,|\s*$)/si',
+        function ($m) use ($chip) {
+            return 'Eigentümer: '.$chip('user', $m[1], $m[2]);
+        },
+        $html
+    );
+
+    // User: (5) PlainName  (change-log without <b> on old value)
+    $html = preg_replace_callback(
+        '/\bUser:\s*\((\d+)\)\s+(?!<)([^,<]+?)(?=\s*&rArr;|\s*,|\s*$)/si',
+        function ($m) use ($chip) {
+            return 'User: '.$chip('user', $m[1], $m[2]);
+        },
+        $html
+    );
+
+    // Legacy Melde-Logs: User: <b>Name</b> (no id) — resolve via Melde-ID / unique name
+    $html = preg_replace_callback(
+        '/\bUser:\s*<b>(.*?)<\/b>/si',
+        function ($m) use ($chip, $plainLabel, $source) {
+            $label = $plainLabel($m[1]);
+            // Bold may contain "(id) Name" from change arrows
+            if(preg_match('/^\((\d+)\)\s*(.*)$/s', $label, $im)) {
+                $rest = trim($im[2]);
+                return 'User: '.$chip('user', $im[1], $rest !== '' ? $rest : $label);
+            }
+            $uid = logResolveUserIdFromMessage($source, $label);
+            if($uid > 0) {
+                return 'User: '.$chip('user', $uid, $label);
+            }
+            return $m[0];
+        },
+        $html
+    );
+
+    // Eigentümer: <b>(id) Name</b> (arrow target)
+    $html = preg_replace_callback(
+        '/\bEigentümer:\s*<b>\((\d+)\)\s*(.*?)<\/b>/si',
+        function ($m) use ($chip) {
+            return 'Eigentümer: '.$chip('user', $m[1], $m[2]);
+        },
+        $html
+    );
+
+    return $html;
+}
+
 function getPage($string, $groupId = '') {
     if($string == $_SESSION['page']) {
         echo $GLOBALS['optionsDB']['colorTitleBar'];

--- a/libs/inventories.php
+++ b/libs/inventories.php
@@ -104,7 +104,8 @@ class Inventories
         $family = $this->getInstrumentName();
         if($family !== '') $typeName = $family;
 
-        $str = sprintf('Inventory-ID: %d, <b>%s</b> %s',
+        $str = sprintf('Inventory-ID: %d, Inventory: (%d) <b>%s</b> %s',
+            (int)$this->Index,
             (int)$this->Index,
             $typeName,
             RegNumber::displayInventory($this->Inventory, $this->RegNumber)
@@ -122,7 +123,10 @@ class Inventories
         if($this->SerialNr != $old->SerialNr) $str .= ', Seriennummer: '.$old->SerialNr.' &rArr; <b>'.$this->SerialNr.'</b>';
         if($this->PurchaseDate != $old->PurchaseDate) $str .= ', Kaufdatum: '.germanDate($old->PurchaseDate,0).' &rArr; <b>'.germanDate($this->PurchaseDate,0).'</b>';
         if($this->PurchasePrize != $old->PurchasePrize) $str .= ', Kaufpreis: '.mkPrize($old->PurchasePrize).' &rArr; <b>'.mkPrize($this->PurchasePrize).'</b>';
-        if($this->Owner != $old->Owner) $str .= ', Eigentümer: '.getOwner((int)$old->Owner).' &rArr; <b>'.getOwner((int)$this->Owner).'</b>';
+        if($this->Owner != $old->Owner) {
+            $str .= ', Eigentümer: ('.(int)$old->Owner.') '.getOwner((int)$old->Owner)
+                .' &rArr; <b>('.((int)$this->Owner).') '.getOwner((int)$this->Owner).'</b>';
+        }
         if(boolsDiffer($this->Insurance, $old->Insurance)) $str .= ', Versichert: '.bool2string($old->Insurance).' &rArr; <b>'.bool2string($this->Insurance).'</b>';
         if($this->Comment != $old->Comment) $str .= ', Kommentar: '.$old->Comment.' &rArr; <b>'.$this->Comment.'</b>';
         return $str;
@@ -142,7 +146,7 @@ class Inventories
 
         $parts = array();
         $parts[] = sprintf('Inventory-ID: %d', (int)$this->Index);
-        $parts[] = logPart('Inventory', $typeName);
+        $parts[] = sprintf('Inventory: (%d) <b>%s</b>', (int)$this->Index, $typeName);
         $parts[] = logPart('Inventarnummer', RegNumber::displayInventory($this->Inventory, $this->RegNumber));
         logAppendFilled($parts, 'Beschreibung', $this->Description, (string)$this->Description);
         logAppendFilled($parts, 'Hersteller', $this->Vendor, (string)$this->Vendor);
@@ -153,7 +157,7 @@ class Inventories
         $prize = mkPrize($this->PurchasePrize);
         logAppendFilled($parts, 'Kaufpreis', $prize, (string)$prize);
         if((int)$this->Owner > 0) {
-            $parts[] = logPart('Eigentümer', getOwner((int)$this->Owner));
+            $parts[] = sprintf('Eigentümer: (%d) <b>%s</b>', (int)$this->Owner, getOwner((int)$this->Owner));
         }
         logAppendTrue($parts, 'Versichert', $this->Insurance);
         logAppendFilled($parts, 'Kommentar', $this->Comment, (string)$this->Comment);
@@ -312,10 +316,18 @@ class Inventories
         $showAdminCols = requirePermission('perm_showInventories');
         $insured = !empty($row['Insurance']) || !empty($this->Insurance);
         $typLabel = !empty($row['instName']) ? $row['instName'] : $row['iTyp'];
+        $ownerId = (int)$row['Owner'];
+        $ownerName = trim((string)getOwner($ownerId));
+        $loanUserId = 0;
         $loanShort = (string)($this->getActiveLoanNameShort() ?? '');
         $loanFull = (string)($this->getActiveLoanName() ?? '');
         $loanDate = (string)($this->getActiveLoanDate() ?? '');
-        $ownerName = trim((string)getOwner((int)$row['Owner']));
+        $activeLoanId = $this->getActiveLoan();
+        if($activeLoanId) {
+            $loanForUser = new InventoriesLoan;
+            $loanForUser->load_by_id($activeLoanId);
+            $loanUserId = (int)$loanForUser->User;
+        }
         $regDisplay = RegNumber::displayInventory($row['Inventory'], $row['RegNumber']);
         $desc = trim((string)$row['Description']);
         $comment = trim((string)$row['Comment']);
@@ -347,13 +359,8 @@ class Inventories
         }
         $viewerId = isset($_SESSION['userid']) ? (int)$_SESSION['userid'] : 0;
         $loanedToViewer = false;
-        if($viewerId > 0 && (int)$this->Owner !== $viewerId) {
-            $activeLoanId = $this->getActiveLoan();
-            if($activeLoanId) {
-                $activeLoan = new InventoriesLoan;
-                $activeLoan->load_by_id($activeLoanId);
-                $loanedToViewer = ((int)$activeLoan->User === $viewerId);
-            }
+        if($viewerId > 0 && $ownerId !== $viewerId && $loanUserId === $viewerId) {
+            $loanedToViewer = true;
         }
         if($loanedToViewer) {
             $classes[] = 'inv-row--loaned';
@@ -411,7 +418,10 @@ class Inventories
         }
         $meta = array();
         if($ownerName !== '') {
-            $meta[] = '<span class="inv-meta-item"><span class="inv-meta-k">Eigentümer</span> '.$h($ownerName).'</span>';
+            $ownerHtml = ($ownerId > 0 && function_exists('entityOpenHtml'))
+                ? entityOpenHtml('user', $ownerId, $ownerName)
+                : $h($ownerName);
+            $meta[] = '<span class="inv-meta-item"><span class="inv-meta-k">Eigentümer</span> '.$ownerHtml.'</span>';
         }
         if($comment !== '') {
             $meta[] = '<span class="inv-meta-item"><span class="inv-meta-k">Kommentar</span> '.$h($comment).'</span>';
@@ -420,15 +430,20 @@ class Inventories
             $loanLabel = $loanDate !== '' ? 'seit '.$h($loanDate) : 'aktiv';
             $meta[] = '<span class="inv-meta-item"><span class="inv-meta-k">Ausleihe</span> '.$loanLabel.'</span>';
         }
-        elseif($loanShort !== '' || $loanDate !== '') {
+        elseif($loanShort !== '' || $loanDate !== '' || $loanFull !== '') {
             $loanBits = array();
-            if($loanShort !== '') {
-                $loanBits[] = $h($loanShort);
+            $loanName = $loanShort !== '' ? $loanShort : $loanFull;
+            if($loanName !== '') {
+                $loanBits[] = ($loanUserId > 0 && function_exists('entityOpenHtml'))
+                    ? entityOpenHtml('user', $loanUserId, $loanName)
+                    : $h($loanName);
             }
             if($loanDate !== '') {
                 $loanBits[] = $h($loanDate);
             }
-            $meta[] = '<span class="inv-meta-item"><span class="inv-meta-k">Ausleihe</span> '.implode(' · ', $loanBits).'</span>';
+            if($loanBits) {
+                $meta[] = '<span class="inv-meta-item"><span class="inv-meta-k">Ausleihe</span> '.implode(' · ', $loanBits).'</span>';
+            }
         }
         if($showAdminCols) {
             if($purchaseDate !== '') {
@@ -579,7 +594,11 @@ class Inventories
         $info = new div;
         $info->indent = $indent + 2;
         $info->col(7, 12, 12);
-        $name = htmlspecialchars((string)$L->getName(), ENT_QUOTES, 'UTF-8');
+        $name = (string)$L->getName();
+        $loanUserId = (int)$L->User;
+        $nameHtml = ($loanUserId > 0 && function_exists('entityOpenHtml'))
+            ? entityOpenHtml('user', $loanUserId, $name)
+            : htmlspecialchars($name, ENT_QUOTES, 'UTF-8');
         $from = htmlspecialchars((string)germanDate($L->StartDate, 0), ENT_QUOTES, 'UTF-8');
         $until = $active
             ? '<span class="w3-tag w3-teal w3-round">offen</span>'
@@ -591,7 +610,7 @@ class Inventories
         if($hasLeihgebuehr) {
             $meta .= ' · Leihgebühr '.htmlspecialchars(LoanForm::formatAmount($L->Leihgebuehr), ENT_QUOTES, 'UTF-8');
         }
-        $info->body = '<div><b>'.$name.'</b></div>'
+        $info->body = '<div><b>'.$nameHtml.'</b></div>'
             .'<div class="w3-small" style="margin-top:4px;">'.$meta.'</div>';
         $str .= $info->print();
 

--- a/libs/listChunk.php
+++ b/libs/listChunk.php
@@ -732,8 +732,11 @@ function mailOutboxRenderListItemHtml(array $row, &$userNameCache = null) {
     $id = (int)$row['Index'];
     $unread = empty($row['ReadAt']);
     $when = htmlspecialchars(mailListFormatDate(isset($row['Created']) ? $row['Created'] : ''), ENT_QUOTES, 'UTF-8');
-    $senderName = mailListResolveUserName(isset($row['SenderId']) ? $row['SenderId'] : 0, $userNameCache);
-    $sender = htmlspecialchars($senderName, ENT_QUOTES, 'UTF-8');
+    $senderId = isset($row['SenderId']) ? (int)$row['SenderId'] : 0;
+    $senderName = mailListResolveUserName($senderId, $userNameCache);
+    $sender = ($senderId > 0 && function_exists('entityOpenHtml'))
+        ? entityOpenHtml('user', $senderId, $senderName)
+        : htmlspecialchars($senderName, ENT_QUOTES, 'UTF-8');
     $subject = (isset($row['Subject']) && $row['Subject'] !== '' && $row['Subject'] !== null)
         ? htmlspecialchars((string)$row['Subject'], ENT_QUOTES, 'UTF-8')
         : '<em>(ohne Betreff)</em>';

--- a/libs/log.php
+++ b/libs/log.php
@@ -239,8 +239,13 @@ class Log
         echo '</div>';
         echo '<div class="log-rail" aria-hidden="true"></div>';
         echo '<div class="log-main">';
-        echo '<div class="log-user">'.htmlspecialchars($userLabel, ENT_QUOTES, 'UTF-8').'</div>';
-        echo '<div class="log-message">'.$this->Message.'</div>';
+        if((int)$this->User > 0 && function_exists('entityOpenHtml')) {
+            echo '<div class="log-user">'.entityOpenHtml('user', (int)$this->User, $userLabel).'</div>';
+        }
+        else {
+            echo '<div class="log-user">'.htmlspecialchars($userLabel, ENT_QUOTES, 'UTF-8').'</div>';
+        }
+        echo '<div class="log-message">'.logMessageLinkEntities((string)$this->Message).'</div>';
         echo '</div>';
         echo '</div>';
     }

--- a/libs/mailJob.php
+++ b/libs/mailJob.php
@@ -710,7 +710,9 @@ class MailJob
                 $u->load_by_id($byId);
                 $userNameCache[$byId] = $u->Index ? $u->getName() : ('User '.$byId);
             }
-            $byName = htmlspecialchars($userNameCache[$byId], ENT_QUOTES, 'UTF-8');
+            $byName = function_exists('entityOpenHtml')
+                ? entityOpenHtml('user', $byId, $userNameCache[$byId])
+                : htmlspecialchars($userNameCache[$byId], ENT_QUOTES, 'UTF-8');
         }
         else {
             $byName = 'System';
@@ -811,6 +813,24 @@ class MailJob
             $list[] = $j;
         }
         return $list;
+    }
+
+    /**
+     * Compact email detail for ajaxModalHost (MELD-167 / log chips).
+     */
+    public function getModalHtml() {
+        $byId = (int)$this->CreatedBy;
+        $byName = 'System';
+        if($byId > 0) {
+            $byUser = new User;
+            $byUser->load_by_id($byId);
+            $byName = $byUser->Index ? $byUser->getName() : ('User '.$byId);
+        }
+        return render('mail/modal', array(
+            'job' => $this,
+            'byId' => $byId,
+            'byName' => $byName,
+        ));
     }
 
     public function statusLabel() {

--- a/libs/meldung.php
+++ b/libs/meldung.php
@@ -46,12 +46,13 @@ class Meldung
         $t = new Termin;
         $t->load_by_id($this->Termin);
 		$str = "";
-        $strGeneral = sprintf("Melde-ID: %d, Termin: (%d) <b>%s</b> %s %s, User: <b>%s</b>",
+        $strGeneral = sprintf("Melde-ID: %d, Termin: (%d) <b>%s</b> %s %s, User: (%d) <b>%s</b>",
         $this->Index,
         $this->Termin,
         $t->Name,
         medDate($t->Datum),
         sql2timeRaw($t->Uhrzeit),
+        (int)$this->User,
         $u->getName()
         );
         if($this->Wert != $old->Wert) $str.=meldeSymbol($this->Wert)." (vorher:".meldeWert($old->Wert)."), ";
@@ -87,13 +88,14 @@ class Meldung
         if($instrument == 0) $instrument = $u->Instrument;
         $instr = new Instrument;
         $instr->load_by_id($instrument);
-        $str = sprintf("%s Melde-ID: %d, Termin: (%d) <b>%s</b> %s %s, User: <b>%s</b>, Instrument: <b>%s</b>",
+        $str = sprintf("%s Melde-ID: %d, Termin: (%d) <b>%s</b> %s %s, User: (%d) <b>%s</b>, Instrument: <b>%s</b>",
         meldeSymbol($this->Wert),
         $this->Index,
         $this->Termin,
         $t->Name,
         medDate($t->Datum),
         sql2timeRaw($t->Uhrzeit),
+        (int)$this->User,
         $u->getName(),
         $instr->Name
         );

--- a/libs/shift.php
+++ b/libs/shift.php
@@ -168,7 +168,7 @@ class Shift
     public function getMeldungenUser($val) {
         $user = array();
         $sql = sprintf(
-            'SELECT u.`Vorname`, u.`Nachname`
+            'SELECT u.`Index`, u.`Vorname`, u.`Nachname`
              FROM `%sSchichtmeldung` m
              INNER JOIN `%sUser` u ON m.`User` = u.`Index`
              WHERE m.`Shift` = %d AND m.`Wert` = %d
@@ -182,7 +182,10 @@ class Shift
         sqlerror();
         if($dbr) {
             while($row = mysqli_fetch_array($dbr)) {
-                $user[] = trim($row['Vorname'].' '.$row['Nachname']);
+                $user[] = array(
+                    'userId' => (int)$row['Index'],
+                    'name' => trim($row['Vorname'].' '.$row['Nachname']),
+                );
             }
         }
         return $user;

--- a/libs/shiftmeldung.php
+++ b/libs/shiftmeldung.php
@@ -41,7 +41,7 @@ class Shiftmeldung
         $s->load_by_id($this->Shift);
         $t = new Termin;
         $t->load_by_id($s->Termin);
-        $str = sprintf("Melde-ID: %d, Termin: (%d) <b>%s</b>, Schicht/Aufgabe: (%d) <b>%s %s</b> %s, User: <b>%s</b>",
+        $str = sprintf("Melde-ID: %d, Termin: (%d) <b>%s</b>, Schicht/Aufgabe: (%d) <b>%s %s</b> %s, User: (%d) <b>%s</b>",
         $this->Index,
         $t->Index,
         $t->Name,
@@ -49,6 +49,7 @@ class Shiftmeldung
         $s->Name,
                        medDate($t->Datum),
         Shift::formatTimeLog($s->Start),
+        (int)$this->User,
         $u->getName()
         );
 
@@ -63,7 +64,7 @@ class Shiftmeldung
         $s->load_by_id($this->Shift);
         $t = new Termin;
         $t->load_by_id($s->Termin);
-        $str = sprintf("Melde-ID: %d, Termin: (%d) <b>%s</b>, Schicht/Aufgabe: (%d) <b>%s %s</b> %s, User: <b>%s</b>, Wert: <b>%s</b>",
+        $str = sprintf("Melde-ID: %d, Termin: (%d) <b>%s</b>, Schicht/Aufgabe: (%d) <b>%s %s</b> %s, User: (%d) <b>%s</b>, Wert: <b>%s</b>",
         $this->Index,
         $t->Index,
         $t->Name,
@@ -71,6 +72,7 @@ class Shiftmeldung
         $s->Name,
         medDate($t->Datum),
         Shift::formatTimeLog($s->Start),
+        (int)$this->User,
         $u->getName(),
         meldeSymbol($this->Wert)
         );

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -91,7 +91,8 @@ class Termin
         $old = new Termin;
         $old->load_by_id($this->Index);
         
-        $str = sprintf("Termin-ID: %d, <b>%s</b>",
+        $str = sprintf("Termin-ID: %d, Termin: (%d) <b>%s</b>",
+        $this->Index,
         $this->Index,
         $this->Name
         );
@@ -154,9 +155,9 @@ class Termin
             $this->vName = $row ? $row['Name'] : '';
         }
         $parts = array();
-        $parts[] = sprintf("Termin-ID: <b>%d</b>", $this->Index);
+        $parts[] = sprintf('Termin-ID: %d', (int)$this->Index);
         if($this->Name !== null && $this->Name !== '') {
-            $parts[] = sprintf("Name: <b>%s</b>", $this->Name);
+            $parts[] = sprintf('Termin: (%d) <b>%s</b>', (int)$this->Index, $this->Name);
         }
         $dateStr = $this->getDate();
         if($dateStr !== null && $dateStr !== '') {
@@ -2059,18 +2060,28 @@ class Termin
     }
 
     /**
-     * @param array<int, string> $names
+     * @param array<int, array{userId?:int,name:string}|string> $names
      */
     private function renderShiftResponseNames(array $names, $colorClass) {
         if(!count($names)) {
             return '';
         }
         $html = '';
-        foreach($names as $name) {
+        foreach($names as $item) {
+            $name = '';
+            $userId = 0;
+            if(is_array($item)) {
+                $name = isset($item['name']) ? (string)$item['name'] : '';
+                $userId = isset($item['userId']) ? (int)$item['userId'] : 0;
+            }
+            else {
+                $name = (string)$item;
+            }
             $html .= render('termin/response_line', array(
                 'entry' => array(
                     'colorClass' => $colorClass,
-                    'name' => (string)$name,
+                    'name' => $name,
+                    'userId' => $userId,
                     'instrument' => '',
                     'children' => null,
                     'guests' => null,
@@ -2340,6 +2351,7 @@ ORDER BY `Nachname`, `Vorname`;",
             'statusClass' => isset($statusColors[$wert]) ? $statusColors[$wert] : '',
             'registerColor' => $regHex,
             'name' => $name,
+            'userId' => (int)$userId > 0 ? (int)$userId : 0,
             'instrument' => $instrument,
             'children' => null,
             'guests' => null,

--- a/libs/user.php
+++ b/libs/user.php
@@ -101,7 +101,8 @@ class User
         $old->load_by_id($this->Index);
 
         $header = sprintf(
-            'User-ID: %d <b>%s %s</b>',
+            'User-ID: %d, User: (%d) <b>%s %s</b>',
+            (int)$this->Index,
             (int)$this->Index,
             htmlspecialchars((string)$this->Vorname, ENT_QUOTES, 'UTF-8'),
             htmlspecialchars((string)$this->Nachname, ENT_QUOTES, 'UTF-8')
@@ -201,6 +202,14 @@ class User
         }
         $parts = array();
         $parts[] = sprintf('User-ID: %d', (int)$this->Index);
+        $fullName = trim((string)$this->Vorname.' '.(string)$this->Nachname);
+        if($fullName !== '') {
+            $parts[] = sprintf(
+                'User: (%d) <b>%s</b>',
+                (int)$this->Index,
+                htmlspecialchars($fullName, ENT_QUOTES, 'UTF-8')
+            );
+        }
         logAppendFilled($parts, 'Vorname', $this->Vorname, (string)$this->Vorname);
         logAppendFilled($parts, 'Nachname', $this->Nachname, (string)$this->Nachname);
         logAppendFilled($parts, 'RefID', $this->RefID, (string)$this->RefID);

--- a/mail.php
+++ b/mail.php
@@ -551,7 +551,10 @@ function delFile(hash) {
     if($byId > 0) {
         $byUser = new User;
         $byUser->load_by_id($byId);
-        $byName = $byUser->Index ? htmlspecialchars($byUser->getName(), ENT_QUOTES, 'UTF-8') : ('User '.$byId);
+        $byLabel = $byUser->Index ? $byUser->getName() : ('User '.$byId);
+        $byName = function_exists('entityOpenHtml')
+            ? entityOpenHtml('user', $byId, $byLabel)
+            : htmlspecialchars($byLabel, ENT_QUOTES, 'UTF-8');
     }
     else {
         $byName = 'System';
@@ -609,8 +612,11 @@ function delFile(hash) {
         $tView = new Termin;
         $tView->load_by_id($jobTerminId);
         if($tView->Index) {
-            $verteilerHtml = 'Alle Teilnehmer von '
-                .htmlspecialchars($tView->Name.' ('.$tView->getGermanDate().')', ENT_QUOTES, 'UTF-8');
+            $tLabel = $tView->Name.' ('.$tView->getGermanDate().')';
+            $tChip = function_exists('entityOpenHtml')
+                ? entityOpenHtml('termin', $jobTerminId, $tLabel)
+                : htmlspecialchars($tLabel, ENT_QUOTES, 'UTF-8');
+            $verteilerHtml = 'Alle Teilnehmer von '.$tChip;
         }
         else {
             $verteilerHtml = 'Alle Teilnehmer von Termin #'.$jobTerminId;
@@ -643,9 +649,11 @@ else {
     foreach($outboxRows as $or) {
         $ou = new User;
         $ou->load_by_id((int)$or['User']);
-        $ouName = $ou->Index
-            ? htmlspecialchars($ou->getName(), ENT_QUOTES, 'UTF-8')
-            : ('User '.(int)$or['User']);
+        $ouId = (int)$or['User'];
+        $ouLabel = $ou->Index ? $ou->getName() : ('User '.$ouId);
+        $ouName = ($ouId > 0 && $ou->Index && function_exists('entityOpenHtml'))
+            ? entityOpenHtml('user', $ouId, $ouLabel)
+            : htmlspecialchars($ouLabel, ENT_QUOTES, 'UTF-8');
         $st = (string)$or['Status'];
         $stLabel = isset($outboxStatusLabel[$st]) ? $outboxStatusLabel[$st] : $st;
         $stCls = isset($outboxStatusClass[$st]) ? $outboxStatusClass[$st] : 'w3-light-grey';

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2603,6 +2603,18 @@ a.app-titlebar-logo {
   color: #444;
 }
 
+/* MELD-167: clickable entity chips → async openModal (delegation on .entity-open) */
+.entity-open {
+  cursor: pointer;
+  text-decoration: none;
+}
+.entity-open:hover,
+.entity-open:focus-visible {
+  filter: brightness(0.97);
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(52, 90, 149, 0.35);
+}
+
 .mail-recipient-suggest {
   position: relative;
   z-index: 5;

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -200,7 +200,7 @@ $sections[] = array(
     'visible' => isAdmin() && requirePermission('perm_showResponse'),
     'body' => '
 <p>Unter Admin → <b>Meldungen</b> siehst du Rückmeldungen übergreifend; im <b>Archiv</b> vergangene Termine. Beide Listen haben eine Suchzeile (Titel, Ort, Datum, Beschreibung) und dieselben kompakten Terminzeilen wie auf der Startseite (Status-Chips, Register-Zusammenfassung).</p>
-<p>In Termin- und Register-Ansichten kannst du Rückmeldungs-Modals öffnen – Namenslisten nach Status gruppiert, Personenzeilen in Registerfarbe. Die Orchesterübersicht skaliert auf die Fensterbreite und zeigt die Besetzung farbig nach Meldestatus (Hover zeigt Name und Status). Mit <b>Nur aktive Besetzung</b> siehst du einen Sitzplan nur mit Zusagen und Unsicheren – ohne Lücken durch Absagen oder fehlende Meldungen.</p>
+<p>In Termin- und Register-Ansichten kannst du Rückmeldungs-Modals öffnen – Namenslisten nach Status gruppiert, Personenzeilen in Registerfarbe; Namen als Chip öffnen das Personen-Modal. Die Orchesterübersicht skaliert auf die Fensterbreite und zeigt die Besetzung farbig nach Meldestatus (Hover zeigt Name und Status). Mit <b>Nur aktive Besetzung</b> siehst du einen Sitzplan nur mit Zusagen und Unsicheren – ohne Lücken durch Absagen oder fehlende Meldungen.</p>
 '.(requirePermission('perm_editResponse') ? '<p>Mit Recht <b>Rückmeldungen bearbeiten</b> kannst du im Orchesterplan per Klick auf einen Kreis den Status durchschalten: (keine Meldung →) Zusage → Absage → unsicher → Zusage …</p>' : '').'
 '
 );
@@ -224,7 +224,7 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 '.(requirePermission('perm_showInventories') ? '
-<li><b>Inventar</b> – Vereinsbesitz (Bestände, Details und Ausleihen); die Liste lädt beim Scrollen nach, Sortier-Chips sortieren serverseitig, Suche (mehrere Wörter = UND, z. B. <code>marsch Ralf</code>) und Chip <b>Versichert</b> filtern die bereits geladenen Einträge (bei aktiver Filterung wird weiter nachgeladen); Klick öffnet Details im Modal; „Übersicht für Versicherung“ öffnet eine druck-/PDF-fähige Tabelle (Spalten per Checkbox wählen, dann kopieren oder als PDF speichern)</li>
+<li><b>Inventar</b> – Vereinsbesitz (Bestände, Details und Ausleihen); die Liste lädt beim Scrollen nach, Sortier-Chips sortieren serverseitig, Suche (mehrere Wörter = UND, z. B. <code>marsch Ralf</code>) und Chip <b>Versichert</b> filtern die bereits geladenen Einträge (bei aktiver Filterung wird weiter nachgeladen); Klick auf die Zeile öffnet Details; Eigentümer-/Ausleihe-Chips öffnen die Person; „Übersicht für Versicherung“ öffnet eine druck-/PDF-fähige Tabelle (Spalten per Checkbox wählen, dann kopieren oder als PDF speichern)</li>
 ' : '').'
 '.(requirePermission('perm_editInventories') ? '
 <li><b>Inventar anlegen</b> – neue Stücke über die eigene Seite (Plus in der Inventarliste oder Admin → Inventar anlegen)</li>
@@ -264,7 +264,7 @@ $sections[] = array(
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Statistik</b> – Auswertungen; auf breiten Bildschirmen Diagramme und Listen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>). Ranking und Inaktive teilen sich denselben Chip-Filter wie die Personenliste (Aktive/Gäste/Mitglieder, Register, Gruppen) und nutzen denselben Zeilen-Stil inkl. Sortier-Chips</li>
-<li><b>Log</b> – Anwendungsprotokoll (Suche serverseitig; mehrere Wörter = UND, z. B. <code>ERROR Meier</code>; Live-Aktualisierung); Chunk-Größe für Scroll und Live-Nachladen über <code>logListChunkSize</code></li>
+<li><b>Log</b> – Anwendungsprotokoll (Suche serverseitig; mehrere Wörter = UND, z. B. <code>ERROR Meier</code>; Live-Aktualisierung); Akteure und referenzierte User/Termine/Inventar/Emails in der Nachricht als Chip öffnen das jeweilige Modal; Chunk-Größe für Scroll und Live-Nachladen über <code>logListChunkSize</code></li>
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '
 <li><b>Backup</b> – Datenbank-ZIP herunterladen (inkl. Versionsinfo) oder wieder einspielen; im Browser über <code>Backup</code>, per CLI mit <code>php cron.php CRONID backup</code>; automatisiert remote nur mit eigenem <code>$backupToken</code> in <code>config.php</code> (mind. 32 Zeichen) über <code>cron.php?id=…&amp;cmd=backup</code> — nicht mit dem allgemeinen Cron-ID. Erfolgreiche Downloads erscheinen im <b>Log</b> als Info, fehlgeschlagene als Fehler</li>

--- a/views/inventar/modal.php
+++ b/views/inventar/modal.php
@@ -147,8 +147,14 @@ $insured = !empty($row['Insurance']) || !empty($inv->Insurance);
         <label class="profile-label" for="inv-owner">Eigentümer</label>
 <?php if($canEdit) { ?>
         <select id="inv-owner" class="w3-select w3-border w3-input profile-control <?php echo $h($inputBg); ?>" name="Owner"><?php echo UserOptionAll((int)$inv->Owner); ?></select>
-<?php } else { ?>
-        <div class="profile-value"><?php echo $display(getOwner((int)$inv->Owner)); ?></div>
+<?php } else {
+        $ownerId = (int)$inv->Owner;
+        $ownerLabel = getOwner($ownerId);
+        $ownerHtml = ($ownerId > 0 && function_exists('entityOpenHtml'))
+            ? entityOpenHtml('user', $ownerId, $ownerLabel)
+            : $display($ownerLabel);
+?>
+        <div class="profile-value"><?php echo $ownerHtml; ?></div>
 <?php } ?>
       </div>
       <div class="profile-field">

--- a/views/mail/modal.php
+++ b/views/mail/modal.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * MailJob detail modal (profile-shell).
+ * Expects: $job (MailJob), $byId (int), $byName (string)
+ */
+$h = function ($s) {
+    return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
+};
+$subject = trim((string)$job->Subject);
+$title = $subject !== '' ? $subject : '(ohne Betreff)';
+$createdRaw = (string)$job->listTimestamp();
+$createdView = (string)germanDate($createdRaw, true);
+if(strlen($createdRaw) >= 16) {
+    $createdView .= ' '.sql2timeRaw(substr($createdRaw, 11, 8));
+}
+$byHtml = ($byId > 0 && function_exists('entityOpenHtml'))
+    ? entityOpenHtml('user', $byId, $byName)
+    : $h($byName);
+$body = formatMailBodyForDisplay((string)$job->BodyText);
+$counts = ((string)$job->Status !== 'draft')
+    ? MailJob::formatCounts($job->Sent, $job->Total, $job->Failed)
+    : '—';
+$btn = isset($GLOBALS['optionsDB']['colorBtnSubmit'])
+    ? $GLOBALS['optionsDB']['colorBtnSubmit']
+    : 'w3-blue';
+?>
+<div class="profile-shell modal-shell mail-modal" data-mail-id="<?php echo (int)$job->Index; ?>">
+  <header class="profile-hero">
+    <div class="profile-hero-text">
+      <p class="profile-kicker">Email</p>
+      <h2 class="profile-title"><?php echo $h($title); ?></h2>
+    </div>
+    <div class="profile-hero-actions">
+      <div class="profile-actions">
+        <div class="profile-actions-primary">
+          <a class="w3-btn profile-btn-primary <?php echo $h($btn); ?> w3-border w3-mobile" href="mail.php?id=<?php echo (int)$job->Index; ?>">Öffnen</a>
+        </div>
+      </div>
+      <button type="button" class="modal-close w3-button" onclick="closeModal()" aria-label="Schließen">&times;</button>
+    </div>
+  </header>
+
+  <div class="profile-grid profile-grid--2">
+    <section class="profile-col" aria-labelledby="mail-modal-meta">
+      <h3 id="mail-modal-meta" class="profile-col-title">Versand</h3>
+      <div class="profile-field">
+        <span class="profile-label">Email-ID</span>
+        <div class="profile-value"><?php echo (int)$job->Index; ?></div>
+      </div>
+      <div class="profile-field">
+        <span class="profile-label">Status</span>
+        <div class="profile-value"><span class="w3-tag <?php echo $h($job->statusClass()); ?>"><?php echo $h($job->statusLabel()); ?></span></div>
+      </div>
+      <div class="profile-field">
+        <span class="profile-label">Zeit</span>
+        <div class="profile-value"><?php echo $h($createdView); ?></div>
+      </div>
+      <div class="profile-field">
+        <span class="profile-label">Von</span>
+        <div class="profile-value"><?php echo $byHtml; ?></div>
+      </div>
+      <div class="profile-field">
+        <span class="profile-label">Empfänger</span>
+        <div class="profile-value"><?php echo $h($counts); ?></div>
+      </div>
+    </section>
+
+    <section class="profile-col" aria-labelledby="mail-modal-body">
+      <h3 id="mail-modal-body" class="profile-col-title">Text</h3>
+      <div class="profile-field">
+        <div class="profile-value mail-body-content"><?php echo $body !== '' ? $body : '<em>(kein Text)</em>'; ?></div>
+      </div>
+    </section>
+  </div>
+</div>

--- a/views/termin/response_line.php
+++ b/views/termin/response_line.php
@@ -7,6 +7,10 @@ $h = function ($s) {
     return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
 };
 $name = isset($entry['name']) ? (string)$entry['name'] : '';
+$userId = isset($entry['userId']) ? (int)$entry['userId'] : 0;
+$nameHtml = ($userId > 0 && function_exists('entityOpenHtml'))
+    ? entityOpenHtml('user', $userId, $name)
+    : $h($name);
 $instrument = isset($entry['instrument']) ? (string)$entry['instrument'] : '';
 $regHex = '';
 if(!empty($entry['registerColor']) && function_exists('normalizeHexColor')) {
@@ -39,7 +43,7 @@ elseif($statusClass !== '') {
 ?>
 <div class="<?php echo $h($cls); ?>"<?php echo $style; ?>>
   <div class="melde-response-person-main">
-    <div class="melde-response-person-name"><?php echo $h($name); ?></div>
+    <div class="melde-response-person-name"><?php echo $nameHtml; ?></div>
 <?php if($instrument !== '') { ?>
     <div class="melde-response-person-instrument"><?php echo $h($instrument); ?></div>
 <?php } ?>


### PR DESCRIPTION
## Summary
- Entity-Chips (`entityOpenHtml`) öffnen User-/Termin-/Inventar-/Email-Modals asynchron
- Log-Anzeige verknüpft bekannte Fragmente; redundante ID-/Betreff-/Namensfelder entfallen
- Hilfe + Cursor-Regel `ui-chips.mdc`

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-167

## Test plan
- [ ] Log: User/Termin/Inventar/Email-Chips öffnen Modal
- [ ] Melde-/Schichtlisten, Inventar Eigentümer/Leihe, Mail-Absender klickbar
- [ ] Keine doppelten Namen/IDs im Log bei Anlegen/Ändern
- [ ] `EntityOpenHtmlTest` grün