### PR TITLE
MELD-194: Nav-Label Mitglieder statt Mitgliederverw.

### DIFF
--- a/common/nav.php
+++ b/common/nav.php
@@ -110,7 +110,7 @@ if(requirePermission('perm_editConfig')) {
 <?php } ?>
 <?php if($ssoMit !== '') { ?>
     <a class="app-nav-item app-nav-item--secondary <?php echo htmlspecialchars(navGroupClass('nutzer'), ENT_QUOTES, 'UTF-8'); ?>" href="<?php echo htmlspecialchars($ssoMit, ENT_QUOTES, 'UTF-8'); ?>" title="Mitgliederverwaltung">
-      <i class="fas fa-id-card" aria-hidden="true"></i><span class="nav-label">Mitgliederverw.</span>
+      <i class="fas fa-id-card" aria-hidden="true"></i><span class="nav-label">Mitglieder</span>
     </a>
 <?php } ?>
     <a class="app-nav-item app-nav-item--secondary <?php getPage('help', 'system'); ?>" href="help.php" title="Hilfe">
@@ -152,7 +152,7 @@ if(requirePermission('perm_editConfig')) {
 <?php } ?>
 <?php if($ssoMit !== '') { ?>
         <a class="app-nav-item app-nav-more-only-mobile <?php echo htmlspecialchars(navGroupClass('nutzer'), ENT_QUOTES, 'UTF-8'); ?>" href="<?php echo htmlspecialchars($ssoMit, ENT_QUOTES, 'UTF-8'); ?>" title="Mitgliederverwaltung">
-          <i class="fas fa-id-card" aria-hidden="true"></i><span class="nav-label">Mitgliederverw.</span>
+          <i class="fas fa-id-card" aria-hidden="true"></i><span class="nav-label">Mitglieder</span>
         </a>
 <?php } ?>
         <a class="app-nav-item app-nav-more-only-mobile <?php getPage('help', 'system'); ?>" href="help.php" title="Hilfe">

--- a/libs/permissions.php
+++ b/libs/permissions.php
@@ -357,7 +357,7 @@ class Permissions
             'perm_editConfig' => array('short' => 'Config', 'label' => 'Konfiguration bearbeiten'),
             'perm_editPermissions' => array('short' => 'Rechte', 'label' => 'Berechtigungen bearbeiten'),
             'perm_accessNotenarchiv' => array('short' => 'Notenarchiv', 'label' => 'Notenarchiv'),
-            'perm_accessMitgliederverwaltung' => array('short' => 'Mitgliederverw.', 'label' => 'Mitgliederverwaltung'),
+            'perm_accessMitgliederverwaltung' => array('short' => 'Mitglieder', 'label' => 'Mitgliederverwaltung'),
         );
     }
 

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -49,7 +49,7 @@ $sections[] = array(
 <li><i class="fas fa-user"></i> <b>Mein Profil</b> – eigene Stammdaten und Einstellungen (Desktop in der Seitenleiste, Tablet/Smartphone unter <b>Mehr</b>)</li>
 <li><i class="fas fa-photo-film"></i> <b>Medien</b> – Links zu Aufnahmen und Social Media (konfigurierbar)</li>
 '.((!empty($optionsDB['urlNotenarchiv']) && requirePermission('perm_accessNotenarchiv')) ? '<li><i class="fas fa-book"></i> <b>Notenarchiv</b> – SSO-Link zum Notenarchiv</li>' : '').'
-'.((!empty($optionsDB['urlMitgliederverwaltung']) && requirePermission('perm_accessMitgliederverwaltung')) ? '<li><i class="fas fa-id-card"></i> <b>Mitgliederverw.</b> – SSO-Link zur Mitgliederverwaltung</li>' : '').'
+'.((!empty($optionsDB['urlMitgliederverwaltung']) && requirePermission('perm_accessMitgliederverwaltung')) ? '<li><i class="fas fa-id-card"></i> <b>Mitglieder</b> – SSO-Link zur Mitgliederverwaltung</li>' : '').'
 <li>Logo oben rechts – öffnet die <b>Vereinshomepage</b> in einem neuen Tab</li>
 <li><i class="fas fa-circle-question"></i> <b>Hilfe</b> – diese Seite inkl. Changelog</li>
 '.(isAdmin() ? '<li><i class="fas fa-wrench"></i> <b>Admin</b> – Verwaltungsmenü in der Reihenfolge Personen → Termine → Meldungen → Kommunikation → Inventar → Register → System; Einträge sind in denselben Farben wie die Rechte-Chips eingefärbt (Desktop links unten, Tablet/Smartphone unter Mehr)</li>' : '').'
@@ -262,7 +262,7 @@ $sections[] = array(
 ' : '').'
 '.(requirePermission('perm_editConfig') ? '
 <li><b>Konfiguration</b> – Farben, Texte, Feature-Schalter, Webhooks, …; Änderungen erscheinen im Log</li>
-<li><b>Plattform / SSO</b> – <code>urlNotenarchiv</code> und <code>urlMitgliederverwaltung</code> setzen die Modul-Ziele (Hosts daraus sind für SSO automatisch erlaubt); <code>ssoRedirectAllowlist</code> nur für Extra-Hosts. Nav-Links erscheinen bei gesetzter URL und dem Recht <b>Notenarchiv</b> bzw. <b>Mitgliederverw.</b></li>
+<li><b>Plattform / SSO</b> – <code>urlNotenarchiv</code> und <code>urlMitgliederverwaltung</code> setzen die Modul-Ziele (Hosts daraus sind für SSO automatisch erlaubt); <code>ssoRedirectAllowlist</code> nur für Extra-Hosts. Nav-Links erscheinen bei gesetzter URL und dem Recht <b>Notenarchiv</b> bzw. <b>Mitglieder</b></li>
 ' : '').'
 '.(requirePermission('perm_showLog') ? '
 <li><b>Statistik</b> – Auswertungen; auf breiten Bildschirmen Diagramme und Listen zweispaltig. Zeitraum in Tagen frei wählen, Teilnahme-/Log-Charts, Ranking und Inaktive (ohne Login/Teilnahme im Schwellwert <code>inactiveUsersDays</code>). Ranking und Inaktive teilen sich denselben Chip-Filter wie die Personenliste (Aktive/Gäste/Mitglieder, Register, Gruppen) und nutzen denselben Zeilen-Stil inkl. Sortier-Chips</li>


### PR DESCRIPTION
## Summary
- Nav- und Rechte-Chip-Kurzlabel „Mitglieder“ (ohne Abbreviation)
- Tooltip bleibt „Mitgliederverwaltung“; Hilfe angepasst

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-194

## Test plan
- [ ] Nav zeigt „Mitglieder“
- [ ] title/Hover weiterhin Mitgliederverwaltung