### PR TITLE
MELD-188: Leihvertrag anpassen

### DIFF
--- a/config/DBconfig.json
+++ b/config/DBconfig.json
@@ -58,6 +58,7 @@
 	"Kaution": {"Type": "decimal(10,2)", "Null": "YES", "Default": "0.00"},
 	"Leihgebuehr": {"Type": "decimal(10,2)", "Null": "YES", "Default": "0.00"},
 	"BorrowerAddress": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
+	"ContractNotes": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
 	"ReturnChecklist": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
 	"ContractFile": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
 	"ReturnContractFile": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"}

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -3,5 +3,5 @@
  * Expected DB schema version number (MELD-51).
  * Bump when DBconfig.json, DatabaseManager migrations, or ConfigDefaults.php change.
  */
-return 31;
+return 32;
 ?>

--- a/js/modal.js
+++ b/js/modal.js
@@ -782,6 +782,7 @@ function inventarLoanFormAction(form) {
     if(!form || !form.querySelector) return '';
     if(form.querySelector('[name="newLoan"]')) return 'newLoan';
     if(form.querySelector('[name="endLoan"]')) return 'endLoan';
+    if(form.querySelector('[name="deleteLoanScan"]')) return 'deleteLoanScan';
     if(form.querySelector('[name="deleteLoan"]')) return 'deleteLoan';
     if(form.querySelector('[name="updateLoanFees"]') || form.querySelector('[name="updateLoanKaution"]')) {
         return 'updateLoanFees';

--- a/libs/inventories.php
+++ b/libs/inventories.php
@@ -632,12 +632,32 @@ class Inventories
         if($hasLoanScan || $hasReturnScan) {
             $str .= '<div class="inventory-loan-action-group inventory-loan-action-group--scans" role="group" aria-label="Scans">';
             if($hasLoanScan) {
+                $str .= '<div class="inventory-loan-scan-pair">';
                 $str .= '<a class="inventory-loan-btn inventory-loan-btn--scan" target="_blank" rel="noopener" '
                     .'href="loan-contract.php?loan='.$loanId.'&amp;kind=loan">Scan Vertrag</a>';
+                if($canEdit) {
+                    $str .= '<form method="POST" action="" class="inventory-loan-delete" '
+                        .'data-confirm="Scan Vertrag löschen? Die Leihe bleibt erhalten." data-confirm-ok="Scan löschen">'
+                        .'<input type="hidden" name="LoanIndex" value="'.$loanId.'">'
+                        .'<input type="hidden" name="scanKind" value="loan">'
+                        .'<button type="submit" name="deleteLoanScan" value="1" class="inventory-loan-btn inventory-loan-btn--scan-del" title="Scan löschen" aria-label="Scan Vertrag löschen">Löschen</button>'
+                        .'</form>';
+                }
+                $str .= '</div>';
             }
             if($hasReturnScan) {
+                $str .= '<div class="inventory-loan-scan-pair">';
                 $str .= '<a class="inventory-loan-btn inventory-loan-btn--scan" target="_blank" rel="noopener" '
                     .'href="loan-contract.php?loan='.$loanId.'&amp;kind=return">Scan Rückgabe</a>';
+                if($canEdit) {
+                    $str .= '<form method="POST" action="" class="inventory-loan-delete" '
+                        .'data-confirm="Scan Rückgabe löschen? Die Leihe bleibt erhalten." data-confirm-ok="Scan löschen">'
+                        .'<input type="hidden" name="LoanIndex" value="'.$loanId.'">'
+                        .'<input type="hidden" name="scanKind" value="return">'
+                        .'<button type="submit" name="deleteLoanScan" value="1" class="inventory-loan-btn inventory-loan-btn--scan-del" title="Scan löschen" aria-label="Scan Rückgabe löschen">Löschen</button>'
+                        .'</form>';
+                }
+                $str .= '</div>';
             }
             $str .= '</div>';
         }
@@ -645,9 +665,9 @@ class Inventories
         if($canEdit) {
             $str .= '<div class="inventory-loan-action-group inventory-loan-action-group--danger">';
             $str .= '<form method="POST" action="" class="inventory-loan-delete" '
-                .'data-confirm="Diese Leih-Information wirklich löschen?" data-confirm-ok="Löschen">'
+                .'data-confirm="Diesen Leiheintrag wirklich löschen?" data-confirm-ok="Eintrag löschen">'
                 .'<input type="hidden" name="LoanIndex" value="'.$loanId.'">'
-                .'<button type="submit" name="deleteLoan" value="1" class="inventory-loan-btn inventory-loan-btn--danger '.$btnDelete.'">Löschen</button>'
+                .'<button type="submit" name="deleteLoan" value="1" class="inventory-loan-btn inventory-loan-btn--danger '.$btnDelete.'">Eintrag löschen</button>'
                 .'</form>';
             $str .= '</div>';
         }
@@ -832,6 +852,7 @@ function respondInventoriesAjax($result) {
  */
 function handleInventoriesMutations() {
     $mutating = isset($_POST['newLoan']) || isset($_POST['endLoan']) || isset($_POST['deleteLoan'])
+        || isset($_POST['deleteLoanScan'])
         || isset($_POST['updateLoanFees']) || isset($_POST['updateLoanKaution'])
         || isset($_POST['insert']) || isset($_POST['update']) || isset($_POST['delete']);
     if(!$mutating) {
@@ -895,6 +916,18 @@ function handleInventoriesMutations() {
         $result['action'] = 'endLoan';
         $result['loanId'] = (int)$n->Index;
         $result['inventoryId'] = (int)$n->Inventory;
+    }
+    if(isset($_POST['deleteLoanScan'])) {
+        $n = new InventoriesLoan;
+        $loanId = isset($_POST['LoanIndex']) ? (int)$_POST['LoanIndex'] : (int)$_POST['Index'];
+        $n->load_by_id($loanId);
+        if($n->Index) {
+            $kind = isset($_POST['scanKind']) ? (string)$_POST['scanKind'] : LoanForm::KIND_LOAN;
+            LoanForm::deleteScan($n, $kind);
+            $result['action'] = 'deleteLoanScan';
+            $result['loanId'] = (int)$n->Index;
+            $result['inventoryId'] = (int)$n->Inventory;
+        }
     }
     if(isset($_POST['deleteLoan'])) {
         $n = new InventoriesLoan;

--- a/libs/inventoriesLoan.php
+++ b/libs/inventoriesLoan.php
@@ -10,6 +10,7 @@ class InventoriesLoan
         'Kaution' => null,
         'Leihgebuehr' => null,
         'BorrowerAddress' => null,
+        'ContractNotes' => null,
         'ReturnChecklist' => null,
         'ContractFile' => null,
         'ReturnContractFile' => null,
@@ -25,6 +26,7 @@ class InventoriesLoan
 	    case 'Kaution':
 	    case 'Leihgebuehr':
 	    case 'BorrowerAddress':
+	    case 'ContractNotes':
 	    case 'ReturnChecklist':
 	    case 'ContractFile':
 	    case 'ReturnContractFile':
@@ -43,6 +45,7 @@ class InventoriesLoan
             $this->_data[$key] = $val;
             break;
 	    case 'BorrowerAddress':
+	    case 'ContractNotes':
 	    case 'ReturnChecklist':
             $this->_data[$key] = trim((string)$val);
             break;
@@ -136,6 +139,9 @@ class InventoriesLoan
             $str .= ', Adresse: '.htmlspecialchars((string)$old->BorrowerAddress, ENT_QUOTES, 'UTF-8')
                 .' &rArr; <b>'.htmlspecialchars((string)$this->BorrowerAddress, ENT_QUOTES, 'UTF-8').'</b>';
         }
+        if((string)$this->ContractNotes !== (string)$old->ContractNotes) {
+            $str .= ', Bemerkungen aktualisiert';
+        }
         if((string)$this->ReturnChecklist !== (string)$old->ReturnChecklist) {
             $str .= ', Checkliste aktualisiert';
         }
@@ -170,6 +176,9 @@ class InventoriesLoan
             $parts[] = logPart('Leihgebühr', LoanForm::formatAmount($this->Leihgebuehr));
         }
         logAppendFilled($parts, 'Adresse', $this->BorrowerAddress, (string)$this->BorrowerAddress);
+        if(trim((string)$this->ContractNotes) !== '') {
+            $parts[] = logPart('Bemerkungen', 'gesetzt');
+        }
         if(trim((string)$this->ReturnChecklist) !== '') {
             $parts[] = logPart('Checkliste', 'gesetzt');
         }
@@ -189,6 +198,9 @@ class InventoriesLoan
         if($this->BorrowerAddress === null) {
             $this->BorrowerAddress = '';
         }
+        if($this->ContractNotes === null) {
+            $this->ContractNotes = '';
+        }
         if($this->ReturnChecklist === null) {
             $this->ReturnChecklist = '';
         }
@@ -206,7 +218,7 @@ class InventoriesLoan
 
     protected function insert() {
         $sql = sprintf(
-            'INSERT INTO `%sInventoriesLoans` (`User`, `Inventory`, `StartDate`, `EndDate`, `Kaution`, `Leihgebuehr`, `BorrowerAddress`, `ReturnChecklist`, `ContractFile`, `ReturnContractFile`) VALUES ("%d", "%d", %s, %s, "%s", "%s", "%s", "%s", "%s", "%s");',
+            'INSERT INTO `%sInventoriesLoans` (`User`, `Inventory`, `StartDate`, `EndDate`, `Kaution`, `Leihgebuehr`, `BorrowerAddress`, `ContractNotes`, `ReturnChecklist`, `ContractFile`, `ReturnContractFile`) VALUES ("%d", "%d", %s, %s, "%s", "%s", "%s", "%s", "%s", "%s", "%s");',
             $GLOBALS['dbprefix'],
             $this->User,
             $this->Inventory,
@@ -215,6 +227,7 @@ class InventoriesLoan
             $this->moneySql($this->Kaution),
             $this->moneySql($this->Leihgebuehr),
             $this->escapeDb($this->BorrowerAddress),
+            $this->escapeDb($this->ContractNotes),
             $this->escapeDb($this->ReturnChecklist),
             $this->escapeDb($this->ContractFile),
             $this->escapeDb($this->ReturnContractFile)
@@ -228,7 +241,7 @@ class InventoriesLoan
 
     protected function update() {
         $sql = sprintf(
-            'UPDATE `%sInventoriesLoans` SET `User` = "%d", `Inventory` = "%d", `StartDate` = %s, `EndDate` = %s, `Kaution` = "%s", `Leihgebuehr` = "%s", `BorrowerAddress` = "%s", `ReturnChecklist` = "%s", `ContractFile` = "%s", `ReturnContractFile` = "%s" WHERE `Index` = "%d";',
+            'UPDATE `%sInventoriesLoans` SET `User` = "%d", `Inventory` = "%d", `StartDate` = %s, `EndDate` = %s, `Kaution` = "%s", `Leihgebuehr` = "%s", `BorrowerAddress` = "%s", `ContractNotes` = "%s", `ReturnChecklist` = "%s", `ContractFile` = "%s", `ReturnContractFile` = "%s" WHERE `Index` = "%d";',
             $GLOBALS['dbprefix'],
             $this->User,
             $this->Inventory,
@@ -237,6 +250,7 @@ class InventoriesLoan
             $this->moneySql($this->Kaution),
             $this->moneySql($this->Leihgebuehr),
             $this->escapeDb($this->BorrowerAddress),
+            $this->escapeDb($this->ContractNotes),
             $this->escapeDb($this->ReturnChecklist),
             $this->escapeDb($this->ContractFile),
             $this->escapeDb($this->ReturnContractFile),

--- a/libs/loanForm.php
+++ b/libs/loanForm.php
@@ -180,6 +180,45 @@ class LoanForm
     }
 
     /**
+     * Remove stored scan for loan|return; clears DB pointer and deletes the file.
+     * @return bool True if DB was cleared (file may already have been missing).
+     */
+    public static function deleteScan(InventoriesLoan $loan, $kind) {
+        if(!(int)$loan->Index) {
+            return false;
+        }
+        $kind = self::normalizeKind($kind);
+        $loanId = (int)$loan->Index;
+        $stored = $kind === self::KIND_RETURN
+            ? trim((string)$loan->ReturnContractFile)
+            : trim((string)$loan->ContractFile);
+        if($stored === '') {
+            return true;
+        }
+        $path = self::resolveStoredFile($loanId, $stored);
+        if($path !== null && is_file($path)) {
+            @unlink($path);
+        }
+        if($kind === self::KIND_RETURN) {
+            $loan->ReturnContractFile = '';
+        }
+        else {
+            $loan->ContractFile = '';
+        }
+        $loan->save();
+        return true;
+    }
+
+    /** Normalize free-text contract remarks (max 2000). */
+    public static function normalizeContractNotes($raw) {
+        $notes = trim((string)$raw);
+        if(strlen($notes) > 2000) {
+            $notes = substr($notes, 0, 2000);
+        }
+        return $notes;
+    }
+
+    /**
      * Build context for form rendering / tests.
      * @return array|null
      */
@@ -259,6 +298,7 @@ class LoanForm
         $borrowerLabel = 'Entleiher';
         $title = $kind === self::KIND_RETURN ? 'Rückgabeprotokoll' : 'Leihvertrag';
         $borrowerAddress = trim((string)$loan->BorrowerAddress);
+        $contractNotes = self::normalizeContractNotes($loan->ContractNotes);
 
         $ctx = array(
             'kind' => $kind,
@@ -275,9 +315,12 @@ class LoanForm
             'isMember' => $isMember,
             'mitgliedsnummer' => $mitgliedsnummer,
             'needMitgliedsnummerField' => false,
-            'needAddressField' => $mitgliedsnummer === '',
-            'needAddressEditField' => $mitgliedsnummer === '' && $borrowerAddress === '',
+            // Address always optional and re-editable (MELD-188).
+            'needAddressField' => true,
+            'needAddressEditField' => true,
             'borrowerAddress' => $borrowerAddress,
+            'contractNotes' => $contractNotes,
+            'needContractNotesField' => true,
             'startDate' => (string)$loan->StartDate,
             'startDateDe' => germanDate($loan->StartDate, 0),
             'endDate' => $hasEnd ? (string)$loan->EndDate : '',
@@ -367,7 +410,8 @@ class LoanForm
 
     /**
      * Persist free fields from the online contract form.
-     * Adresse (wenn keine Mitgliedsnummer) → InventoriesLoans.BorrowerAddress;
+     * Adresse (optional) → InventoriesLoans.BorrowerAddress;
+     * Bemerkungen → InventoriesLoans.ContractNotes;
      * return checklist → InventoriesLoans.ReturnChecklist (JSON).
      * @return bool
      */
@@ -382,12 +426,19 @@ class LoanForm
             return false;
         }
         $loanDirty = false;
-        $hasMitgliedsnummer = $user->RefID !== null && $user->RefID !== '' && (int)$user->RefID > 0;
 
-        if(!$hasMitgliedsnummer && array_key_exists('BorrowerAddress', $post)) {
+        if(array_key_exists('BorrowerAddress', $post)) {
             $addr = trim((string)$post['BorrowerAddress']);
             if((string)$loan->BorrowerAddress !== $addr) {
                 $loan->BorrowerAddress = $addr;
+                $loanDirty = true;
+            }
+        }
+
+        if(array_key_exists('ContractNotes', $post)) {
+            $notes = self::normalizeContractNotes($post['ContractNotes']);
+            if((string)$loan->ContractNotes !== $notes) {
+                $loan->ContractNotes = $notes;
                 $loanDirty = true;
             }
         }

--- a/loan-contract.php
+++ b/loan-contract.php
@@ -1,8 +1,9 @@
 <?php
 /**
- * Upload / download scanned loan or return contracts (MELD-181).
+ * Upload / download / delete scanned loan or return contracts (MELD-181 / MELD-188).
  * GET: loan, kind — download stored scan
  * POST: loan, kind, action=upload, scan — store scan
+ * POST: loan, kind, action=deleteScan — clear scan
  */
 require_once __DIR__.'/libs/sessionBootstrap.php';
 meldeConfigureSession();
@@ -36,6 +37,13 @@ if($isPost) {
         denyAccess();
     }
     $action = isset($_POST['action']) ? (string)$_POST['action'] : '';
+    if($action === 'deleteScan') {
+        if(!LoanForm::deleteScan($loan, $kind)) {
+            denyAccess('Scan konnte nicht gelöscht werden.');
+        }
+        header('Location: loan-form.php?loan='.$loanId.'&kind='.rawurlencode($kind));
+        exit;
+    }
     if($action !== 'upload' || !isset($_FILES['scan'])) {
         denyAccess('Upload fehlgeschlagen.');
     }

--- a/loan-form.php
+++ b/loan-form.php
@@ -84,8 +84,9 @@ $showMemberNr = isset($ctx['mitgliedsnummer']) && (string)$ctx['mitgliedsnummer'
 $editMemberNr = false;
 $showAddress = !empty($ctx['needAddressField']);
 $editAddress = $canEdit && !empty($ctx['needAddressEditField']);
+$editNotes = $canEdit && !empty($ctx['needContractNotesField']);
 $editChecklist = $canEdit && $kind === LoanForm::KIND_RETURN;
-$hasEditableFields = $editMemberNr || $editAddress || $editChecklist;
+$hasEditableFields = $editMemberNr || $editAddress || $editNotes || $editChecklist;
 $checklist = isset($ctx['checklist']) && is_array($ctx['checklist'])
     ? $ctx['checklist']
     : LoanForm::defaultChecklist();
@@ -93,6 +94,7 @@ $checkReturned = !empty($checklist['returned']);
 $checkDeposit = !empty($checklist['depositReturned']);
 $checkDeductions = isset($checklist['deductions']) ? (string)$checklist['deductions'] : '';
 $checkNotes = isset($checklist['notes']) ? (string)$checklist['notes'] : '';
+$contractNotes = isset($ctx['contractNotes']) ? (string)$ctx['contractNotes'] : '';
 
 $scanLabel = $kind === LoanForm::KIND_RETURN ? 'Scan Rückgabe' : 'Scan Vertrag';
 
@@ -117,7 +119,17 @@ header('Content-Type: text/html; charset=utf-8');
 <?php if($canEdit || $hasScan) { ?>
     <div class="loan-form-toolbar-group loan-form-toolbar-group--scan">
 <?php   if($hasScan) { ?>
+      <div class="loan-form-scan-pair">
       <a class="loan-form-btn loan-form-btn--scan" href="loan-contract.php?loan=<?php echo (int)$ctx['loanId']; ?>&amp;kind=<?php echo $h($kind); ?>"><?php echo $h($scanLabel); ?></a>
+<?php     if($canEdit) { ?>
+      <form class="loan-form-upload" method="POST" action="loan-contract.php" onsubmit="return confirm('Scan löschen? Die Leihe bleibt erhalten.');">
+        <input type="hidden" name="loan" value="<?php echo (int)$ctx['loanId']; ?>">
+        <input type="hidden" name="kind" value="<?php echo $h($kind); ?>">
+        <input type="hidden" name="action" value="deleteScan">
+        <button type="submit" class="loan-form-btn" title="Scan löschen" aria-label="Scan löschen">Löschen</button>
+      </form>
+<?php     } ?>
+      </div>
 <?php   } ?>
 <?php   if($canEdit) { ?>
       <form class="loan-form-upload" method="POST" action="loan-contract.php" enctype="multipart/form-data">
@@ -189,8 +201,12 @@ header('Content-Type: text/html; charset=utf-8');
           <div class="loan-form-field-row loan-form-field-row--stack">
             <span class="loan-form-field-label">Adresse</span>
 <?php   if($editAddress) { ?>
-            <textarea id="loan-adresse" class="loan-form-input loan-form-input--address no-print" name="BorrowerAddress" rows="2" aria-label="Adresse"></textarea>
+            <textarea id="loan-adresse" class="loan-form-input loan-form-input--address no-print" name="BorrowerAddress" rows="2" aria-label="Adresse"><?php echo $h($ctx['borrowerAddress']); ?></textarea>
+<?php     if($ctx['borrowerAddress'] !== '') { ?>
+            <p class="loan-form-address-value loan-form-print-only"><?php echo nl2br($h($ctx['borrowerAddress'])); ?></p>
+<?php     } else { ?>
             <span class="loan-form-blank loan-form-blank--address loan-form-print-only" aria-hidden="true"></span>
+<?php     } ?>
 <?php   } elseif($ctx['borrowerAddress'] !== '') { ?>
             <p class="loan-form-address-value"><?php echo nl2br($h($ctx['borrowerAddress'])); ?></p>
 <?php   } else { ?>
@@ -247,6 +263,25 @@ header('Content-Type: text/html; charset=utf-8');
           <li><?php echo $clause; ?></li>
 <?php } ?>
         </ol>
+      </section>
+
+      <section class="loan-form-section loan-form-panel">
+        <h2>Zusätzliche Vereinbarungen</h2>
+        <div class="loan-form-field-row loan-form-field-row--stack">
+          <span class="loan-form-field-label">Bemerkungen</span>
+<?php if($editNotes) { ?>
+          <textarea id="loan-contract-notes" class="loan-form-input loan-form-input--address no-print" name="ContractNotes" rows="4" aria-label="Bemerkungen"><?php echo $h($contractNotes); ?></textarea>
+<?php   if($contractNotes !== '') { ?>
+          <p class="loan-form-address-value loan-form-print-only"><?php echo nl2br($h($contractNotes)); ?></p>
+<?php   } else { ?>
+          <span class="loan-form-blank loan-form-blank--address loan-form-print-only" aria-hidden="true"></span>
+<?php   } ?>
+<?php } elseif($contractNotes !== '') { ?>
+          <p class="loan-form-address-value"><?php echo nl2br($h($contractNotes)); ?></p>
+<?php } else { ?>
+          <span class="loan-form-blank loan-form-blank--address"></span>
+<?php } ?>
+        </div>
       </section>
 
 <?php if($kind === LoanForm::KIND_RETURN) { ?>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2966,17 +2966,22 @@ body.loan-form-print {
   display: flex;
   flex-wrap: wrap;
   gap: 0.4rem;
-  align-items: center;
+  align-items: stretch;
 }
 
 .loan-form-toolbar-group--scan {
   margin-left: auto;
   padding-left: 0.65rem;
   border-left: 1px solid #c5ccd4;
+  align-items: center;
 }
 
 .loan-form-btn {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  min-height: 2.15rem;
   font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
   font-size: 0.88rem;
   line-height: 1.25;
@@ -2987,6 +2992,8 @@ body.loan-form-print {
   border-radius: 3px;
   padding: 0.38rem 0.7rem;
   cursor: pointer;
+  margin: 0;
+  white-space: nowrap;
 }
 
 .loan-form-btn:hover {
@@ -3024,8 +3031,33 @@ body.loan-form-print {
   display: inline-flex;
   flex-wrap: wrap;
   gap: 0.4rem;
-  align-items: center;
+  align-items: stretch;
   margin: 0;
+}
+
+.loan-form-scan-pair {
+  display: inline-flex;
+  flex-wrap: nowrap;
+  gap: 0;
+  align-items: stretch;
+  border: 1px solid var(--loan-brand, #345A95);
+  border-radius: 3px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.loan-form-scan-pair .loan-form-btn {
+  border: 0;
+  border-radius: 0;
+  min-height: 2.15rem;
+}
+
+.loan-form-scan-pair .loan-form-btn--scan {
+  border-right: 1px solid rgba(52, 90, 149, 0.35);
+}
+
+.loan-form-scan-pair .loan-form-upload {
+  gap: 0;
 }
 
 /*
@@ -3459,35 +3491,80 @@ body.loan-form-print {
   font-weight: 400;
 }
 
+/* Loan row actions: stacked, always flush right (no left/right mix on wrap). */
 .inventory-loan-actions {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem 0.7rem;
-  justify-content: flex-end;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
 }
 
 .inventory-loan-action-group {
-  display: inline-flex;
+  display: flex;
   flex-wrap: wrap;
-  gap: 0.3rem;
+  gap: 0.35rem;
   align-items: center;
+  justify-content: flex-end;
+  max-width: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
 }
 
-.inventory-loan-action-group--scans {
-  padding-left: 0.55rem;
-  border-left: 1px solid rgba(0, 0, 0, 0.14);
-}
-
+.inventory-loan-action-group--scans,
 .inventory-loan-action-group--danger {
-  padding-left: 0.55rem;
-  border-left: 1px solid rgba(0, 0, 0, 0.14);
+  padding-left: 0;
+  margin-left: 0;
+  border-left: 0;
+}
+
+/* Scan + delete as one segmented control, right-aligned with the rest. */
+.inventory-loan-scan-pair {
+  display: inline-flex;
+  flex-wrap: nowrap;
+  gap: 0;
+  align-items: stretch;
+  border: 1px solid #345A95;
+  border-radius: 2px;
+  overflow: hidden;
+  background: #fff;
+}
+
+.inventory-loan-scan-pair .inventory-loan-btn {
+  border: 0;
+  border-radius: 0;
+  min-height: 2rem;
+}
+
+.inventory-loan-scan-pair .inventory-loan-btn--scan {
+  border-right: 1px solid rgba(52, 90, 149, 0.35);
+  color: #345A95;
+  background: #fff;
+}
+
+.inventory-loan-scan-pair .inventory-loan-btn--scan:hover {
+  background: rgba(52, 90, 149, 0.06);
+}
+
+.inventory-loan-scan-pair .inventory-loan-btn--scan-del {
+  color: #555;
+  background: rgba(52, 90, 149, 0.04);
+  padding-left: 0.45rem;
+  padding-right: 0.45rem;
+}
+
+.inventory-loan-scan-pair .inventory-loan-btn--scan-del:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: #111;
 }
 
 .inventory-loan-btn {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   box-sizing: border-box;
   margin: 0;
+  min-height: 2rem;
   padding: 0.28rem 0.55rem;
   font: inherit;
   font-size: 0.85rem;
@@ -3499,6 +3576,7 @@ body.loan-form-print {
   border-radius: 2px;
   cursor: pointer;
   white-space: nowrap;
+  vertical-align: middle;
 }
 
 .inventory-loan-btn:hover {
@@ -3514,25 +3592,46 @@ body.loan-form-print {
   background: rgba(52, 90, 149, 0.06);
 }
 
+.inventory-loan-btn--scan-del {
+  border-color: rgba(0, 0, 0, 0.22);
+  color: #444;
+}
+
+.inventory-loan-btn--scan-del:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
 .inventory-loan-btn--danger {
   border-color: transparent;
 }
 
 .inventory-loan-delete {
-  display: inline;
+  display: inline-flex;
   margin: 0;
+  padding: 0;
+  border: 0;
+  align-items: stretch;
+}
+
+.inventory-loan-delete .inventory-loan-btn {
+  height: 100%;
 }
 
 @media (max-width: 600px) {
   .inventory-loan-actions {
+    align-items: stretch;
+  }
+
+  .inventory-loan-action-group {
     justify-content: flex-start;
   }
 
-  .inventory-loan-action-group--scans,
-  .inventory-loan-action-group--danger {
-    padding-left: 0;
-    border-left: 0;
+  .inventory-loan-scan-pair {
     width: 100%;
+  }
+
+  .inventory-loan-scan-pair .inventory-loan-btn--scan {
+    flex: 1 1 auto;
   }
 
   .loan-form-toolbar-group--scan {

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -229,8 +229,8 @@ $sections[] = array(
 '.(requirePermission('perm_editInventories') ? '
 <li><b>Inventar anlegen</b> – neue Stücke über die eigene Seite (Plus in der Inventarliste oder Admin → Inventar anlegen)</li>
 <li><b>Inventar-Typen</b> – Prefix bestimmt den Nummernkreis (z.&nbsp;B. <code>MARSCH-001</code>, <code>INSTR-42</code>); die Beschriftung erscheint in Listen und Formularen</li>
-<li>Bearbeiten, Löschen und Ausleihen nur mit Schreibrechten; im Inventar-Modal unter <b>Leihen</b> neue Ausleihen für jedes Inventarstück eintragen (optional <b>Kaution</b> und <b>Leihgebühr</b>) — das Modal bleibt offen, <b>Leihvertrag</b> folgt in der neuen Zeile; offene Leihen beenden oder einzelne Historie-Einträge löschen</li>
-<li><b>Leihvertrag / Rückgabe</b> – aus der Leihhistorie druckbare Formulare (alle Inventartypen); Kaution und Leihgebühr nur wenn &gt; 0 €; Entleiher immer so bezeichnet; Mitgliedsnummer wenn hinterlegt, sonst Adresse als Freifeld; Rückgabe-Checkliste online abhakbar und speicherbar; nach Unterschrift Scan ablegen und in der Historie öffnen. Bei Vereinsmitgliedern endet die Leihe mit dem Austritt, sonst neuer Vertrag als Nicht-Mitglied</li>
+<li>Bearbeiten, Löschen und Ausleihen nur mit Schreibrechten; im Inventar-Modal unter <b>Leihen</b> neue Ausleihen für jedes Inventarstück eintragen (optional <b>Kaution</b> und <b>Leihgebühr</b>) — das Modal bleibt offen, <b>Leihvertrag</b> folgt in der neuen Zeile; offene Leihen beenden; Scans einzeln löschen oder den ganzen Leiheintrag entfernen</li>
+<li><b>Leihvertrag / Rückgabe</b> – aus der Leihhistorie druckbare Formulare (alle Inventartypen); Kaution und Leihgebühr nur wenn &gt; 0 €; Entleiher immer so bezeichnet; Mitgliedsnummer wenn hinterlegt; Adresse und zusätzliche Vereinbarungen/Bemerkungen optional und jederzeit änderbar; Rückgabe-Checkliste online abhakbar und speicherbar; nach Unterschrift Scan ablegen, öffnen oder löschen und neu hochladen. Bei Vereinsmitgliedern endet die Leihe mit dem Austritt, sonst neuer Vertrag als Nicht-Mitglied</li>
 ' : '').'
 </ul>
 '


### PR DESCRIPTION
## Summary
- Adresse und zusätzliche Vereinbarungen jederzeit optional editierbar (auch mit Mitgliedsnummer)
- Scan von Leih-/Rückgabevertrag einzeln löschen (Leihe bleibt); Segment-Buttons im Inventar-Modal
- Schema: `ContractNotes`, Version 32

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-188

## Test plan
- [ ] Leihvertrag: Adresse/Bemerkungen speichern und erneut ändern
- [ ] Scan hochladen, „Löschen“ → nur Datei weg, Leihe bleibt
- [ ] Inventar-Modal: Scan-Segment und „Eintrag löschen“ getrennt
- [ ] PHPUnit LoanFormTest / SchemaTest