### PR TITLE
MELD-197: Termin-Programm aus Archiv-Sammlungen

### DIFF
--- a/common/include.php
+++ b/common/include.php
@@ -54,4 +54,5 @@ include "libs/icalFeed.php";
 include "libs/ssoTicket.php";
 include "libs/ssoRedirect.php";
 include "libs/userVoice.php";
+include "libs/archivCollection.php";
 ?>

--- a/config/DBconfig.json
+++ b/config/DBconfig.json
@@ -201,6 +201,7 @@
 	"defaultFreeText": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
 	"VisibilitySpec": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
 	"GuestMusicians": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
+	"Sammlungen": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
 	"PostDiscord": {"Type": "tinyint", "Default": 0},
 	"Created": {"Type": "timestamp", "Default": "CURRENT_TIMESTAMP", "Extra": "DEFAULT_GENERATED"},
 	"Updated": {"Type": "timestamp", "Default": "CURRENT_TIMESTAMP", "Extra": "DEFAULT_GENERATED"}

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -5,6 +5,8 @@
  * v34: drop User.Birthday (owned by mit_MemberProfile); Fördernde filter via mit_Membership.
  * v35: drop User.Mitglied (owned by MIT MembershipPeriod tenure; Melde Active stays Betriebsflag).
  * v36: drop User.RefID (Mitgliedsnummer obsolete; canonical id is User.Index).
+ * v37: Termine.Sammlungen (JSON int[] → archiv_Collection when Notenarchiv is attached).
+ * v38: ensure Termine.Sammlungen (text JSON); drop obsolete Termine.Sammlung if present.
  */
-return 36;
+return 38;
 ?>

--- a/getModal.php
+++ b/getModal.php
@@ -143,6 +143,36 @@ case 'mail':
     echo $job->getModalHtml();
     break;
 
+case 'sammlung':
+    if(!function_exists('archivFeatureEnabled') || !archivFeatureEnabled()) {
+        http_response_code(404);
+        echo '<div class="profile-shell modal-shell"><header class="profile-hero"><h2 class="profile-title">Sammlung</h2><button type="button" class="modal-close w3-button" onclick="closeModal()" aria-label="Schließen">&times;</button></header><p class="profile-value">Notenarchiv ist nicht angeschlossen.</p></div>';
+        exit;
+    }
+    $html = archivCollectionModalHtml($id);
+    if($html === '') {
+        http_response_code(404);
+        echo '<div class="profile-shell modal-shell"><header class="profile-hero"><h2 class="profile-title">Sammlung</h2><button type="button" class="modal-close w3-button" onclick="closeModal()" aria-label="Schließen">&times;</button></header><p class="profile-value">Sammlung nicht gefunden.</p></div>';
+        exit;
+    }
+    echo $html;
+    break;
+
+case 'programm':
+    if(!function_exists('archivFeatureEnabled') || !archivFeatureEnabled()) {
+        http_response_code(404);
+        echo '<div class="profile-shell modal-shell"><header class="profile-hero"><h2 class="profile-title">Programm</h2><button type="button" class="modal-close w3-button" onclick="closeModal()" aria-label="Schließen">&times;</button></header><p class="profile-value">Notenarchiv ist nicht angeschlossen.</p></div>';
+        exit;
+    }
+    $html = archivTerminProgrammModalHtml($id);
+    if($html === '') {
+        http_response_code(404);
+        echo '<div class="profile-shell modal-shell"><header class="profile-hero"><h2 class="profile-title">Programm</h2><button type="button" class="modal-close w3-button" onclick="closeModal()" aria-label="Schließen">&times;</button></header><p class="profile-value">Termin nicht gefunden.</p></div>';
+        exit;
+    }
+    echo $html;
+    break;
+
 default:
     http_response_code(400);
     echo '<div class="w3-container w3-padding"><p>Unbekannter Modal-Typ.</p></div>';

--- a/js/modal.js
+++ b/js/modal.js
@@ -69,7 +69,7 @@ function openEntityFromEl(el) {
     if(!type || !(id > 0)) return false;
     if(type === 'inventory') type = 'inventar';
     if(type === 'shift') type = 'shiftResponse';
-    if(type !== 'user' && type !== 'termin' && type !== 'inventar' && type !== 'mail' && type !== 'shiftResponse') return false;
+    if(type !== 'user' && type !== 'termin' && type !== 'inventar' && type !== 'mail' && type !== 'shiftResponse' && type !== 'sammlung' && type !== 'programm') return false;
     openModal(type, id);
     return true;
 }

--- a/js/sammlungChips.js
+++ b/js/sammlungChips.js
@@ -1,0 +1,204 @@
+/**
+ * MELD-197: chip picker for Archiv-Sammlungen (id list in hidden JSON).
+ */
+(function(global) {
+  'use strict';
+
+  function normalizeIdList(list) {
+    if(!Array.isArray(list)) return [];
+    return list.map(Number).filter(function(n) { return n > 0; }).filter(function(n, i, a) {
+      return a.indexOf(n) === i;
+    });
+  }
+
+  function parseCatalog(el) {
+    if(!el) return [];
+    try {
+      var c = JSON.parse(el.textContent || '[]');
+      if(!Array.isArray(c)) return [];
+      return c.map(function(row) {
+        return {
+          id: Number(row.id) || 0,
+          label: String(row.label || row.name || '').trim()
+        };
+      }).filter(function(row) { return row.id > 0 && row.label !== ''; });
+    } catch(e) {
+      return [];
+    }
+  }
+
+  function parseIds(el) {
+    if(!el) return [];
+    try {
+      return normalizeIdList(JSON.parse(el.value || '[]'));
+    } catch(e) {
+      return [];
+    }
+  }
+
+  function normalize(str) {
+    return (str || '').toLowerCase().replace(/\s+/g, ' ').trim();
+  }
+
+  var SammlungChips = {
+    init: function(opts) {
+      this.catalog = parseCatalog(opts.catalogEl);
+      this.chipsEl = opts.chipsEl;
+      this.inputEl = opts.inputEl;
+      this.suggestEl = opts.suggestEl;
+      this.hiddenEl = opts.hiddenEl;
+      this.ids = parseIds(this.hiddenEl);
+      this._active = -1;
+      if(this.inputEl) {
+        this.inputEl.addEventListener('input', this.onInput.bind(this));
+        this.inputEl.addEventListener('keydown', this.onKeydown.bind(this));
+        this.inputEl.addEventListener('blur', this.onBlur.bind(this));
+        this.inputEl.addEventListener('focus', this.onInput.bind(this));
+      }
+      this.render();
+      this.syncHidden();
+    },
+
+    syncHidden: function() {
+      if(this.hiddenEl) {
+        this.hiddenEl.value = JSON.stringify(this.ids.slice());
+      }
+    },
+
+    labelFor: function(id) {
+      id = Number(id);
+      for(var i = 0; i < this.catalog.length; i++) {
+        if(this.catalog[i].id === id) return this.catalog[i].label;
+      }
+      return 'Sammlung #' + id;
+    },
+
+    render: function() {
+      if(!this.chipsEl) return;
+      var self = this;
+      this.chipsEl.innerHTML = '';
+      this.ids.forEach(function(id) {
+        var chip = document.createElement('span');
+        chip.className = 'mail-recipient-chip mail-recipient-chip--instrument';
+        chip.setAttribute('role', 'listitem');
+        chip.textContent = self.labelFor(id) + ' ';
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'mail-recipient-chip-remove';
+        btn.setAttribute('aria-label', 'Entfernen');
+        btn.textContent = '×';
+        btn.addEventListener('click', function(e) {
+          e.preventDefault();
+          e.stopPropagation();
+          self.removeId(id);
+        });
+        chip.appendChild(btn);
+        self.chipsEl.appendChild(chip);
+      });
+    },
+
+    addId: function(id) {
+      id = Number(id);
+      if(id < 1 || this.ids.indexOf(id) !== -1) return;
+      this.ids.push(id);
+      this.syncHidden();
+      this.render();
+      if(this.inputEl) this.inputEl.value = '';
+      this.hideSuggest();
+    },
+
+    removeId: function(id) {
+      id = Number(id);
+      this.ids = this.ids.filter(function(n) { return n !== id; });
+      this.syncHidden();
+      this.render();
+    },
+
+    matches: function(q) {
+      q = normalize(q);
+      var self = this;
+      var selected = {};
+      this.ids.forEach(function(id) { selected[id] = true; });
+      return this.catalog.filter(function(row) {
+        if(selected[row.id]) return false;
+        if(q === '') return true;
+        return normalize(row.label).indexOf(q) !== -1;
+      }).slice(0, 12);
+    },
+
+    hideSuggest: function() {
+      if(!this.suggestEl) return;
+      this.suggestEl.hidden = true;
+      this.suggestEl.innerHTML = '';
+      this._active = -1;
+    },
+
+    showSuggest: function(items) {
+      if(!this.suggestEl) return;
+      var self = this;
+      this.suggestEl.innerHTML = '';
+      if(!items.length) {
+        this.hideSuggest();
+        return;
+      }
+      items.forEach(function(row, idx) {
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'mail-recipient-suggest-item';
+        btn.textContent = row.label;
+        btn.addEventListener('mousedown', function(e) {
+          e.preventDefault();
+          self.addId(row.id);
+        });
+        if(idx === self._active) {
+          btn.className += ' mail-recipient-suggest-item--active';
+        }
+        self.suggestEl.appendChild(btn);
+      });
+      this.suggestEl.hidden = false;
+    },
+
+    onInput: function() {
+      var q = this.inputEl ? this.inputEl.value : '';
+      this._active = -1;
+      this.showSuggest(this.matches(q));
+    },
+
+    onBlur: function() {
+      var self = this;
+      setTimeout(function() { self.hideSuggest(); }, 150);
+    },
+
+    onKeydown: function(e) {
+      var items = this.suggestEl && !this.suggestEl.hidden
+        ? this.suggestEl.querySelectorAll('.mail-recipient-suggest-item')
+        : [];
+      if(e.key === 'ArrowDown' && items.length) {
+        e.preventDefault();
+        this._active = Math.min(this._active + 1, items.length - 1);
+        this.showSuggest(this.matches(this.inputEl.value));
+      }
+      else if(e.key === 'ArrowUp' && items.length) {
+        e.preventDefault();
+        this._active = Math.max(this._active - 1, 0);
+        this.showSuggest(this.matches(this.inputEl.value));
+      }
+      else if(e.key === 'Enter') {
+        var list = this.matches(this.inputEl ? this.inputEl.value : '');
+        if(list.length) {
+          e.preventDefault();
+          var idx = this._active >= 0 ? this._active : 0;
+          if(list[idx]) this.addId(list[idx].id);
+        }
+      }
+      else if(e.key === 'Backspace' && this.inputEl && this.inputEl.value === '' && this.ids.length) {
+        this.removeId(this.ids[this.ids.length - 1]);
+      }
+      else if(e.key === 'Escape') {
+        this.hideSuggest();
+      }
+    }
+  };
+
+  global.SammlungChips = SammlungChips;
+})(window);

--- a/libs/archivCollection.php
+++ b/libs/archivCollection.php
@@ -1,0 +1,473 @@
+<?php
+/**
+ * Read-only access to Notenarchiv collections (shared DB, prefix archiv_).
+ * MELD-197 — no PHP include from Notenarchiv.
+ */
+
+/** @return string */
+function archivDbPrefix() {
+    return 'archiv_';
+}
+
+/**
+ * Whether archiv collection + composition (+ people/publisher) tables exist.
+ * @return bool
+ */
+function archivCollectionsReady() {
+    static $ready = null;
+    static $probedMissing = false;
+    if($ready === true) {
+        return true;
+    }
+    if($ready === false && $probedMissing) {
+        $probedMissing = false;
+    }
+    if(!isset($GLOBALS['conn']) || !($GLOBALS['conn'] instanceof mysqli)) {
+        $ready = false;
+        $probedMissing = true;
+        return false;
+    }
+    $prefix = archivDbPrefix();
+    $tables = array(
+        $prefix.'Collection',
+        $prefix.'CollectionItem',
+        $prefix.'Composition',
+        $prefix.'Composer',
+        $prefix.'Publisher',
+    );
+    foreach($tables as $table) {
+        $like = mysqli_real_escape_string($GLOBALS['conn'], $table);
+        $dbr = mysqli_query($GLOBALS['conn'], "SHOW TABLES LIKE '".$like."'");
+        if(!$dbr || !mysqli_fetch_array($dbr)) {
+            $ready = false;
+            $probedMissing = true;
+            return false;
+        }
+    }
+    $ready = true;
+    return true;
+}
+
+/**
+ * Feature gate: Archiv URL configured and collection tables present.
+ * @return bool
+ */
+function archivFeatureEnabled() {
+    $url = isset($GLOBALS['optionsDB']['urlNotenarchiv'])
+        ? trim((string)$GLOBALS['optionsDB']['urlNotenarchiv'])
+        : '';
+    if($url === '') {
+        return false;
+    }
+    return archivCollectionsReady();
+}
+
+/**
+ * Base URL of the Notenarchiv app (trailing slash), or ''.
+ * @return string
+ */
+function archivNotenarchivBaseUrl() {
+    $url = isset($GLOBALS['optionsDB']['urlNotenarchiv'])
+        ? trim((string)$GLOBALS['optionsDB']['urlNotenarchiv'])
+        : '';
+    if($url === '') {
+        return '';
+    }
+    return rtrim($url, '/').'/';
+}
+
+/**
+ * Active collections for a select list: list of array{id:int,name:string}.
+ * @return list<array{id:int,name:string}>
+ */
+function archivListCollectionsForSelect() {
+    $out = array();
+    if(!archivCollectionsReady()) {
+        return $out;
+    }
+    $sql = sprintf(
+        'SELECT `Index`, `Name` FROM `%sCollection` WHERE `Archived` = 0 ORDER BY `Name` ASC, `Index` ASC;',
+        archivDbPrefix()
+    );
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    if(!$dbr) {
+        return $out;
+    }
+    while($row = mysqli_fetch_array($dbr)) {
+        $id = (int)$row['Index'];
+        $name = trim((string)$row['Name']);
+        if($id < 1) {
+            continue;
+        }
+        if($name === '') {
+            $name = 'Sammlung #'.$id;
+        }
+        $out[] = array('id' => $id, 'name' => $name);
+    }
+    return $out;
+}
+
+/**
+ * Collection name or '' if missing.
+ * @param int $id
+ * @return string
+ */
+function archivCollectionName($id) {
+    $id = (int)$id;
+    if($id < 1 || !archivCollectionsReady()) {
+        return '';
+    }
+    $sql = sprintf(
+        'SELECT `Name` FROM `%sCollection` WHERE `Index` = "%d" LIMIT 1;',
+        archivDbPrefix(),
+        $id
+    );
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    if(!$dbr || !($row = mysqli_fetch_array($dbr))) {
+        return '';
+    }
+    $name = trim((string)$row['Name']);
+    return $name !== '' ? $name : ('Sammlung #'.$id);
+}
+
+/**
+ * Legacy Archiv text may store HTML entities (&uuml;, &bdquo;, …).
+ * @param mixed $value
+ * @return string
+ */
+function archivPlainText($value) {
+    return html_entity_decode((string)$value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+}
+
+/**
+ * @param string $first
+ * @param string $last
+ * @return string
+ */
+function archivPersonDisplayName($first, $last) {
+    $parts = array();
+    $first = trim(archivPlainText($first));
+    $last = trim(archivPlainText($last));
+    if($first !== '') {
+        $parts[] = $first;
+    }
+    if($last !== '') {
+        $parts[] = $last;
+    }
+    return implode(' ', $parts);
+}
+
+/**
+ * Up to two initials from a title (Archiv cover placeholder parity).
+ * @param string $title
+ * @return string
+ */
+function archivCoverInitials($title) {
+    $title = trim((string)$title);
+    if($title === '') {
+        return '—';
+    }
+    $skip = array(
+        'der', 'die', 'das', 'den', 'dem', 'des',
+        'ein', 'eine', 'einen', 'einem', 'einer',
+        'the', 'a', 'an', 'le', 'la', 'les',
+        'of', 'und', 'and', 'im', 'in', 'am', 'zu', 'zur', 'zum',
+    );
+    $words = preg_split('/[\s\-–—]+/u', $title, -1, PREG_SPLIT_NO_EMPTY);
+    if(!is_array($words)) {
+        $words = array($title);
+    }
+    $letters = array();
+    $firstWord = '';
+    foreach($words as $w) {
+        $plain = preg_replace('/[^\p{L}\p{N}]+/u', '', (string)$w);
+        if($plain === null || $plain === '') {
+            continue;
+        }
+        if(in_array(mb_strtolower($plain, 'UTF-8'), $skip, true)) {
+            continue;
+        }
+        if($firstWord === '') {
+            $firstWord = $plain;
+        }
+        $letters[] = mb_strtoupper(mb_substr($plain, 0, 1, 'UTF-8'), 'UTF-8');
+        if(count($letters) >= 2) {
+            break;
+        }
+    }
+    if(count($letters) >= 2) {
+        return implode('', $letters);
+    }
+    if($firstWord !== '') {
+        return mb_strtoupper(mb_substr($firstWord, 0, 2, 'UTF-8'), 'UTF-8');
+    }
+    $compact = preg_replace('/\s+/u', '', $title);
+    return mb_strtoupper(mb_substr((string)$compact, 0, 2, 'UTF-8'), 'UTF-8');
+}
+
+/**
+ * Absolute http(s) URL for a stored website value, or empty string.
+ * @param string $url
+ * @return string
+ */
+function archivNormalizeWebsiteUrl($url) {
+    $url = trim((string)$url);
+    if($url === '') {
+        return '';
+    }
+    if(!preg_match('#^https?://#i', $url)) {
+        $url = 'https://'.$url;
+    }
+    return $url;
+}
+
+/**
+ * Cover thumbnail HTML (Archiv list parity). Uses urlNotenarchiv + FilePath when set.
+ * Fallback: initials placeholder (no complex inline JS — Melde cannot probe Archiv FS).
+ * @param int $compositionId
+ * @param string $title
+ * @param string|null $filePath Relative path under Archiv web root (trailing slash typical)
+ * @return string
+ */
+function archivCompositionCoverHtml($compositionId, $title, $filePath) {
+    $compositionId = (int)$compositionId;
+    $title = trim(archivPlainText($title));
+    $filePath = trim((string)$filePath);
+    $cls = 'archiv-thumb piece-cover';
+    $ini = htmlspecialchars(archivCoverInitials($title), ENT_QUOTES, 'UTF-8');
+    if($ini === '') {
+        $ini = '—';
+    }
+    $seed = (string)$compositionId.'|'.$title;
+    $hue = (int)(sprintf('%u', crc32($seed)) % 360);
+    $placeholderInner = '<span class="piece-cover-initials">'.$ini.'</span>';
+    $base = archivNotenarchivBaseUrl();
+    $coverUrl = '';
+    if($base !== '' && $filePath !== '') {
+        $rel = str_replace('\\', '/', $filePath);
+        if(substr($rel, -1) !== '/') {
+            $rel .= '/';
+        }
+        $coverUrl = $base.ltrim($rel, '/').'cover.png';
+    }
+    if($coverUrl === '') {
+        return '<span class="'.$cls.' piece-cover--placeholder" style="background-color:hsl('.$hue.',42%,38%)" aria-hidden="true">'
+            .$placeholderInner.'</span>';
+    }
+    $src = htmlspecialchars($coverUrl, ENT_QUOTES, 'UTF-8');
+    // Attribute-safe onerror (only single quotes in JS; reveal sibling fallback).
+    $onerror = htmlspecialchars(
+        'this.onerror=null;var p=this.parentNode;if(!p)return;this.remove();'
+        ."p.classList.add('piece-cover--placeholder');"
+        ."p.style.backgroundColor='hsl(".$hue.",42%,38%)';"
+        ."var f=p.querySelector('.piece-cover-fallback');if(f)f.hidden=false;",
+        ENT_QUOTES,
+        'UTF-8'
+    );
+    return '<span class="'.$cls.'" aria-hidden="true">'
+        .'<img src="'.$src.'" alt="" onerror="'.$onerror.'">'
+        .'<span class="piece-cover-fallback piece-cover-initials" hidden>'.$ini.'</span>'
+        .'</span>';
+}
+
+/**
+ * Link label for Verlag: publisher name, else host of URL (not the full URL).
+ * @param string $name
+ * @param string $href
+ * @return string
+ */
+function archivPublisherLabel($name, $href) {
+    $name = trim(archivPlainText($name));
+    if($name !== '') {
+        return $name;
+    }
+    $href = trim((string)$href);
+    if($href === '') {
+        return '';
+    }
+    $host = parse_url($href, PHP_URL_HOST);
+    if(is_string($host) && $host !== '') {
+        return preg_replace('/^www\./i', '', $host);
+    }
+    return 'Link';
+}
+
+/**
+ * Modal payload: name + ordered pieces with Archiv list meta.
+ * @param int $id
+ * @return array{id:int,name:string,items:list<array<string,mixed>}|null
+ */
+function archivLoadCollectionModalData($id) {
+    $id = (int)$id;
+    if($id < 1 || !archivCollectionsReady()) {
+        return null;
+    }
+    $prefix = archivDbPrefix();
+    $sql = sprintf(
+        'SELECT `Index`, `Name`, `Archived` FROM `%sCollection` WHERE `Index` = "%d" LIMIT 1;',
+        $prefix,
+        $id
+    );
+    $dbr = mysqli_query($GLOBALS['conn'], $sql);
+    sqlerror();
+    if(!$dbr || !($row = mysqli_fetch_array($dbr))) {
+        return null;
+    }
+    $name = trim((string)$row['Name']);
+    if($name === '') {
+        $name = 'Sammlung #'.$id;
+    }
+    $items = array();
+    $sqlItems = sprintf(
+        'SELECT i.`CollectionNumber`, i.`Composition`,
+                c.`Title`, c.`Year`, c.`Grade`, c.`FilePath`, c.`Website`,
+                cf.`FirstName` AS `ComposerFirst`, cf.`LastName` AS `ComposerLast`,
+                ar.`FirstName` AS `ArrangerFirst`, ar.`LastName` AS `ArrangerLast`,
+                p.`Name` AS `PublisherName`, p.`Website` AS `PublisherWebsite`
+         FROM `%sCollectionItem` i
+         LEFT JOIN `%sComposition` c ON c.`Index` = i.`Composition`
+         LEFT JOIN `%sComposer` cf ON cf.`Index` = c.`Composer`
+         LEFT JOIN `%sComposer` ar ON ar.`Index` = c.`Arranger`
+         LEFT JOIN `%sPublisher` p ON p.`Index` = c.`Publisher`
+         WHERE i.`Collections` = "%d"
+         ORDER BY i.`CollectionNumber` ASC, i.`Index` ASC;',
+        $prefix,
+        $prefix,
+        $prefix,
+        $prefix,
+        $prefix,
+        $id
+    );
+    $dbrItems = mysqli_query($GLOBALS['conn'], $sqlItems);
+    sqlerror();
+    $seen = array();
+    if($dbrItems) {
+        while($item = mysqli_fetch_array($dbrItems)) {
+            $compId = (int)$item['Composition'];
+            if($compId < 1 || isset($seen[$compId])) {
+                continue;
+            }
+            $seen[$compId] = true;
+            $num = $item['CollectionNumber'];
+            $title = trim(archivPlainText(isset($item['Title']) ? $item['Title'] : ''));
+            if($title === '') {
+                $title = 'Stück #'.$compId;
+            }
+            $composer = archivPersonDisplayName(
+                isset($item['ComposerFirst']) ? $item['ComposerFirst'] : '',
+                isset($item['ComposerLast']) ? $item['ComposerLast'] : ''
+            );
+            $arranger = archivPersonDisplayName(
+                isset($item['ArrangerFirst']) ? $item['ArrangerFirst'] : '',
+                isset($item['ArrangerLast']) ? $item['ArrangerLast'] : ''
+            );
+            $publisher = trim(archivPlainText(isset($item['PublisherName']) ? $item['PublisherName'] : ''));
+            $year = isset($item['Year']) && $item['Year'] !== null && $item['Year'] !== ''
+                ? (string)(int)$item['Year']
+                : '';
+            $grade = isset($item['Grade']) && $item['Grade'] !== null && $item['Grade'] !== ''
+                ? rtrim(rtrim(sprintf('%.1f', (float)$item['Grade']), '0'), '.')
+                : '';
+            $productUrl = archivNormalizeWebsiteUrl(isset($item['Website']) ? $item['Website'] : '');
+            $publisherUrl = archivNormalizeWebsiteUrl(
+                isset($item['PublisherWebsite']) ? $item['PublisherWebsite'] : ''
+            );
+            $publisherHref = $productUrl !== '' ? $productUrl : $publisherUrl;
+            $filePath = isset($item['FilePath']) ? trim((string)$item['FilePath']) : '';
+            $items[] = array(
+                'compositionId' => $compId,
+                'number' => ($num !== null && $num !== '') ? (string)(int)$num : '',
+                'title' => $title,
+                'composer' => $composer,
+                'arranger' => $arranger,
+                'publisher' => $publisher,
+                'publisherHref' => $publisherHref,
+                'publisherLabel' => archivPublisherLabel($publisher, $publisherHref),
+                'year' => $year,
+                'grade' => $grade,
+                'coverHtml' => archivCompositionCoverHtml($compId, $title, $filePath),
+            );
+        }
+    }
+    return array(
+        'id' => $id,
+        'name' => $name,
+        'items' => $items,
+    );
+}
+
+/**
+ * Modal HTML for Melde AJAX host.
+ * @param int $id
+ * @return string
+ */
+function archivCollectionModalHtml($id) {
+    $data = archivLoadCollectionModalData($id);
+    if($data === null) {
+        return '';
+    }
+    return render('sammlung/modal', array(
+        'collectionId' => $data['id'],
+        'collectionName' => $data['name'],
+        'items' => $data['items'],
+    ));
+}
+
+/**
+ * Programm modal payload for a Termin (all linked collections + pieces).
+ * @param int $terminId
+ * @return array{terminId:int,terminName:string,collections:list<array{id:int,name:string,items:list}>}|null
+ */
+function archivLoadTerminProgrammModalData($terminId) {
+    $terminId = (int)$terminId;
+    if($terminId < 1 || !archivFeatureEnabled()) {
+        return null;
+    }
+    $t = new Termin();
+    $t->load_by_id($terminId);
+    if((int)$t->Index < 1) {
+        return null;
+    }
+    $ids = $t->getSammlungenArray();
+    $collections = array();
+    foreach($ids as $cid) {
+        $data = archivLoadCollectionModalData($cid);
+        if($data === null) {
+            continue;
+        }
+        $collections[] = array(
+            'id' => $data['id'],
+            'name' => $data['name'],
+            'items' => $data['items'],
+        );
+    }
+    $terminName = trim((string)$t->Name);
+    if($terminName === '') {
+        $terminName = 'Termin #'.$terminId;
+    }
+    return array(
+        'terminId' => $terminId,
+        'terminName' => $terminName,
+        'collections' => $collections,
+    );
+}
+
+/**
+ * Programm modal HTML (Termin id).
+ * @param int $terminId
+ * @return string
+ */
+function archivTerminProgrammModalHtml($terminId) {
+    $data = archivLoadTerminProgrammModalData($terminId);
+    if($data === null) {
+        return '';
+    }
+    return render('programm/modal', array(
+        'terminId' => $data['terminId'],
+        'terminName' => $data['terminName'],
+        'collections' => $data['collections'],
+    ));
+}
+?>

--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -728,6 +728,8 @@ function entityOpenHtml($type, $id, $label, $chipMod = '') {
         'inventar' => 'instrument',
         'mail' => 'mailGroup',
         'shift' => 'termin',
+        'sammlung' => 'instrument',
+        'programm' => 'programm',
     );
     if($id < 1 || !isset($chipMods[$type])) {
         return $h($label);

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -1,7 +1,7 @@
 <?php
 class Termin
 {
-    private $_data = array('Index' => null, 'Datum' => null, 'EndDatum' => null, 'Uhrzeit' => null, 'Uhrzeit2' => null, 'Abfahrt' => null, 'Capacity' => null, 'Vehicle' => 1, 'Name' => null, 'Auftritt' => null, 'Ort1' => null, 'Ort2' => null, 'Ort3' => null, 'Ort4' => null, 'Beschreibung' => null, 'Shifts' => null, 'open' => 1, 'Wert' => null, 'Children' => null, 'Guests' => null, 'new' => null, 'vName' => null, 'defaultFreeText' => null, 'VisibilitySpec' => null, 'GuestMusicians' => null, 'PostDiscord' => 0, 'Created' => null, 'Updated' => null);
+    private $_data = array('Index' => null, 'Datum' => null, 'EndDatum' => null, 'Uhrzeit' => null, 'Uhrzeit2' => null, 'Abfahrt' => null, 'Capacity' => null, 'Vehicle' => 1, 'Name' => null, 'Auftritt' => null, 'Ort1' => null, 'Ort2' => null, 'Ort3' => null, 'Ort4' => null, 'Beschreibung' => null, 'Shifts' => null, 'open' => 1, 'Wert' => null, 'Children' => null, 'Guests' => null, 'new' => null, 'vName' => null, 'defaultFreeText' => null, 'VisibilitySpec' => null, 'GuestMusicians' => null, 'Sammlungen' => null, 'PostDiscord' => 0, 'Created' => null, 'Updated' => null);
     /** @var array<int,int>|null */
     private $_meldungenCountsByWert = null;
     /** @var array<int,string>|null */
@@ -35,6 +35,7 @@ class Termin
         case 'defaultFreeText':
         case 'VisibilitySpec':
         case 'GuestMusicians':
+        case 'Sammlungen':
         case 'PostDiscord':
         case 'Created':
         case 'Updated':
@@ -63,6 +64,7 @@ class Termin
         case 'defaultFreeText':
         case 'VisibilitySpec':
         case 'GuestMusicians':
+        case 'Sammlungen':
         case 'Created':
         case 'Updated':
             $this->_data[$key] = trim((string)$val);
@@ -127,6 +129,13 @@ class Termin
         sort($newGuests);
         if($oldGuests !== $newGuests) {
             $str.=", Gastmusiker: ".count($oldGuests)." &rArr; <b>".count($newGuests)."</b>";
+        }
+        $oldSammlungen = $old->getSammlungenArray();
+        $newSammlungen = $this->getSammlungenArray();
+        sort($oldSammlungen);
+        sort($newSammlungen);
+        if($oldSammlungen !== $newSammlungen) {
+            $str.=", Sammlungen: ".count($oldSammlungen)." &rArr; <b>".count($newSammlungen)."</b>";
         }
         if(boolsDiffer($this->PostDiscord, $old->PostDiscord)) {
             $str.=", Discord: ".bool2string($old->PostDiscord)." &rArr; <b>".bool2string($this->PostDiscord)."</b>";
@@ -299,7 +308,7 @@ class Termin
         else {
             $end = "NULL";
         }
-        $sql = sprintf('INSERT INTO `%sTermine` (`Datum`, `EndDatum`, `Uhrzeit`, `Uhrzeit2`, `Abfahrt`, `Capacity`, `Vehicle`, `Name`, `Beschreibung`, `Shifts`, `Auftritt`, `Ort1`, `Ort2`, `Ort3`, `Ort4`, `open`, `defaultFreeText`, `VisibilitySpec`, `GuestMusicians`, `PostDiscord`) VALUES ("%s", %s, %s, %s, %s, "%d", "%d", "%s", "%s", "%d", "%d", "%s", "%s", "%s", "%s", "%d", "%s", %s, %s, "%d");',
+        $sql = sprintf('INSERT INTO `%sTermine` (`Datum`, `EndDatum`, `Uhrzeit`, `Uhrzeit2`, `Abfahrt`, `Capacity`, `Vehicle`, `Name`, `Beschreibung`, `Shifts`, `Auftritt`, `Ort1`, `Ort2`, `Ort3`, `Ort4`, `open`, `defaultFreeText`, `VisibilitySpec`, `GuestMusicians`, `Sammlungen`, `PostDiscord`) VALUES ("%s", %s, %s, %s, %s, "%d", "%d", "%s", "%s", "%d", "%d", "%s", "%s", "%s", "%s", "%d", "%s", %s, %s, %s, "%d");',
         $GLOBALS['dbprefix'],
         mysqli_real_escape_string($GLOBALS['conn'], $this->Datum),
         $end,
@@ -320,6 +329,7 @@ class Termin
                        mysqli_real_escape_string($GLOBALS['conn'], (string)$this->defaultFreeText),
                        $this->sqlVisibilitySpec(),
                        $this->sqlGuestMusicians(),
+                       $this->sqlSammlungen(),
                        (int)$this->PostDiscord
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
@@ -503,7 +513,7 @@ class Termin
         else {
             $end = "NULL";
         }
-        $sql = sprintf('UPDATE `%sTermine` SET `Datum` = "%s", `EndDatum` = %s, `Uhrzeit` = %s, `Uhrzeit2` = %s, `Abfahrt` = %s, `Capacity`= "%d", `Vehicle`= "%d", `Name` = "%s", `Beschreibung` = "%s", `Shifts` = "%d", `Auftritt` = "%d", `Ort1` = "%s", `Ort2` = "%s", `Ort3` = "%s", `Ort4` = "%s", `open` = "%d", `new` = "%d", `defaultFreeText` = "%s", `VisibilitySpec` = %s, `GuestMusicians` = %s, `PostDiscord` = "%d", `Updated` = CURRENT_TIMESTAMP WHERE `Index` = "%d";',
+        $sql = sprintf('UPDATE `%sTermine` SET `Datum` = "%s", `EndDatum` = %s, `Uhrzeit` = %s, `Uhrzeit2` = %s, `Abfahrt` = %s, `Capacity`= "%d", `Vehicle`= "%d", `Name` = "%s", `Beschreibung` = "%s", `Shifts` = "%d", `Auftritt` = "%d", `Ort1` = "%s", `Ort2` = "%s", `Ort3` = "%s", `Ort4` = "%s", `open` = "%d", `new` = "%d", `defaultFreeText` = "%s", `VisibilitySpec` = %s, `GuestMusicians` = %s, `Sammlungen` = %s, `PostDiscord` = "%d", `Updated` = CURRENT_TIMESTAMP WHERE `Index` = "%d";',
         $GLOBALS['dbprefix'],
         mysqli_real_escape_string($GLOBALS['conn'], $this->Datum),
         $end,
@@ -525,6 +535,7 @@ class Termin
                        mysqli_real_escape_string($GLOBALS['conn'], (string)$this->defaultFreeText),
                        $this->sqlVisibilitySpec(),
                        $this->sqlGuestMusicians(),
+                       $this->sqlSammlungen(),
                        (int)$this->PostDiscord,
         $this->Index
         );
@@ -575,7 +586,8 @@ class Termin
     public function fill_from_array($row) {
         foreach($row as $key => $val) {
             if($key === 'VisibilitySpec' || $key === 'visibilitySpec'
-                || $key === 'GuestMusicians' || $key === 'guestMusicians') {
+                || $key === 'GuestMusicians' || $key === 'guestMusicians'
+                || $key === 'Sammlungen' || $key === 'sammlungen') {
                 continue;
             }
             if(array_key_exists($key, $this->_data)) {
@@ -584,6 +596,7 @@ class Termin
         }
         $hadVisibility = isset($row['VisibilitySpec']) || isset($row['visibilitySpec']);
         $hadGuests = isset($row['GuestMusicians']) || isset($row['guestMusicians']);
+        $hadSammlungen = isset($row['Sammlungen']) || isset($row['sammlungen']);
         if($hadVisibility) {
             $raw = isset($row['VisibilitySpec']) ? $row['VisibilitySpec'] : $row['visibilitySpec'];
             if(is_array($raw)) {
@@ -596,6 +609,10 @@ class Termin
         if($hadGuests) {
             $raw = isset($row['GuestMusicians']) ? $row['GuestMusicians'] : $row['guestMusicians'];
             $this->setGuestMusiciansArray($raw);
+        }
+        if($hadSammlungen) {
+            $raw = isset($row['Sammlungen']) ? $row['Sammlungen'] : $row['sammlungen'];
+            $this->setSammlungenArray($raw);
         }
         if($hadVisibility || $hadGuests) {
             $this->mergeGuestMusiciansIntoVisibilityUsers();
@@ -772,6 +789,82 @@ class Termin
             return 'NULL';
         }
         return '"'.mysqli_real_escape_string($GLOBALS['conn'], json_encode($ids)).'"';
+    }
+
+    /** Nullable JSON int[] of archiv_Collection ids for SQL INSERT/UPDATE. */
+    protected function sqlSammlungen() {
+        $ids = $this->getSammlungenArray();
+        if(!count($ids)) {
+            return 'NULL';
+        }
+        return '"'.mysqli_real_escape_string($GLOBALS['conn'], json_encode($ids)).'"';
+    }
+
+    /** @return list<int> */
+    public function getSammlungenArray() {
+        $raw = $this->Sammlungen;
+        if(is_array($raw)) {
+            $list = $raw;
+        }
+        else {
+            $s = trim((string)$raw);
+            if($s === '') {
+                return array();
+            }
+            $decoded = json_decode($s, true);
+            $list = is_array($decoded) ? $decoded : array();
+        }
+        $ids = array();
+        foreach($list as $id) {
+            $id = (int)$id;
+            if($id > 0) {
+                $ids[$id] = $id;
+            }
+        }
+        return array_values($ids);
+    }
+
+    /** @param mixed $input JSON string, array, or null */
+    public function setSammlungenArray($input) {
+        if(is_array($input)) {
+            $list = $input;
+        }
+        else {
+            $s = trim((string)$input);
+            if($s === '') {
+                $this->Sammlungen = null;
+                return;
+            }
+            $decoded = json_decode($s, true);
+            $list = is_array($decoded) ? $decoded : array();
+        }
+        $ids = array();
+        foreach($list as $id) {
+            $id = (int)$id;
+            if($id > 0) {
+                $ids[$id] = $id;
+            }
+        }
+        $list = array_values($ids);
+        $this->Sammlungen = count($list) ? json_encode($list) : null;
+    }
+
+    /**
+     * Single "Programm" chip → modal with all linked Archiv-Sammlungen.
+     * @return string
+     */
+    public function renderProgrammChipHtml() {
+        if(!function_exists('archivFeatureEnabled') || !archivFeatureEnabled()) {
+            return '';
+        }
+        $tid = (int)$this->Index;
+        if($tid < 1 || !count($this->getSammlungenArray())) {
+            return '';
+        }
+        if(!function_exists('entityOpenHtml')) {
+            return '';
+        }
+        return entityOpenHtml('programm', $tid, 'Programm', 'programm');
     }
 
     /**
@@ -1746,6 +1839,10 @@ class Termin
         $ort = trim((string)$this->getOrt());
         if($ort !== '') {
             $str .= '<div class="melde-ort">'.$h($ort).'</div>';
+        }
+        $programmChip = $this->renderProgrammChipHtml();
+        if($programmChip !== '') {
+            $str .= '<div class="melde-programm mail-recipient-chips" data-melde-stop>'.$programmChip.'</div>';
         }
         $str .= '</div>';
 

--- a/new-termin.php
+++ b/new-termin.php
@@ -103,6 +103,29 @@ if($fill && $n) {
         <label class="profile-label" for="termin-beschreibung">Beschreibung</label>
         <input id="termin-beschreibung" class="w3-input w3-border profile-control <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" name="Beschreibung" type="text" placeholder="Beschreibung" <?php if($fill) echo 'value="'.htmlspecialchars((string)$n->Beschreibung, ENT_QUOTES, 'UTF-8').'"'; ?>>
       </div>
+<?php if(function_exists('archivFeatureEnabled') && archivFeatureEnabled()) {
+    $sammlungCatalog = array();
+    foreach(archivListCollectionsForSelect() as $opt) {
+        $sammlungCatalog[] = array(
+            'id' => (int)$opt['id'],
+            'label' => (string)$opt['name'],
+        );
+    }
+    $selectedSammlungen = ($fill && $n) ? $n->getSammlungenArray() : array();
+?>
+      <div class="profile-field termin-sammlungen">
+        <span class="profile-label">Programm</span>
+        <div class="termin-visibility-box w3-padding w3-border <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>">
+          <div id="terminSammlungChips" class="mail-recipient-chips" aria-live="polite"></div>
+          <input type="text" id="terminSammlungInput" class="w3-input w3-border <?php echo htmlspecialchars($inputBg, ENT_QUOTES, 'UTF-8'); ?>" placeholder="Sammlung…" autocomplete="off">
+          <div id="terminSammlungSuggest" class="mail-recipient-suggest" hidden></div>
+          <input type="hidden" name="Sammlungen" id="terminSammlungen" value="<?php
+            echo htmlspecialchars(json_encode($selectedSammlungen), ENT_QUOTES, 'UTF-8');
+          ?>">
+        </div>
+      </div>
+<script type="application/json" id="terminSammlungCatalog"><?php echo json_encode($sammlungCatalog, JSON_UNESCAPED_UNICODE); ?></script>
+<?php } ?>
     </section>
 
     <section class="profile-col" aria-labelledby="termin-col-wann">
@@ -349,8 +372,18 @@ $terminVisibilityCatalog = AudienceSpec::buildCatalog(array(
 ?>
 <script type="application/json" id="terminVisibilityCatalog"><?php echo json_encode($terminVisibilityCatalog, JSON_UNESCAPED_UNICODE); ?></script>
 <script src="js/mailRecipients.js?<?php echo isset($GLOBALS['version']['Hash']) ? $GLOBALS['version']['Hash'] : '0'; ?>-<?php echo @filemtime(__DIR__.'/js/mailRecipients.js'); ?>"></script>
+<script src="<?php echo assetUrl('js/sammlungChips.js'); ?>"></script>
 <script>
 (function() {
+  if(typeof SammlungChips !== 'undefined' && document.getElementById('terminSammlungChips')) {
+    SammlungChips.init({
+      catalogEl: document.getElementById('terminSammlungCatalog'),
+      chipsEl: document.getElementById('terminSammlungChips'),
+      inputEl: document.getElementById('terminSammlungInput'),
+      suggestEl: document.getElementById('terminSammlungSuggest'),
+      hiddenEl: document.getElementById('terminSammlungen')
+    });
+  }
   if(typeof MailRecipientChips === 'undefined') return;
   MailRecipientChips.init({
     catalogEl: document.getElementById('terminVisibilityCatalog'),

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2577,6 +2577,13 @@ a.app-titlebar-logo {
   border-color: rgba(0, 0, 0, 0.18);
 }
 
+.mail-recipient-chip--programm {
+  background: #e0f2f1;
+  border-color: #00897b;
+  color: #004d40;
+  font-weight: 600;
+}
+
 .mail-recipient-chip--insured {
   background: #e8eef6;
   border-color: #7f9dc1;
@@ -5186,6 +5193,142 @@ select.profile-control {
   font-size: 0.88rem;
   line-height: 1.3;
   opacity: 0.85;
+}
+
+.melde-programm {
+  margin-top: 0.35rem;
+}
+
+/* MELD-197: Sammlung/Programm modal piece rows (Archiv Composition::printLine parity) */
+.archiv-piece-modal-list {
+  grid-column: 1 / -1;
+}
+
+.archiv-piece-modal .piece-row {
+  --archiv-rail-w: 0.35rem;
+  --archiv-rail-color: var(--page-title-accent, #345A95);
+  --archiv-row-pad-y: 0.85rem;
+  --archiv-rail-inset: 0.4rem;
+  display: grid;
+  grid-template-columns: var(--archiv-rail-w) minmax(0, 1fr);
+  column-gap: 0.85rem;
+  align-items: start;
+  box-sizing: border-box;
+  padding: var(--archiv-row-pad-y) 1rem;
+  margin: 0 0 0.55rem;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 0.35rem;
+  overflow: hidden;
+  cursor: default;
+}
+
+.archiv-piece-modal .piece-rail {
+  width: var(--archiv-rail-w);
+  align-self: stretch;
+  margin-top: calc(-1 * var(--archiv-row-pad-y) + var(--archiv-rail-inset));
+  margin-bottom: calc(-1 * var(--archiv-row-pad-y) + var(--archiv-rail-inset));
+  min-height: calc(100% + 2 * var(--archiv-row-pad-y) - 2 * var(--archiv-rail-inset));
+  background: var(--archiv-rail-color);
+  border-radius: 2px;
+}
+
+.archiv-piece-modal .piece-main {
+  min-width: 0;
+  align-self: start;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem 0.85rem;
+}
+
+.archiv-piece-modal .piece-text {
+  min-width: 0;
+  flex: 1 1 8rem;
+}
+
+.archiv-piece-modal .archiv-thumb,
+.archiv-piece-modal .piece-cover {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 3.5rem;
+  border-radius: 0.25rem;
+  overflow: hidden;
+  flex: 0 0 auto;
+  background: rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  color: rgba(0, 0, 0, 0.55);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  box-sizing: border-box;
+}
+
+.archiv-piece-modal .archiv-thumb img,
+.archiv-piece-modal .piece-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center center;
+  display: block;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+.archiv-piece-modal .piece-cover--placeholder {
+  color: #fff;
+  border-color: rgba(0, 0, 0, 0.12);
+  font-size: 1.2rem;
+}
+
+.archiv-piece-modal .piece-cover--placeholder .piece-cover-initials,
+.archiv-piece-modal .piece-cover-fallback {
+  line-height: 1;
+  user-select: none;
+}
+
+.archiv-piece-modal .piece-cover-fallback[hidden] {
+  display: none !important;
+}
+
+.archiv-piece-modal .piece-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.3;
+  word-break: break-word;
+}
+
+.archiv-piece-modal .piece-meta-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  margin-top: 0.35rem;
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.archiv-piece-modal .piece-meta-item {
+  min-width: 0;
+  word-break: break-word;
+}
+
+.archiv-piece-modal .piece-meta-k {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  opacity: 0.65;
+  margin-right: 0.25rem;
+}
+
+@media (max-width: 600px) {
+  .archiv-piece-modal .piece-row {
+    --archiv-row-pad-y: 0.75rem;
+    column-gap: 0.55rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
 }
 
 .melde-actions {

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -172,6 +172,7 @@ $sections[] = array(
     'visible' => isAdmin() && requirePermission('perm_editAppmnts'),
     'body' => '
 <p>Unter Admin → <b>Termin erstellen</b> legst du neue Termine an. Das Formular ist in Abschnitte gegliedert (Was, Wann, Wo, Optionen): auf dem Smartphone untereinander, auf dem Tablet zweispaltig, am PC als vier Spalten nebeneinander.</p>
+<p>Ist ein <b>Notenarchiv</b> angeschlossen, kannst du dem Termin unter <b>Programm</b> eine oder mehrere Archiv-Sammlungen zuordnen (Chip-Eingabe). In der Terminübersicht erscheint der Chip <b>Programm</b>; Klick öffnet die Stückliste wie im Archiv (Cover, Komponist, Arrangeur, Verlag, …).</p>
 <p>Im <b>Kalender</b> kannst du auf eine freie Tagesfläche klicken: Nach Bestätigung öffnet sich das Anlege-Formular mit vorausgefülltem Datum.</p>
 <p>Nach Speichern/Löschen von Terminen oder Schichten &amp; Aufgaben erfolgt ein Redirect (kein erneutes Absenden beim Aktualisieren); Rücksprungziele können über Session-Token (<code>return_token</code>) geführt werden. Beginn- und Endzeit einer Schicht/Aufgabe sind optional.</p>
 <p>Das Flag <b>Besetzung</b> steuert, ob Registeraufschlüsselung und Orchesterdarstellung greifen – für Proben und Auftritte. Veranstaltungen ohne Besetzung (z.&nbsp;B. Grillfest, Radtour) brauchen das nicht (nur Manpower).</p>

--- a/views/programm/modal.php
+++ b/views/programm/modal.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Termin-Programm modal: all linked Archiv-Sammlungen + pieces (MELD-197).
+ * Expects: $terminId, $terminName, $collections (list of {id,name,items}).
+ */
+$h = function ($s) {
+    return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
+};
+$terminName = trim((string)$terminName);
+if($terminName === '') {
+    $terminName = 'Termin';
+}
+$collections = isset($collections) && is_array($collections) ? $collections : array();
+?>
+<div class="profile-shell modal-shell archiv-piece-modal programm-modal" data-termin-id="<?php echo (int)$terminId; ?>">
+  <header class="profile-hero">
+    <div class="profile-hero-text">
+      <p class="profile-kicker">Programm</p>
+      <h2 class="profile-title"><?php echo $h($terminName); ?></h2>
+    </div>
+    <div class="profile-hero-actions">
+      <button type="button" class="modal-close w3-button" onclick="closeModal()" aria-label="Schließen">&times;</button>
+    </div>
+  </header>
+
+  <div class="profile-grid">
+<?php if(!count($collections)) { ?>
+    <section class="profile-col archiv-piece-modal-list">
+      <div class="profile-field">
+        <div class="profile-value">Keine Sammlungen verknüpft.</div>
+      </div>
+    </section>
+<?php } else {
+    foreach($collections as $idx => $col) {
+        $colName = isset($col['name']) ? trim((string)$col['name']) : '';
+        if($colName === '') {
+            $colName = 'Sammlung';
+        }
+        $items = isset($col['items']) && is_array($col['items']) ? $col['items'] : array();
+        $itemCount = count($items);
+        $headingId = 'programm-col-'.$idx;
+?>
+    <section class="profile-col archiv-piece-modal-list" aria-labelledby="<?php echo $h($headingId); ?>">
+      <h3 id="<?php echo $h($headingId); ?>" class="profile-col-title"><?php echo $h($colName); ?></h3>
+<?php   if(!$itemCount) { ?>
+      <div class="profile-field">
+        <div class="profile-value">Keine Stücke in dieser Sammlung.</div>
+      </div>
+<?php   } else {
+            echo render('sammlung/piece_list', array('items' => $items));
+        } ?>
+    </section>
+<?php
+    }
+} ?>
+  </div>
+</div>

--- a/views/sammlung/modal.php
+++ b/views/sammlung/modal.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Archiv-Sammlung detail modal (MELD-197).
+ * Expects: $collectionId, $collectionName, $items.
+ */
+$h = function ($s) {
+    return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
+};
+$name = trim((string)$collectionName);
+if($name === '') {
+    $name = 'Sammlung';
+}
+$items = isset($items) && is_array($items) ? $items : array();
+$itemCount = count($items);
+?>
+<div class="profile-shell modal-shell archiv-piece-modal sammlung-modal" data-sammlung-id="<?php echo (int)$collectionId; ?>">
+  <header class="profile-hero">
+    <div class="profile-hero-text">
+      <p class="profile-kicker">Sammlung</p>
+      <h2 class="profile-title"><?php echo $h($name); ?></h2>
+    </div>
+    <div class="profile-hero-actions">
+      <button type="button" class="modal-close w3-button" onclick="closeModal()" aria-label="Schließen">&times;</button>
+    </div>
+  </header>
+
+  <div class="profile-grid">
+    <section class="profile-col archiv-piece-modal-list" aria-labelledby="sammlung-modal-inhalt">
+      <h3 id="sammlung-modal-inhalt" class="profile-col-title">Stücke</h3>
+<?php if(!$itemCount) { ?>
+      <div class="profile-field">
+        <div class="profile-value">Keine Stücke in dieser Sammlung.</div>
+      </div>
+<?php } else {
+    echo render('sammlung/piece_list', array('items' => $items));
+} ?>
+    </section>
+  </div>
+</div>

--- a/views/sammlung/piece_list.php
+++ b/views/sammlung/piece_list.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Archiv piece rows (Archiv Composition::printLine parity).
+ * Expects: $items (list of piece arrays with coverHtml/meta).
+ */
+$h = function ($s) {
+    return htmlspecialchars((string)$s, ENT_QUOTES, 'UTF-8');
+};
+$items = isset($items) && is_array($items) ? $items : array();
+if(count($items)) {
+foreach($items as $item) {
+    $title = isset($item['title']) ? trim((string)$item['title']) : '';
+    if($title === '') {
+        $title = '—';
+    }
+    $composer = isset($item['composer']) ? trim((string)$item['composer']) : '';
+    $arranger = isset($item['arranger']) ? trim((string)$item['arranger']) : '';
+    $publisher = isset($item['publisher']) ? trim((string)$item['publisher']) : '';
+    $publisherHref = isset($item['publisherHref']) ? trim((string)$item['publisherHref']) : '';
+    $publisherLabel = isset($item['publisherLabel']) ? trim((string)$item['publisherLabel']) : '';
+    if($publisherLabel === '') {
+        $publisherLabel = $publisher !== '' ? $publisher : $publisherHref;
+    }
+    $year = isset($item['year']) ? trim((string)$item['year']) : '';
+    $coverHtml = isset($item['coverHtml']) ? (string)$item['coverHtml'] : '';
+?>
+      <div class="piece-row list-row">
+        <div class="piece-rail" aria-hidden="true"></div>
+        <div class="piece-main">
+<?php if($coverHtml !== '') {
+    echo $coverHtml;
+} ?>
+          <div class="piece-text">
+            <div class="piece-title"><?php echo $h($title); ?></div>
+            <div class="piece-meta-line">
+<?php if($composer !== '') { ?>
+              <span class="piece-meta-item"><span class="piece-meta-k">Komponist</span> <?php echo $h($composer); ?></span>
+<?php } ?>
+<?php if($arranger !== '') { ?>
+              <span class="piece-meta-item"><span class="piece-meta-k">Arrangeur</span> <?php echo $h($arranger); ?></span>
+<?php } ?>
+<?php if($publisherLabel !== '') { ?>
+              <span class="piece-meta-item"><span class="piece-meta-k">Verlag</span> <?php
+    if($publisherHref !== '') {
+        echo '<a href="'.$h($publisherHref).'" target="_blank" rel="noopener noreferrer">'.$h($publisherLabel).'</a>';
+    }
+    else {
+        echo $h($publisherLabel);
+    }
+?></span>
+<?php } ?>
+<?php if($year !== '') { ?>
+              <span class="piece-meta-item"><span class="piece-meta-k">Jahr</span> <?php echo $h($year); ?></span>
+<?php } ?>
+            </div>
+          </div>
+        </div>
+      </div>
+<?php
+}
+} ?>

--- a/views/termin/detail_modal.php
+++ b/views/termin/detail_modal.php
@@ -81,6 +81,15 @@ if(!empty($GLOBALS['googlemapsapi']) && ($t->Ort1 || $t->Ort2)) {
         <span class="profile-label">Beschreibung</span>
         <div class="profile-value"><?php echo $val($t->Beschreibung); ?></div>
       </div>
+<?php
+$programmChip = $t->renderProgrammChipHtml();
+if($programmChip !== '') {
+?>
+      <div class="profile-field">
+        <span class="profile-label">Programm</span>
+        <div class="profile-value profile-value--chips"><?php echo $programmChip; ?></div>
+      </div>
+<?php } ?>
     </section>
 
     <section class="profile-col" aria-labelledby="termin-detail-wann">


### PR DESCRIPTION
## Summary
- Termine.Sammlungen (JSON int[], Schema v38) für mehrere Archiv-Sammlungen
- Chip-Eingabe im Termin-Formular (Label Programm)
- Übersicht: Programm-Chip öffnet Modal mit allen Sammlungen und Stückliste (Archiv-Layout)
- Hilfe aktualisiert

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-197

## Test plan
- [ ] Schema-Update / Repair (Sammlungen-Spalte)
- [ ] Termin: Sammlungen zuordnen, speichern
- [ ] Übersicht: Programm-Chip → Modal mit Stücken (Cover, Meta)
- [ ] Ohne Notenarchiv: kein Programm-Feld/-Chip