### PR TITLE
MELD-182: Kalender/ICS zeigen Schichten

### DIFF
--- a/.cursor/rules/ui-chips.mdc
+++ b/.cursor/rules/ui-chips.mdc
@@ -28,14 +28,14 @@ Wo ein verwaltetes Objekt referenziert wird und ein Detail-Modal existiert:
 
 1. PHP: `entityOpenHtml($type, $id, $label)` (`libs/helpers.php`)
 2. Markup: `mail-recipient-chip mail-recipient-chip--{mod} entity-open` + `data-entity-type` / `data-entity-id`
-3. Mapping: `user`→`--user`, `termin`→`--termin`, `inventar`→`--instrument`, `mail`→`--mailGroup`
-4. Klick: Event-Delegation (capture) in `js/modal.js` auf `.entity-open` → `openModal` (async XHR + Cache)
+3. Mapping: `user`→`--user`, `termin`→`--termin`, `inventar`→`--instrument`, `mail`→`--mailGroup`, `shift`→`--termin`
+4. Klick: Event-Delegation (capture) in `js/modal.js` auf `.entity-open` → `openModal` (async XHR + Cache); `shift` öffnet `shiftResponse`
 5. Optionaler 4. Parameter: Chip-Modifier-Override (z. B. `guestMusician` bei User-Modal)
 6. Kein Modal-HTML in Listen/Log-Chunks; kein Prefetch beim Rendern; kein Inline-`onclick` pro Zeile
 
 ## Log-Payload
 
-Beim Anzeigen: `logMessageLinkEntities()` wandelt bekannte Fragmente (`Termin: (id) <b>…</b>`, `User: (id) …`, `User: <b>Name</b>` per Melde-ID/Namensauflösung, `Inventory: (id) <b>…</b>`, `Email-ID: <b>N</b>` / `Email: (id) <b>…</b>`) in Entity-Chips um — nur Anzeige, Speicherung unverändert. Neue Melde-Logs schreiben `User: (id) <b>…</b>`.
+Beim Anzeigen: `logMessageLinkEntities()` wandelt bekannte Fragmente (`Termin: (id) <b>…</b>`, `User: (id) …`, `User: <b>Name</b>` per Melde-ID/Namensauflösung, `Inventory: (id) <b>…</b>`, `Email-ID: <b>N</b>` / `Email: (id) <b>…</b>`, `Schicht/Aufgabe: (id) <b>…</b>`) in Entity-Chips um — nur Anzeige, Speicherung unverändert. Neue Melde-Logs schreiben `User: (id) <b>…</b>`; neue Schicht-Logs `Schicht/Aufgabe: (id) <b>…</b>`.
 
 - Unterstrichene Textlinks statt Chips für Entity-Referenzen
 - Modal-Inhalt in Listenzeilen einbetten

--- a/download-ics.php
+++ b/download-ics.php
@@ -29,7 +29,51 @@ if(!(int)$n->Index) {
     die('Error: Appointment not found.');
 }
 
-$rawName = preg_replace('/[^\w.\-]+/u', '_', (string)$n->Name);
+$shiftId = 0;
+if(isset($_GET['shiftID'])) {
+    $shiftId = (int)$_GET['shiftID'];
+} elseif(isset($_POST['shiftID'])) {
+    $shiftId = (int)$_POST['shiftID'];
+}
+
+$shift = null;
+if((int)$n->Shifts) {
+    if($shiftId <= 0) {
+        http_response_code(400);
+        die('Error: Shift required.');
+    }
+    $shift = new Shift;
+    $shift->load_by_id($shiftId);
+    if(!(int)$shift->Index || (int)$shift->Termin !== (int)$n->Index) {
+        http_response_code(404);
+        die('Error: Shift not found.');
+    }
+}
+
+$summary = (string)$n->Name;
+$startTime = trim((string)$n->Uhrzeit);
+$endTime = trim((string)$n->Uhrzeit2);
+$fileLabel = (string)$n->Name;
+if($shift) {
+    $shiftName = trim((string)$shift->Name);
+    $fileLabel = $shiftName !== '' ? $shiftName : $fileLabel;
+    if($summary !== '' && $shiftName !== '') {
+        $summary = $summary.': '.$shiftName;
+    }
+    elseif($shiftName !== '') {
+        $summary = $shiftName;
+    }
+    $startNorm = Shift::normalizedTime($shift->Start);
+    $endNorm = Shift::normalizedTime($shift->End);
+    if($startNorm !== null) {
+        $startTime = $startNorm;
+    }
+    if($endNorm !== null) {
+        $endTime = $endNorm;
+    }
+}
+
+$rawName = preg_replace('/[^\w.\-]+/u', '_', $fileLabel);
 if($rawName === null || $rawName === '') {
     $rawName = 'termin';
 }
@@ -41,27 +85,27 @@ header('X-Content-Type-Options: nosniff');
 
 date_default_timezone_set('Europe/Berlin');
 if($n->EndDatum) {
-    $end = gmdate('Y-m-d H:i:s', strtotime($n->EndDatum." 23:59:00"));
-    if($n->Uhrzeit2) {
-        $end = gmdate('Y-m-d H:i:s', strtotime($n->EndDatum." ".$n->Uhrzeit2));
+    $end = gmdate('Y-m-d H:i:s', strtotime($n->EndDatum.' 23:59:00'));
+    if($endTime !== '') {
+        $end = gmdate('Y-m-d H:i:s', strtotime($n->EndDatum.' '.$endTime));
     }
-    $begin = gmdate('Y-m-d H:i:s', strtotime($n->Datum." ".$n->Uhrzeit));
-    if($n->Uhrzeit == NULL) {
-        $begin = gmdate('Y-m-d H:i:s', strtotime($n->Datum." 00:00:00"));
-        $end = gmdate('Y-m-d H:i:s', strtotime($n->EndDatum." 23:59:00"));
+    $begin = gmdate('Y-m-d H:i:s', strtotime($n->Datum.' '.$startTime));
+    if($startTime === '') {
+        $begin = gmdate('Y-m-d H:i:s', strtotime($n->Datum.' 00:00:00'));
+        $end = gmdate('Y-m-d H:i:s', strtotime($n->EndDatum.' 23:59:00'));
     }
 }
 else {
-    $end = gmdate('Y-m-d H:i:s', strtotime("+120 minutes", strtotime($n->Datum." ".$n->Uhrzeit)));
+    $end = gmdate('Y-m-d H:i:s', strtotime('+120 minutes', strtotime($n->Datum.' '.$startTime)));
 
-    if($n->Uhrzeit2) {
-        $end = gmdate('Y-m-d H:i:s', strtotime($n->Datum." ".$n->Uhrzeit2));
+    if($endTime !== '') {
+        $end = gmdate('Y-m-d H:i:s', strtotime($n->Datum.' '.$endTime));
     }
 
-    $begin = gmdate('Y-m-d H:i:s', strtotime($n->Datum." ".$n->Uhrzeit));
-    if($n->Uhrzeit == NULL) {
-        $begin = gmdate('Y-m-d H:i:s', strtotime($n->Datum." 00:00:00"));
-        $end = gmdate('Y-m-d H:i:s', strtotime($n->Datum." 23:59:00"));
+    $begin = gmdate('Y-m-d H:i:s', strtotime($n->Datum.' '.$startTime));
+    if($startTime === '') {
+        $begin = gmdate('Y-m-d H:i:s', strtotime($n->Datum.' 00:00:00'));
+        $end = gmdate('Y-m-d H:i:s', strtotime($n->Datum.' 23:59:00'));
     }
 }
 
@@ -71,7 +115,7 @@ $ics = new ICS(array(
     'description' => $n->Beschreibung,
     'dtstart' => $begin,
     'dtend' => $end,
-    'summary' => $n->Name
+    'summary' => $summary,
 ));
 
 echo $ics->to_string();

--- a/getModal.php
+++ b/getModal.php
@@ -63,6 +63,7 @@ case 'terminResponse':
     echo $t->getResponseModalHtml($filter);
     break;
 
+case 'shift':
 case 'shiftResponse':
     // Same as terminResponse: view without perm_showResponse (MELD-68)
     $s = new Shift;

--- a/js/calendarMelde.js
+++ b/js/calendarMelde.js
@@ -60,6 +60,57 @@ function calendarFormatDeDate(iso) {
     return m[3] + '.' + m[2] + '.' + m[1];
 }
 
+/**
+ * Day overflow "+N": list all events for that day, then open calendarMelde.
+ */
+function openCalendarDayEventsPicker(dateIso, events) {
+    var host = document.getElementById('ajaxModalHost');
+    var content = document.getElementById('ajaxModalContent');
+    if(!host || !content || !events || !events.length) return;
+
+    var esc = function(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    };
+    var titleDate = calendarFormatDeDate(dateIso);
+    var items = '';
+    events.forEach(function(ev) {
+        var id = parseInt(ev.id, 10);
+        if(!(id > 0)) return;
+        var color = esc(ev.color || '');
+        var label = esc(ev.label || ('Termin #' + id));
+        var wert = (ev.wert === null || ev.wert === undefined) ? '' : String(ev.wert);
+        items += '<button type="button" class="meld-cal-day-pick-item ' + color + '"'
+            + ' data-termin-id="' + id + '"'
+            + ' data-melde-wert="' + esc(wert) + '">'
+            + label
+            + '</button>';
+    });
+    if(!items) return;
+
+    content.innerHTML =
+        '<div class="profile-shell modal-shell calendar-day-events-modal" data-date="' + esc(dateIso) + '">'
+        + '<header class="profile-hero">'
+        + '<div class="profile-hero-text">'
+        + '<p class="profile-kicker">Kalender</p>'
+        + '<h2 class="profile-title">' + esc(titleDate) + '</h2>'
+        + '</div>'
+        + '<div class="profile-hero-actions">'
+        + '<button type="button" class="modal-close w3-button" onclick="closeModal()" aria-label="Schließen">&times;</button>'
+        + '</div>'
+        + '</header>'
+        + '<div class="profile-grid">'
+        + '<section class="profile-col">'
+        + '<div class="meld-cal-day-pick-list">' + items + '</div>'
+        + '</section>'
+        + '</div>'
+        + '</div>';
+    host.style.display = 'block';
+}
+
 function calendarOfferNewTermin(dateIso) {
     if(!dateIso) return;
     var label = calendarFormatDeDate(dateIso);
@@ -78,11 +129,38 @@ function calendarOfferNewTermin(dateIso) {
     go();
 }
 
+document.addEventListener('click', function(e) {
+    var more = e.target.closest ? e.target.closest('.meld-cal-more') : null;
+    if(more) {
+        e.preventDefault();
+        e.stopPropagation();
+        var raw = more.getAttribute('data-cal-day-events') || '[]';
+        var events = [];
+        try {
+            events = JSON.parse(raw);
+        }
+        catch(err) {
+            events = [];
+        }
+        openCalendarDayEventsPicker(more.getAttribute('data-date') || '', events);
+        return;
+    }
+    var pick = e.target.closest ? e.target.closest('.meld-cal-day-pick-item') : null;
+    if(pick) {
+        e.preventDefault();
+        e.stopPropagation();
+        var tid = parseInt(pick.getAttribute('data-termin-id'), 10);
+        if(tid > 0 && typeof openModal === 'function') {
+            openModal('calendarMelde', tid);
+        }
+    }
+}, true);
+
 document.addEventListener('DOMContentLoaded', function() {
     var wrap = document.querySelector('.meld-cal-wrap');
     if(!wrap || wrap.getAttribute('data-can-create') !== '1') return;
     wrap.addEventListener('click', function(e) {
-        if(e.target.closest('.meld-cal-chip, .meld-cal-more, button, a, select, input')) {
+        if(e.target.closest('.meld-cal-chip, .meld-cal-more, .meld-cal-day-pick-item, button, a, select, input')) {
             return;
         }
         var cell = e.target.closest('.meld-cal-cell');

--- a/js/modal.js
+++ b/js/modal.js
@@ -68,7 +68,8 @@ function openEntityFromEl(el) {
     var id = parseInt(el.getAttribute('data-entity-id'), 10);
     if(!type || !(id > 0)) return false;
     if(type === 'inventory') type = 'inventar';
-    if(type !== 'user' && type !== 'termin' && type !== 'inventar' && type !== 'mail') return false;
+    if(type === 'shift') type = 'shiftResponse';
+    if(type !== 'user' && type !== 'termin' && type !== 'inventar' && type !== 'mail' && type !== 'shiftResponse') return false;
     openModal(type, id);
     return true;
 }

--- a/libs/calendarView.php
+++ b/libs/calendarView.php
@@ -105,11 +105,12 @@ function calendarColorClassForWert($wert) {
 
 /**
  * Load visible appointments overlapping [fromDate, toDate] for a user.
+ * Shift appointments expand to one event per Schicht (MELD-182).
  *
  * @param int $userId
  * @param string $fromDate Y-m-d
  * @param string $toDate Y-m-d
- * @return list<array{id:int,name:string,date:string,endDate:string,startTime:string,endTime:string,wert:int|null,colorClass:string,description:string,location:string}>
+ * @return list<array{id:int,name:string,date:string,endDate:string,startTime:string,endTime:string,wert:int|null,colorClass:string,description:string,location:string,shiftId?:int}>
  */
 function calendarLoadEventsForUser($userId, $fromDate, $toDate) {
     $userId = (int)$userId;
@@ -153,29 +154,94 @@ function calendarLoadEventsForUser($userId, $fromDate, $toDate) {
         if(!$t->isVisibleToUser($userId)) {
             continue;
         }
-        $wert = null;
-        if(isset($row['meldeWert']) && $row['meldeWert'] !== null && $row['meldeWert'] !== '') {
-            $wert = (int)$row['meldeWert'];
-        }
         $endDate = trim((string)$t->EndDatum);
         if($endDate === '') {
             $endDate = (string)$t->Datum;
         }
-        $startTime = trim((string)$t->Uhrzeit);
-        $endTime = trim((string)$t->Uhrzeit2);
+        $location = method_exists($t, 'getOrt') ? (string)$t->getOrt() : '';
+        $description = (string)$t->Beschreibung;
+        $terminStart = trim((string)$t->Uhrzeit);
+        $terminEnd = trim((string)$t->Uhrzeit2);
+
+        if((int)$t->Shifts) {
+            $shiftIds = $t->getShifts();
+            if(!count($shiftIds)) {
+                continue;
+            }
+            foreach($shiftIds as $sid) {
+                $s = new Shift();
+                $s->load_by_id((int)$sid);
+                if(!(int)$s->Index || (int)$s->Termin !== (int)$t->Index) {
+                    continue;
+                }
+                $sm = new Shiftmeldung();
+                $sm->load_by_user_event($userId, (int)$s->Index);
+                $wert = null;
+                if((int)$sm->Index > 0 && $sm->Wert !== null && $sm->Wert !== '') {
+                    $wert = (int)$sm->Wert;
+                }
+                $startNorm = Shift::normalizedTime($s->Start);
+                $endNorm = Shift::normalizedTime($s->End);
+                $startTime = $startNorm !== null ? $startNorm : $terminStart;
+                $endTime = $endNorm !== null ? $endNorm : $terminEnd;
+                $shiftName = trim((string)$s->Name);
+                $terminName = trim((string)$t->Name);
+                if($terminName !== '' && $shiftName !== '') {
+                    $name = $terminName.': '.$shiftName;
+                }
+                elseif($shiftName !== '') {
+                    $name = $shiftName;
+                }
+                else {
+                    $name = $terminName !== '' ? $terminName : 'Schicht';
+                }
+                $out[] = array(
+                    'id' => (int)$t->Index,
+                    'shiftId' => (int)$s->Index,
+                    'name' => $name,
+                    'date' => (string)$t->Datum,
+                    'endDate' => $endDate,
+                    'startTime' => $startTime,
+                    'endTime' => $endTime,
+                    'wert' => $wert,
+                    'colorClass' => calendarColorClassForWert($wert),
+                    'description' => $description,
+                    'location' => $location,
+                );
+            }
+            continue;
+        }
+
+        $wert = null;
+        if(isset($row['meldeWert']) && $row['meldeWert'] !== null && $row['meldeWert'] !== '') {
+            $wert = (int)$row['meldeWert'];
+        }
         $out[] = array(
             'id' => (int)$t->Index,
             'name' => (string)$t->Name,
             'date' => (string)$t->Datum,
             'endDate' => $endDate,
-            'startTime' => $startTime,
-            'endTime' => $endTime,
+            'startTime' => $terminStart,
+            'endTime' => $terminEnd,
             'wert' => $wert,
             'colorClass' => calendarColorClassForWert($wert),
-            'description' => (string)$t->Beschreibung,
-            'location' => method_exists($t, 'getOrt') ? (string)$t->getOrt() : '',
+            'description' => $description,
+            'location' => $location,
         );
     }
+
+    usort($out, static function ($a, $b) {
+        $c = strcmp((string)$a['date'], (string)$b['date']);
+        if($c !== 0) {
+            return $c;
+        }
+        $c = strcmp((string)$a['startTime'], (string)$b['startTime']);
+        if($c !== 0) {
+            return $c;
+        }
+        return strcmp((string)$a['name'], (string)$b['name']);
+    });
+
     return $out;
 }
 

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -502,6 +502,7 @@ function entityOpenHtml($type, $id, $label, $chipMod = '') {
         'termin' => 'termin',
         'inventar' => 'instrument',
         'mail' => 'mailGroup',
+        'shift' => 'termin',
     );
     if($id < 1 || !isset($chipMods[$type])) {
         return $h($label);
@@ -737,6 +738,46 @@ function logMessageLinkEntities($html) {
     if($userCreateLinked) {
         $html = preg_replace('/,?\s*Vorname:\s*<b>.*?<\/b>/si', '', $html, 1);
         $html = preg_replace('/,?\s*Nachname:\s*<b>.*?<\/b>/si', '', $html, 1);
+    }
+
+    // Melde / canonical: Schicht/Aufgabe: (3) <b>Bierstand …</b> optional time
+    $html = preg_replace_callback(
+        '/\bSchicht\/Aufgabe:\s*\((\d+)\)\s*<b>(.*?)<\/b>(?:\s*([^,<]*?))?(?=,|$)/si',
+        function ($m) use ($chip, $plainLabel) {
+            $extra = isset($m[3]) ? $plainLabel($m[3]) : '';
+            $label = $plainLabel($m[2]);
+            if($extra !== '') {
+                $label = trim($label.' '.$extra);
+            }
+            if($label === '') {
+                $label = '#'.$m[1];
+            }
+            return 'Schicht/Aufgabe: '.$chip('shift', $m[1], $label);
+        },
+        $html
+    );
+
+    // Edit/create: Schicht/Aufgabe: 7, … Name: <b>…</b>
+    $shiftNameLinked = false;
+    $html = preg_replace_callback(
+        '/\bSchicht\/Aufgabe:\s*(\d+)(?=\s*,|\s*$)/si',
+        function ($m) use ($chip, $plainLabel, $source, &$shiftNameLinked) {
+            $label = '';
+            if(preg_match('/\bName:\s*<b>(.*?)<\/b>/si', $source, $n)) {
+                $label = $plainLabel($n[1]);
+            }
+            if($label === '') {
+                $label = '#'.$m[1];
+            }
+            else {
+                $shiftNameLinked = true;
+            }
+            return 'Schicht/Aufgabe: '.$chip('shift', $m[1], $label);
+        },
+        $html
+    );
+    if($shiftNameLinked) {
+        $html = preg_replace('/,?\s*Name:\s*<b>.*?<\/b>/si', '', $html, 1);
     }
 
     // Email: (23) <b>Betreff</b>

--- a/libs/icalFeed.php
+++ b/libs/icalFeed.php
@@ -65,13 +65,19 @@ function icalFeedUidHost($websiteUrl = null) {
  *
  * @param int $terminId
  * @param string|null $host
+ * @param int $shiftId 0 = plain termin event
  * @return string
  */
-function icalFeedUid($terminId, $host = null) {
+function icalFeedUid($terminId, $host = null, $shiftId = 0) {
     if($host === null || $host === '') {
         $host = icalFeedUidHost();
     }
-    return 'meld-'.(int)$terminId.'@'.$host;
+    $tid = (int)$terminId;
+    $sid = (int)$shiftId;
+    if($sid > 0) {
+        return 'meld-'.$tid.'-s'.$sid.'@'.$host;
+    }
+    return 'meld-'.$tid.'@'.$host;
 }
 
 /**
@@ -205,6 +211,7 @@ function icalFeedBuild(array $events, $websiteUrl = null) {
 
     foreach($events as $ev) {
         $id = (int)$ev['id'];
+        $shiftId = isset($ev['shiftId']) ? (int)$ev['shiftId'] : 0;
         $times = icalFeedEventTimes($ev);
         $wert = isset($ev['wert']) ? $ev['wert'] : null;
         $status = ($wert === null || $wert === '' || (int)$wert === 3) ? 'TENTATIVE' : 'CONFIRMED';
@@ -223,7 +230,7 @@ function icalFeedBuild(array $events, $websiteUrl = null) {
 
         $vevent = array(
             'BEGIN:VEVENT',
-            'UID:'.icalFeedUid($id, $host),
+            'UID:'.icalFeedUid($id, $host, $shiftId),
             'DTSTAMP:'.$dtstamp,
             'SUMMARY:'.icalFeedEscapeText((string)$ev['name']),
             'DESCRIPTION:'.icalFeedEscapeText($description),
@@ -258,7 +265,8 @@ function icalFeedEtag($userId, array $events, $from, $to) {
     $parts = array((int)$userId, (string)$from, (string)$to);
     foreach($events as $ev) {
         $w = isset($ev['wert']) && $ev['wert'] !== null && $ev['wert'] !== '' ? (int)$ev['wert'] : 0;
-        $parts[] = (int)$ev['id'].':'.$w.':'.(string)$ev['date'].':'.(string)$ev['endDate'].':'.(string)$ev['startTime'].':'.(string)$ev['endTime'];
+        $sid = isset($ev['shiftId']) ? (int)$ev['shiftId'] : 0;
+        $parts[] = (int)$ev['id'].':'.$sid.':'.$w.':'.(string)$ev['date'].':'.(string)$ev['endDate'].':'.(string)$ev['startTime'].':'.(string)$ev['endTime'];
     }
     return '"'.hash('sha256', implode('|', $parts)).'"';
 }

--- a/libs/shift.php
+++ b/libs/shift.php
@@ -74,14 +74,18 @@ class Shift
         if(count($parts) < 1) {
             return '';
         }
-        return sprintf('Schicht/Aufgabe: %d, ', (int)$this->Index).implode(', ', $parts);
+        return sprintf('Schicht/Aufgabe: (%d) <b>%s</b>, ', (int)$this->Index, htmlspecialchars(trim((string)$this->Name) !== '' ? trim((string)$this->Name) : ('#'.(int)$this->Index), ENT_QUOTES, 'UTF-8')).implode(', ', $parts);
     }
 
     public function getVars() {
         $parts = array();
-        $parts[] = sprintf('Schicht/Aufgabe: %d', (int)$this->Index);
+        $name = trim((string)$this->Name);
+        $parts[] = sprintf(
+            'Schicht/Aufgabe: (%d) <b>%s</b>',
+            (int)$this->Index,
+            htmlspecialchars($name !== '' ? $name : ('#'.(int)$this->Index), ENT_QUOTES, 'UTF-8')
+        );
         $parts[] = logPart('Termin', (string)(int)$this->Termin);
-        logAppendFilled($parts, 'Name', $this->Name, (string)$this->Name);
         if(self::normalizedTime($this->Start) !== null) {
             $parts[] = logPart('Start', self::formatTimeLog($this->Start));
         }

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -1750,7 +1750,7 @@ class Termin
         $str .= '</div>';
 
         $str .= '<div class="melde-actions" data-melde-stop>';
-        if(!empty($GLOBALS['optionsDB']['showAddToCalendarButton'])) {
+        if(!empty($GLOBALS['optionsDB']['showAddToCalendarButton']) && !$this->Shifts) {
             // GET link so Android WebView can intercept/download (MELD-180); POST still accepted server-side
             $str .= '<a id="icalform'.$tid.'" class="melde-ical melde-ical-btn" href="download-ics.php?appID='.$tid.'"'
                 .' title="In Kalender" aria-label="In Kalender eintragen" download>'
@@ -1833,6 +1833,12 @@ class Termin
                 }
                 $str .= '</div>';
                 $str .= '<div class="melde-actions">';
+                if(!empty($GLOBALS['optionsDB']['showAddToCalendarButton'])) {
+                    $sid = (int)$s->Index;
+                    $str .= '<a id="icalform'.$tid.'_s'.$sid.'" class="melde-ical melde-ical-btn" href="download-ics.php?appID='.$tid.'&amp;shiftID='.$sid.'"'
+                        .' title="In Kalender" aria-label="In Kalender eintragen" download>'
+                        .'<i class="fa fa-calendar-plus" aria-hidden="true"></i></a>';
+                }
                 if($s->Bedarf) {
                     $str .= '<div class="melde-meta"><i class="fas fa-user-friends" aria-hidden="true"></i> '.$h($s->getResponseString()).'</div>';
                 }
@@ -2066,6 +2072,9 @@ class Termin
         if(!count($names)) {
             return '';
         }
+        // Soft tint like termin response register rows — solid cfg-hex would force
+        // white text onto light entity chips (MELD-167 / MELD-182).
+        $tintHex = $this->resolveMeldeColorHex($colorClass);
         $html = '';
         foreach($names as $item) {
             $name = '';
@@ -2077,16 +2086,22 @@ class Termin
             else {
                 $name = (string)$item;
             }
+            $entry = array(
+                'name' => $name,
+                'userId' => $userId,
+                'instrument' => '',
+                'children' => null,
+                'guests' => null,
+                'freeText' => null,
+            );
+            if($tintHex !== '') {
+                $entry['registerColor'] = $tintHex;
+            }
+            else {
+                $entry['colorClass'] = $colorClass;
+            }
             $html .= render('termin/response_line', array(
-                'entry' => array(
-                    'colorClass' => $colorClass,
-                    'name' => $name,
-                    'userId' => $userId,
-                    'instrument' => '',
-                    'children' => null,
-                    'guests' => null,
-                    'freeText' => null,
-                ),
+                'entry' => $entry,
             ));
         }
         return $html;

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -3960,6 +3960,11 @@ body.loan-form-print {
   word-break: break-word;
 }
 
+/* Entity chips keep their light fill; never inherit white from solid status rows */
+.melde-response-person .mail-recipient-chip {
+  color: #1a1a1a;
+}
+
 .melde-response-person-instrument {
   margin-top: 0.1rem;
   font-size: 0.85rem;

--- a/views/calendar/month.php
+++ b/views/calendar/month.php
@@ -29,13 +29,26 @@ $gridEnd = DateTimeImmutable::createFromFormat('Y-m-d', $bounds['gridEnd']);
   border: 1px solid rgba(0,0,0,0.25); cursor: pointer; overflow: hidden;
   text-overflow: ellipsis; white-space: nowrap; border-radius: 2px;
 }
-.meld-cal-more { font-size: 0.7em; color: #555; padding: 0 2px; }
+.meld-cal-more {
+  display: block; width: 100%; box-sizing: border-box; margin: 0;
+  padding: 2px 4px; font-size: 0.7em; line-height: 1.2; text-align: left;
+  border: 1px dashed rgba(0,0,0,0.3); border-radius: 2px;
+  background: transparent; color: #345A95; cursor: pointer;
+  font-family: inherit;
+}
+.meld-cal-more:hover { background: rgba(52, 90, 149, 0.08); }
 .meld-cal-events { max-height: 6.5rem; overflow-y: auto; }
+.meld-cal-day-pick-list { display: flex; flex-direction: column; gap: 6px; }
+.meld-cal-day-pick-item {
+  display: block; width: 100%; box-sizing: border-box; text-align: left;
+  padding: 8px 10px; border: 1px solid rgba(0,0,0,0.2); border-radius: 4px;
+  cursor: pointer; font-size: 0.95em;
+}
 .meld-cal-cell--create { cursor: pointer; }
-.meld-cal-cell--create:hover { filter-color: #345A95; }
+.meld-cal-cell--create:hover { border-color: #345A95; }
 @media (max-width: 900px) {
   .meld-cal-cell { min-height: 4.2rem; padding: 2px; }
-  .meld-cal-chip { font-size: 0.6em; padding: 1px 2px; }
+  .meld-cal-chip, .meld-cal-more { font-size: 0.6em; padding: 1px 2px; }
   .meld-cal-head { font-size: 0.75em; }
 }
 </style>
@@ -83,6 +96,17 @@ while($cursor && $gridEnd && $cursor <= $gridEnd) {
       <div class="meld-cal-daynum"><?php echo (int)$cursor->format('j'); ?></div>
       <div class="meld-cal-events">
 <?php
+    $pickerEvents = array();
+    foreach($dayEvents as $ev) {
+        $timeLabel = calendarFormatTimeShort($ev['startTime']);
+        $label = ($timeLabel !== '' ? $timeLabel.' ' : '').$ev['name'];
+        $pickerEvents[] = array(
+            'id' => (int)$ev['id'],
+            'label' => $label,
+            'color' => (string)$ev['colorClass'],
+            'wert' => $ev['wert'] === null ? '' : (int)$ev['wert'],
+        );
+    }
     foreach($shown as $ev) {
         $timeLabel = calendarFormatTimeShort($ev['startTime']);
         $label = ($timeLabel !== '' ? $timeLabel.' ' : '').$ev['name'];
@@ -100,12 +124,18 @@ while($cursor && $gridEnd && $cursor <= $gridEnd) {
 <?php
     }
     if($extra > 0) {
-        $moreTitle = array();
-        foreach(array_slice($dayEvents, $maxChips) as $ev) {
-            $moreTitle[] = $ev['name'];
-        }
+        $pickerJson = htmlspecialchars(
+            json_encode($pickerEvents, JSON_UNESCAPED_UNICODE),
+            ENT_QUOTES,
+            'UTF-8'
+        );
 ?>
-        <div class="meld-cal-more" title="<?php echo htmlspecialchars(implode(', ', $moreTitle), ENT_QUOTES, 'UTF-8'); ?>">+<?php echo (int)$extra; ?></div>
+        <button type="button"
+          class="meld-cal-more"
+          data-date="<?php echo htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>"
+          data-cal-day-events="<?php echo $pickerJson; ?>"
+          title="Alle Termine an diesem Tag"
+          aria-label="+<?php echo (int)$extra; ?> weitere Termine anzeigen">+<?php echo (int)$extra; ?></button>
 <?php } ?>
       </div>
     </div>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -42,7 +42,7 @@ $sections[] = array(
 <p>Auf dem Desktop steht die Navigation links (Icons mit Beschriftung). Auf Tablet und Smartphone unten; unter <b>Mehr</b> findest du weitere Einträge (u.&nbsp;a. Mein Profil), Admin und Ausloggen.</p>
 <ul class="help-list">
 <li><i class="far fa-calendar-alt"></i> <b>Termine</b> – bevorstehende Termine und schnelles Melden</li>
-<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details); Info-Button für Abo-Link, Drucken für alle kommenden Termine als Tabelle</li>
+<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; bei Schichten erscheinen die einzelnen Schichten mit ihren Zeiten; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details; bei vielen Einträgen am selben Tag öffnet <b>+N</b> die Tagesauswahl); Info-Button für Abo-Link, Drucken für alle kommenden Termine als Tabelle</li>
 <li><i class="fas fa-envelope"></i> <b>Meine Nachrichten</b> – empfangene Mails aus der Meldeliste (Badge bei ungelesenen)</li>
 <li><i class="fas fa-users"></i> <b>Mein Register</b> – Rückmeldungen deines Registers (auf Tablet/Smartphone dauerhaft in der unteren Leiste)</li>
 '.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir gehörendes oder an dich ausgeliehenes Inventar</li>' : '').'
@@ -63,14 +63,14 @@ $sections[] = array(
 <p>Unter <b>Termine</b> (Startseite) kannst du dich zu Terminen eintragen:</p>
 <ul>
 <li>Über die Suchzeile findest du Termine nach Titel, Ort, Datum oder Beschreibung (auch im Termin-Archiv).</li>
-<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details. Über dem Monat: Info öffnet das Abo-Fenster, Drucken listet alle kommenden Termine (nicht nur den aktuellen Monat).</li>
+<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; bei Schichten die einzelnen Schichten mit ihren Zeiten. Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details. Passt nicht alles in die Zelle, öffnet <b>+N</b> eine Liste aller Einträge dieses Tages. Über dem Monat: Info öffnet das Abo-Fenster, Drucken listet alle kommenden Termine (nicht nur den aktuellen Monat).</li>
 </ul>
 '.$meldeButtons.'
 <p>Tippe auf den gewünschten Status. Die Farbe am Termin zeigt deinen aktuellen Stand. Eine erneute Auswahl ändert die Meldung.</p>
 <p><b>Tipp:</b> Auch „vielleicht“ oder „nein“ sind wertvoll – offene Einträge erschweren die Planung.</p>
 <p>Bei Terminen mit <b>Besetzung</b> kannst du im Termin-Detail ggf. das <b>Instrument für diesen Termin</b> anpassen (z.&nbsp;B. Dirigat übernehmen). Speichern mit dem Speicher-Button neben der Auswahl.</p>
 <p>Ein Klick auf Titel, Beschreibung oder Ort öffnet die Termin-Details (Uhrzeit, Orchesterübersicht, …).</p>
-<p>Über <i class="fa fa-calendar-plus"></i> kannst du einen Termin als ICS-Datei in deinen Kalender (Google, Outlook, …) importieren.</p>
+<p>Über <i class="fa fa-calendar-plus"></i> kannst du einen Termin als ICS-Datei in deinen Kalender (Google, Outlook, …) importieren. Bei Terminen mit Schichten steht der Button an jeder Schichtzeile und übernimmt Schichtname und -zeit.</p>
 '
 );
 
@@ -131,7 +131,7 @@ $sections[] = array(
     'title' => 'Persönlichen Kalender abonnieren',
     'body' => '
 <p>Du kannst deine sichtbaren Meldeliste-Termine in deinen privaten Kalender (Google, Apple, Outlook, …) <b>abonnieren</b>. Der Link steht unter <b>Mein Profil</b> und auf der Seite <b>Kalender</b> im Info-Dialog (runde Buttons über der Monatsauswahl).</p>
-<p><b>Einweg:</b> Termine und dein Melde-Status (zugesagt / vielleicht / ohne) werden in den Kalender übernommen. Zu- und Absagen änderst du weiterhin in der Meldeliste — nicht in der Kalender-App.</p>
+<p><b>Einweg:</b> Termine und dein Melde-Status (zugesagt / vielleicht / ohne) werden in den Kalender übernommen. Bei Schichten erscheinen die einzelnen Schichten (Name und Zeit), nicht der Eltern-Termin. Zu- und Absagen änderst du weiterhin in der Meldeliste — nicht in der Kalender-App.</p>
 <p><b>Aktualisierung:</b> Wie oft der Feed neu geladen wird, steuert dein Kalender-Anbieter (oft erst nach einigen Stunden). Darauf hat die Meldeliste keinen Einfluss.</p>
 <ul>
 <li><b>Google Kalender</b> (am PC): Weitere Kalender → <b>Über URL hinzufügen</b> → HTTPS-Link einfügen.</li>
@@ -264,7 +264,7 @@ $sections[] = array(
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Statistik</b> – Auswertungen; auf breiten Bildschirmen Diagramme und Listen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>). Ranking und Inaktive teilen sich denselben Chip-Filter wie die Personenliste (Aktive/Gäste/Mitglieder, Register, Gruppen) und nutzen denselben Zeilen-Stil inkl. Sortier-Chips</li>
-<li><b>Log</b> – Anwendungsprotokoll (Suche serverseitig; mehrere Wörter = UND, z. B. <code>ERROR Meier</code>; Live-Aktualisierung); Akteure und referenzierte User/Termine/Inventar/Emails in der Nachricht als Chip öffnen das jeweilige Modal; Chunk-Größe für Scroll und Live-Nachladen über <code>logListChunkSize</code></li>
+<li><b>Log</b> – Anwendungsprotokoll (Suche serverseitig; mehrere Wörter = UND, z. B. <code>ERROR Meier</code>; Live-Aktualisierung); Akteure und referenzierte User/Termine/Inventar/Emails/Schichten in der Nachricht als Chip öffnen das jeweilige Modal; Chunk-Größe für Scroll und Live-Nachladen über <code>logListChunkSize</code></li>
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '
 <li><b>Backup</b> – Datenbank-ZIP herunterladen (inkl. Versionsinfo) oder wieder einspielen; im Browser über <code>Backup</code>, per CLI mit <code>php cron.php CRONID backup</code>; automatisiert remote nur mit eigenem <code>$backupToken</code> in <code>config.php</code> (mind. 32 Zeichen) über <code>cron.php?id=…&amp;cmd=backup</code> — nicht mit dem allgemeinen Cron-ID. Erfolgreiche Downloads erscheinen im <b>Log</b> als Info, fehlgeschlagene als Fehler</li>


### PR DESCRIPTION
## Summary
- Schicht-Termine: Kalender und ICS-Abo mit Schichtzeiten/-namen (Nein gefiltert)
- ICS-Button pro Schichtzeile; Log-Chips öffnen Schicht-Modal
- Kalender `+N` öffnet Tagesauswahl; weiche Personenzeilen-Tönung im Schicht-Modal

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-182

## Test plan
- [ ] Kalender: mehrere Schichten am Tag → Zeiten/Namen; `+N` → Liste → Melde-Modal
- [ ] ICS-Abo: Schicht-VEVENTs, Nein ausgeblendet
- [ ] Meldezeile: ICS nur an Schichtzeilen
- [ ] Log: Schicht/Aufgabe-Chip öffnet Antworten; lesbare Chip-Schrift