### PR TITLE
MELD-184: aktive Nav-Tabs und CSS-Versionierung

### DIFF
--- a/common/header.php
+++ b/common/header.php
@@ -10,20 +10,14 @@
       <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
       <?php
           include_once 'include.php';
-          // Cache-Bust wie in footer.php: Release-Hash + filemtime erzwingen Reload nach Update
-          $assetV = isset($GLOBALS['version']['Hash']) ? $GLOBALS['version']['Hash'] : '0';
-          $cssUrl = function ($rel) use ($assetV) {
-              $mtime = @filemtime(__DIR__ . '/../' . $rel);
-              return htmlspecialchars($rel . '?' . $assetV . '-' . $mtime, ENT_QUOTES, 'UTF-8');
-          };
       ?>
-      <link rel="stylesheet" href="<?php echo $cssUrl('styles/w3.css'); ?>">
-      <link rel="stylesheet" href="<?php echo $cssUrl('styles/w3-colors-highway.css'); ?>">
-      <link rel="stylesheet" href="<?php echo $cssUrl('styles/w3-color-mvd.css'); ?>">
-      <link rel="stylesheet" href="<?php echo $cssUrl('styles/custom.css'); ?>">
-      <link rel="stylesheet" href="<?php echo $cssUrl('styles/fontawesome-free-6.4.2-web/css/fontawesome.css'); ?>">
-      <link rel="stylesheet" href="<?php echo $cssUrl('styles/fontawesome-free-6.4.2-web/css/brands.css'); ?>">
-      <link rel="stylesheet" href="<?php echo $cssUrl('styles/fontawesome-free-6.4.2-web/css/solid.css'); ?>">
+      <link rel="stylesheet" href="<?php echo assetUrl('styles/w3.css'); ?>">
+      <link rel="stylesheet" href="<?php echo assetUrl('styles/w3-colors-highway.css'); ?>">
+      <link rel="stylesheet" href="<?php echo assetUrl('styles/w3-color-mvd.css'); ?>">
+      <link rel="stylesheet" href="<?php echo assetUrl('styles/custom.css'); ?>">
+      <link rel="stylesheet" href="<?php echo assetUrl('styles/fontawesome-free-6.4.2-web/css/fontawesome.css'); ?>">
+      <link rel="stylesheet" href="<?php echo assetUrl('styles/fontawesome-free-6.4.2-web/css/brands.css'); ?>">
+      <link rel="stylesheet" href="<?php echo assetUrl('styles/fontawesome-free-6.4.2-web/css/solid.css'); ?>">
       <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
       <?php echo renderConfigColorCss(); ?>
       <?php echo renderPermissionGroupColorCss(); ?>

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -1285,14 +1285,18 @@ function loadPermissions($user) {
 }
 
 /**
- * Cache-busting URL for static assets (release hash + file mtime).
- * Needed so JS/CSS reload after_dev deploys without a new makeVersion HASH.
+ * Cache-busting URL for static assets (release version + hash + file mtime).
+ * Needed so JS/CSS reload after deploys (esp. Android WebView).
  */
 function assetUrl($rel) {
     $rel = ltrim(str_replace('\\', '/', (string)$rel), '/');
+    $ver = isset($GLOBALS['version']['String']) ? (string)$GLOBALS['version']['String'] : '0';
     $hash = isset($GLOBALS['version']['Hash']) ? (string)$GLOBALS['version']['Hash'] : '0';
     $mtime = @filemtime(dirname(__DIR__).'/'.$rel);
-    return htmlspecialchars($rel.'?'.$hash.'-'.$mtime, ENT_QUOTES, 'UTF-8');
+    if($mtime === false) {
+        $mtime = 0;
+    }
+    return htmlspecialchars($rel.'?v='.rawurlencode($ver).'&h='.$hash.'-'.$mtime, ENT_QUOTES, 'UTF-8');
 }
 
 function meldeRequest($key, $default = null) {

--- a/loan-form.php
+++ b/loan-form.php
@@ -53,9 +53,7 @@ $stored = $kind === LoanForm::KIND_RETURN
     : $ctx['contractFile'];
 $hasScan = $stored !== '';
 
-$assetV = isset($GLOBALS['version']['Hash']) ? $GLOBALS['version']['Hash'] : '0';
-$cssMtime = @filemtime(__DIR__.'/styles/custom.css');
-$cssUrl = 'styles/custom.css?'.$assetV.'-'.$cssMtime;
+$cssUrl = assetUrl('styles/custom.css');
 $logoPath = is_file(__DIR__.'/imgs/Logo.png') ? 'imgs/Logo.png' : '';
 
 $brandBar = '#345A95';

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -223,7 +223,8 @@ a.app-titlebar-logo {
   box-sizing: border-box;
   padding: 0.65rem 0.9rem;
   border: 0;
-  background: transparent;
+  /* Kein background:transparent — sonst überschreibt custom.css die w3-/TitleBar-Farben
+     (aktive Tabs). Gruppenfarben nutzen !important und waren davon nicht betroffen. */
   color: inherit;
   text-align: left;
   text-decoration: none;


### PR DESCRIPTION
## Summary
- Aktive Bottom-Nav-Tabs wieder mit `colorTitleBar` (`.app-nav-item` überschreibt nicht mehr per `background: transparent`)
- Stylesheets über `assetUrl()` mit VERSION + Hash + mtime (`?v=…&h=…`) für WebView-Cache-Bust

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-184

## Test plan
- [ ] Aktiver Nav-Tab hat TitleBar-Farbe, nicht weiß
- [ ] Safe-Area unter Nav ohne grauen colorNav-Streifen
- [ ] `custom.css?v=…` in Seitenquelle nach Release
- [ ] `AssetUrlTest` grün