### PR TITLE
MELD-171: Notenarchiv-/MIT-Rechte und SSO-Allowlist

### DIFF
--- a/common/include.php
+++ b/common/include.php
@@ -52,5 +52,6 @@ include "libs/backup.php";
 include "libs/calendarView.php";
 include "libs/icalFeed.php";
 include "libs/ssoTicket.php";
+include "libs/ssoRedirect.php";
 include "libs/userVoice.php";
 ?>

--- a/common/nav.php
+++ b/common/nav.php
@@ -7,10 +7,10 @@ $mailUnreadLabel = $mailUnread > 99 ? '99+' : (string)$mailUnread;
 $navUser = new User;
 $navUser->load_by_id($_SESSION['userid']);
 $navHasInventories = $navUser->hasInventories();
-$ssoArchiv = !empty($optionsDB['urlNotenarchiv'])
+$ssoArchiv = (!empty($optionsDB['urlNotenarchiv']) && requirePermission('perm_accessNotenarchiv'))
     ? 'sso.php?redirect='.rawurlencode(trim((string)$optionsDB['urlNotenarchiv']))
     : '';
-$ssoMit = !empty($optionsDB['urlMitgliederverwaltung'])
+$ssoMit = (!empty($optionsDB['urlMitgliederverwaltung']) && requirePermission('perm_accessMitgliederverwaltung'))
     ? 'sso.php?redirect='.rawurlencode(trim((string)$optionsDB['urlMitgliederverwaltung']))
     : '';
 $isAdminNav = isAdmin();

--- a/config/ConfigDefaults.php
+++ b/config/ConfigDefaults.php
@@ -597,19 +597,19 @@ function getConfigDefaults() {
             'Parameter' => 'ssoRedirectAllowlist',
             'Value' => '',
             'Type' => 'string',
-            'Description' => 'SSO-Weiterleitung: kommagetrennte Host-Suffixe oder Pfad-Pr&auml;fixe (leer = nur eigener Host)',
+            'Description' => 'SSO Extra-Hosts: kommagetrennte Host-Suffixe oder Pfad-Pr&auml;fixe (Modul-URLs sind automatisch erlaubt)',
         ),
         array(
             'Parameter' => 'urlNotenarchiv',
             'Value' => '',
             'Type' => 'string',
-            'Description' => 'Basis-URL Notenarchiv (Nav-Link via SSO; leer = ausgeblendet)',
+            'Description' => 'Basis-URL Notenarchiv (SSO + Nav bei Recht; leer = ausgeblendet)',
         ),
         array(
             'Parameter' => 'urlMitgliederverwaltung',
             'Value' => '',
             'Type' => 'string',
-            'Description' => 'Basis-URL Mitgliederverwaltung (Nav-Link via SSO; leer = ausgeblendet)',
+            'Description' => 'Basis-URL Mitgliederverwaltung (SSO + Nav bei Recht; leer = ausgeblendet)',
         ),
     );
 }

--- a/config/DBconfig.json
+++ b/config/DBconfig.json
@@ -143,7 +143,9 @@
 	"perm_showResponse": {"Type": "int", "Default": 0},
 	"perm_editResponse": {"Type": "int", "Default": 0},
 	"perm_editConfig": {"Type": "int", "Default": 0},
-	"perm_editPermissions": {"Type": "int", "Default": 0}
+	"perm_editPermissions": {"Type": "int", "Default": 0},
+	"perm_accessNotenarchiv": {"Type": "int", "Default": 0},
+	"perm_accessMitgliederverwaltung": {"Type": "int", "Default": 0}
     },
     "Register": {
 	"Index": {"Type": "int", "Extra": "AUTO_INCREMENT"},

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -3,5 +3,5 @@
  * Expected DB schema version number (MELD-51).
  * Bump when DBconfig.json, DatabaseManager migrations, or ConfigDefaults.php change.
  */
-return 32;
+return 33;
 ?>

--- a/libs/DatabaseManager.php
+++ b/libs/DatabaseManager.php
@@ -193,7 +193,7 @@ class DatabaseManager
         }
 
         $insert = sprintf(
-            'INSERT INTO `%sPermissions` (`User`, `perm_showHiddenAppmnts`, `perm_showUsers`, `perm_editUsers`, `perm_editAppmnts`, `perm_showLog`, `perm_editRegisters`, `perm_showInventories`, `perm_editInventories`, `perm_sendEmail`, `perm_showResponse`, `perm_editResponse`, `perm_editConfig`, `perm_editPermissions`) VALUES (%d, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);',
+            'INSERT INTO `%sPermissions` (`User`, `perm_showHiddenAppmnts`, `perm_showUsers`, `perm_editUsers`, `perm_editAppmnts`, `perm_showLog`, `perm_editRegisters`, `perm_showInventories`, `perm_editInventories`, `perm_sendEmail`, `perm_showResponse`, `perm_editResponse`, `perm_editConfig`, `perm_editPermissions`, `perm_accessNotenarchiv`, `perm_accessMitgliederverwaltung`) VALUES (%d, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);',
             $GLOBALS['dbprefix'],
             $userId
         );

--- a/libs/permissions.php
+++ b/libs/permissions.php
@@ -16,7 +16,9 @@ class Permissions
         'perm_showResponse' => null,
         'perm_editResponse' => null,
         'perm_editConfig' => null,
-        'perm_editPermissions' => null
+        'perm_editPermissions' => null,
+        'perm_accessNotenarchiv' => null,
+        'perm_accessMitgliederverwaltung' => null
     );
     public function __get($key) {
         switch($key) {
@@ -58,6 +60,8 @@ class Permissions
         if($this->perm_editResponse != $old->perm_editResponse) $str.=", perm_editResponse: ".$old->perm_editResponse." &rArr; <b>".$this->perm_editResponse."</b>";
         if($this->perm_editConfig != $old->perm_editConfig) $str.=", perm_editConfig: ".$old->perm_editConfig." &rArr; <b>".$this->perm_editConfig."</b>";
         if($this->perm_editPermissions != $old->perm_editPermissions) $str.=", perm_editPermissions: ".$old->perm_editPermissions." &rArr; <b>".$this->perm_editPermissions."</b>";
+        if($this->perm_accessNotenarchiv != $old->perm_accessNotenarchiv) $str.=", perm_accessNotenarchiv: ".$old->perm_accessNotenarchiv." &rArr; <b>".$this->perm_accessNotenarchiv."</b>";
+        if($this->perm_accessMitgliederverwaltung != $old->perm_accessMitgliederverwaltung) $str.=", perm_accessMitgliederverwaltung: ".$old->perm_accessMitgliederverwaltung." &rArr; <b>".$this->perm_accessMitgliederverwaltung."</b>";
 
         return $str;
     }
@@ -102,32 +106,7 @@ class Permissions
     }
     
     protected function insert() {
-        $sql = sprintf('INSERT INTO `%sPermissions` (`User`, `perm_showHiddenAppmnts`, `perm_showUsers`, `perm_editUsers`, `perm_editAppmnts`, `perm_showLog`, `perm_editRegisters`, `perm_showInventories`, `perm_editInventories`, `perm_sendEmail`, `perm_showResponse`, `perm_editResponse`, `perm_editConfig`, `perm_editPermissions`) VALUES ("%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d");',
-                       $GLOBALS['dbprefix'],
-                       $this->User,
-                       $this->perm_showHiddenAppmnts,
-                       $this->perm_showUsers,
-                       $this->perm_editUsers,
-                       $this->perm_editAppmnts,
-                       $this->perm_showLog,
-                       $this->perm_editRegisters,
-                       $this->perm_showInventories,
-                       $this->perm_editInventories,
-                       $this->perm_sendEmail,
-                       $this->perm_showResponse,
-                       $this->perm_editResponse,
-                       $this->perm_editConfig,
-                       $this->perm_editPermissions
-        );
-        $dbr = mysqli_query($GLOBALS['conn'], $sql);
-        sqlerror();
-        if(!$dbr) return false;
-        $this->_data['Index'] = mysqli_insert_id($GLOBALS['conn']);
-        return true;
-    }
-    
-    protected function update() {
-        $sql = sprintf('UPDATE `%sPermissions` SET `User` = "%d", `perm_showHiddenAppmnts` = "%d", `perm_showUsers` = "%d", `perm_editUsers` = "%d", `perm_editAppmnts` = "%d", `perm_showLog` = "%d", `perm_editRegisters` = "%d", `perm_showInventories` = "%d", `perm_editInventories` = "%d", `perm_sendEmail` = "%d", `perm_showResponse` = "%d", `perm_editResponse` = "%d", `perm_editConfig` = "%d", `perm_editPermissions` = "%d" WHERE `Index` = "%d";',
+        $sql = sprintf('INSERT INTO `%sPermissions` (`User`, `perm_showHiddenAppmnts`, `perm_showUsers`, `perm_editUsers`, `perm_editAppmnts`, `perm_showLog`, `perm_editRegisters`, `perm_showInventories`, `perm_editInventories`, `perm_sendEmail`, `perm_showResponse`, `perm_editResponse`, `perm_editConfig`, `perm_editPermissions`, `perm_accessNotenarchiv`, `perm_accessMitgliederverwaltung`) VALUES ("%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d", "%d");',
                        $GLOBALS['dbprefix'],
                        $this->User,
                        $this->perm_showHiddenAppmnts,
@@ -143,6 +122,35 @@ class Permissions
                        $this->perm_editResponse,
                        $this->perm_editConfig,
                        $this->perm_editPermissions,
+                       $this->perm_accessNotenarchiv,
+                       $this->perm_accessMitgliederverwaltung
+        );
+        $dbr = mysqli_query($GLOBALS['conn'], $sql);
+        sqlerror();
+        if(!$dbr) return false;
+        $this->_data['Index'] = mysqli_insert_id($GLOBALS['conn']);
+        return true;
+    }
+    
+    protected function update() {
+        $sql = sprintf('UPDATE `%sPermissions` SET `User` = "%d", `perm_showHiddenAppmnts` = "%d", `perm_showUsers` = "%d", `perm_editUsers` = "%d", `perm_editAppmnts` = "%d", `perm_showLog` = "%d", `perm_editRegisters` = "%d", `perm_showInventories` = "%d", `perm_editInventories` = "%d", `perm_sendEmail` = "%d", `perm_showResponse` = "%d", `perm_editResponse` = "%d", `perm_editConfig` = "%d", `perm_editPermissions` = "%d", `perm_accessNotenarchiv` = "%d", `perm_accessMitgliederverwaltung` = "%d" WHERE `Index` = "%d";',
+                       $GLOBALS['dbprefix'],
+                       $this->User,
+                       $this->perm_showHiddenAppmnts,
+                       $this->perm_showUsers,
+                       $this->perm_editUsers,
+                       $this->perm_editAppmnts,
+                       $this->perm_showLog,
+                       $this->perm_editRegisters,
+                       $this->perm_showInventories,
+                       $this->perm_editInventories,
+                       $this->perm_sendEmail,
+                       $this->perm_showResponse,
+                       $this->perm_editResponse,
+                       $this->perm_editConfig,
+                       $this->perm_editPermissions,
+                       $this->perm_accessNotenarchiv,
+                       $this->perm_accessMitgliederverwaltung,
                        $this->Index
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
@@ -325,6 +333,8 @@ class Permissions
             'perm_editResponse',
             'perm_editConfig',
             'perm_editPermissions',
+            'perm_accessNotenarchiv',
+            'perm_accessMitgliederverwaltung',
         );
     }
 
@@ -346,6 +356,8 @@ class Permissions
             'perm_editResponse' => array('short' => 'Melden+', 'label' => 'Rückmeldungen bearbeiten'),
             'perm_editConfig' => array('short' => 'Config', 'label' => 'Konfiguration bearbeiten'),
             'perm_editPermissions' => array('short' => 'Rechte', 'label' => 'Berechtigungen bearbeiten'),
+            'perm_accessNotenarchiv' => array('short' => 'Notenarchiv', 'label' => 'Notenarchiv'),
+            'perm_accessMitgliederverwaltung' => array('short' => 'Mitgliederverw.', 'label' => 'Mitgliederverwaltung'),
         );
     }
 
@@ -396,6 +408,12 @@ class Permissions
                 'title' => 'System',
                 'color' => '#78909C',
                 'keys' => array('perm_showLog', 'perm_editConfig'),
+            ),
+            array(
+                'id' => 'plattform',
+                'title' => 'Plattform',
+                'color' => '#8D6E63',
+                'keys' => array('perm_accessNotenarchiv', 'perm_accessMitgliederverwaltung'),
             ),
         );
     }

--- a/libs/ssoRedirect.php
+++ b/libs/ssoRedirect.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * SSO redirect allowlist helpers (MELD-171).
+ */
+
+/**
+ * Host from an absolute URL, lowercased, or empty string.
+ */
+function ssoHostFromUrl($url) {
+    $url = trim((string)$url);
+    if($url === '') {
+        return '';
+    }
+    $parts = parse_url($url);
+    if(!$parts || empty($parts['host'])) {
+        return '';
+    }
+    return strtolower((string)$parts['host']);
+}
+
+/**
+ * Melde app host from WebSiteURL / HTTP_HOST.
+ */
+function ssoMeldeHost() {
+    global $optionsDB;
+    $base = parse_url(isset($optionsDB['WebSiteURL']) ? (string)$optionsDB['WebSiteURL'] : '');
+    if($base && !empty($base['host'])) {
+        return strtolower((string)$base['host']);
+    }
+    return strtolower((string)($_SERVER['HTTP_HOST'] ?? ''));
+}
+
+/**
+ * True if absolute redirect URL is allowed (same host, configured module URLs, or ssoRedirectAllowlist).
+ */
+function ssoRedirectAllowed($url) {
+    $url = trim((string)$url);
+    if($url === '') {
+        return false;
+    }
+    $parts = parse_url($url);
+    if(!$parts || empty($parts['scheme']) || empty($parts['host'])) {
+        return false;
+    }
+    if(!in_array(strtolower((string)$parts['scheme']), array('http', 'https'), true)) {
+        return false;
+    }
+    $host = strtolower((string)$parts['host']);
+    $path = isset($parts['path']) ? (string)$parts['path'] : '/';
+
+    $meldeHost = ssoMeldeHost();
+    if($meldeHost !== '' && $host === $meldeHost) {
+        return true;
+    }
+
+    global $optionsDB;
+    foreach(array('urlNotenarchiv', 'urlMitgliederverwaltung') as $key) {
+        $cfgHost = ssoHostFromUrl(isset($optionsDB[$key]) ? (string)$optionsDB[$key] : '');
+        if($cfgHost !== '' && $host === $cfgHost) {
+            return true;
+        }
+    }
+
+    $allowlist = isset($optionsDB['ssoRedirectAllowlist']) ? trim((string)$optionsDB['ssoRedirectAllowlist']) : '';
+    if($allowlist === '') {
+        return false;
+    }
+
+    $entries = array_map('trim', explode(',', $allowlist));
+    foreach($entries as $entry) {
+        if($entry === '') {
+            continue;
+        }
+        if($entry[0] === '/') {
+            if(strpos($path, $entry) === 0) {
+                return true;
+            }
+            continue;
+        }
+        $suffix = strtolower($entry);
+        if($host === $suffix || substr($host, -strlen($suffix)) === $suffix) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Permission key required for redirect to a configured module URL, or null.
+ *
+ * @return string|null
+ */
+function ssoPermissionForRedirect($url) {
+    $host = ssoHostFromUrl($url);
+    if($host === '') {
+        return null;
+    }
+    global $optionsDB;
+    $archivHost = ssoHostFromUrl(isset($optionsDB['urlNotenarchiv']) ? (string)$optionsDB['urlNotenarchiv'] : '');
+    if($archivHost !== '' && $host === $archivHost) {
+        return 'perm_accessNotenarchiv';
+    }
+    $mitHost = ssoHostFromUrl(isset($optionsDB['urlMitgliederverwaltung']) ? (string)$optionsDB['urlMitgliederverwaltung'] : '');
+    if($mitHost !== '' && $host === $mitHost) {
+        return 'perm_accessMitgliederverwaltung';
+    }
+    return null;
+}
+?>

--- a/sso.php
+++ b/sso.php
@@ -12,51 +12,6 @@ function ssoAppendParam($url, $key, $value) {
     return $url.$sep.rawurlencode($key).'='.rawurlencode($value);
 }
 
-/**
- * True if absolute redirect URL is allowed by ssoRedirectAllowlist / same host.
- */
-function ssoRedirectAllowed($url) {
-    $url = trim((string)$url);
-    if($url === '') {
-        return false;
-    }
-    $parts = parse_url($url);
-    if(!$parts || empty($parts['scheme']) || empty($parts['host'])) {
-        return false;
-    }
-    if(!in_array(strtolower($parts['scheme']), array('http', 'https'), true)) {
-        return false;
-    }
-    $host = strtolower($parts['host']);
-    $path = isset($parts['path']) ? $parts['path'] : '/';
-
-    global $optionsDB;
-    $allowlist = isset($optionsDB['ssoRedirectAllowlist']) ? trim((string)$optionsDB['ssoRedirectAllowlist']) : '';
-    if($allowlist === '') {
-        $base = parse_url(isset($optionsDB['WebSiteURL']) ? $optionsDB['WebSiteURL'] : '');
-        $baseHost = ($base && !empty($base['host'])) ? strtolower($base['host']) : strtolower($_SERVER['HTTP_HOST'] ?? '');
-        return $host === $baseHost;
-    }
-
-    $entries = array_map('trim', explode(',', $allowlist));
-    foreach($entries as $entry) {
-        if($entry === '') {
-            continue;
-        }
-        if($entry[0] === '/') {
-            if(strpos($path, $entry) === 0) {
-                return true;
-            }
-            continue;
-        }
-        $suffix = strtolower($entry);
-        if($host === $suffix || substr($host, -strlen($suffix)) === $suffix) {
-            return true;
-        }
-    }
-    return false;
-}
-
 function ssoLoginByUserId($userId) {
     $userId = (int)$userId;
     if($userId < 1) {
@@ -106,6 +61,12 @@ if(!loggedIn()) {
 if(!ssoRedirectAllowed($redirect)) {
     http_response_code(403);
     die('<div class="w3-panel w3-red w3-padding"><b>SSO-Weiterleitung nicht erlaubt.</b></div>');
+}
+
+$permKey = ssoPermissionForRedirect($redirect);
+if($permKey !== null && !requirePermission($permKey)) {
+    http_response_code(403);
+    die('<div class="w3-panel w3-red w3-padding"><b>Keine Berechtigung für dieses Modul.</b></div>');
 }
 
 $targetHint = '';

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -48,6 +48,8 @@ $sections[] = array(
 '.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir gehörendes oder an dich ausgeliehenes Inventar</li>' : '').'
 <li><i class="fas fa-user"></i> <b>Mein Profil</b> – eigene Stammdaten und Einstellungen (Desktop in der Seitenleiste, Tablet/Smartphone unter <b>Mehr</b>)</li>
 <li><i class="fas fa-photo-film"></i> <b>Medien</b> – Links zu Aufnahmen und Social Media (konfigurierbar)</li>
+'.((!empty($optionsDB['urlNotenarchiv']) && requirePermission('perm_accessNotenarchiv')) ? '<li><i class="fas fa-book"></i> <b>Notenarchiv</b> – SSO-Link zum Notenarchiv</li>' : '').'
+'.((!empty($optionsDB['urlMitgliederverwaltung']) && requirePermission('perm_accessMitgliederverwaltung')) ? '<li><i class="fas fa-id-card"></i> <b>Mitgliederverw.</b> – SSO-Link zur Mitgliederverwaltung</li>' : '').'
 <li>Logo oben rechts – öffnet die <b>Vereinshomepage</b> in einem neuen Tab</li>
 <li><i class="fas fa-circle-question"></i> <b>Hilfe</b> – diese Seite inkl. Changelog</li>
 '.(isAdmin() ? '<li><i class="fas fa-wrench"></i> <b>Admin</b> – Verwaltungsmenü in der Reihenfolge Personen → Termine → Meldungen → Kommunikation → Inventar → Register → System; Einträge sind in denselben Farben wie die Rechte-Chips eingefärbt (Desktop links unten, Tablet/Smartphone unter Mehr)</li>' : '').'
@@ -260,7 +262,7 @@ $sections[] = array(
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '
 <li><b>Konfiguration</b> – Farben, Texte, Feature-Schalter, Webhooks, …; Änderungen erscheinen im Log</li>
-<li><b>Plattform / SSO</b> – <code>ssoRedirectAllowlist</code>, <code>urlNotenarchiv</code> und <code>urlMitgliederverwaltung</code> für einmalige SSO-Tickets zu Schwester-Modulen (Nav-Links erscheinen bei gesetzter URL)</li>
+<li><b>Plattform / SSO</b> – <code>urlNotenarchiv</code> und <code>urlMitgliederverwaltung</code> setzen die Modul-Ziele (Hosts daraus sind für SSO automatisch erlaubt); <code>ssoRedirectAllowlist</code> nur für Extra-Hosts. Nav-Links erscheinen bei gesetzter URL und dem Recht <b>Notenarchiv</b> bzw. <b>Mitgliederverw.</b></li>
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Statistik</b> – Auswertungen; auf breiten Bildschirmen Diagramme und Listen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>). Ranking und Inaktive teilen sich denselben Chip-Filter wie die Personenliste (Aktive/Gäste/Mitglieder, Register, Gruppen) und nutzen denselben Zeilen-Stil inkl. Sortier-Chips</li>


### PR DESCRIPTION
## Summary
- Hosts aus `urlNotenarchiv` / `urlMitgliederverwaltung` für SSO automatisch erlaubt
- Neue Rechte `perm_accessNotenarchiv` und `perm_accessMitgliederverwaltung` (Schema 33)
- Nav-Links und SSO-Tickets nur mit entsprechendem Recht

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-171

## Test plan
- [ ] Updater/DB-Repair auf Schema 33
- [ ] Recht „Notenarchiv“ vergeben → Nav-Link sichtbar
- [ ] SSO zum Archiv ohne „Weiterleitung nicht erlaubt“
- [ ] Ohne Recht: kein Nav-Link, SSO 403
- [ ] Tests grün (`SsoRedirectAllowedTest`, Schema 33)