### PR TITLE
MELD-203: Ausgegraute Termine auch in Kalender und webcal zeigen

### DIFF
--- a/js/calendarMelde.js
+++ b/js/calendarMelde.js
@@ -83,7 +83,10 @@ function openCalendarDayEventsPicker(dateIso, events) {
         var color = esc(ev.color || '');
         var label = esc(ev.label || ('Termin #' + id));
         var wert = (ev.wert === null || ev.wert === undefined) ? '' : String(ev.wert);
-        items += '<button type="button" class="meld-cal-day-pick-item ' + color + '"'
+        var wrap = document.querySelector('.meld-cal-wrap');
+        var unpubCls = wrap ? (wrap.getAttribute('data-style-unpublished') || 'w3-opacity') : 'w3-opacity';
+        var unpub = ev.unpublished ? (' ' + esc(unpubCls)) : '';
+        items += '<button type="button" class="meld-cal-day-pick-item ' + color + unpub + '"'
             + ' data-termin-id="' + id + '"'
             + ' data-melde-wert="' + esc(wert) + '">'
             + label

--- a/libs/calendarView.php
+++ b/libs/calendarView.php
@@ -104,13 +104,25 @@ function calendarColorClassForWert($wert) {
 }
 
 /**
- * Load visible appointments overlapping [fromDate, toDate] for a user.
+ * Overview unpublished style (grayed). Same config as list cards.
+ *
+ * @return string
+ */
+function calendarUnpublishedClass() {
+    $opts = isset($GLOBALS['optionsDB']) ? $GLOBALS['optionsDB'] : array();
+    $cls = isset($opts['styleAppmntUnpublished']) ? trim((string)$opts['styleAppmntUnpublished']) : '';
+    return $cls !== '' ? $cls : 'w3-opacity';
+}
+
+/**
+ * Load appointments overlapping [fromDate, toDate] for a user.
+ * Same visibility as the overview (including grayed / unpublished).
  * Shift appointments expand to one event per Schicht (MELD-182).
  *
  * @param int $userId
  * @param string $fromDate Y-m-d
  * @param string $toDate Y-m-d
- * @return list<array{id:int,name:string,date:string,endDate:string,startTime:string,endTime:string,wert:int|null,colorClass:string,description:string,location:string,shiftId?:int}>
+ * @return list<array{id:int,name:string,date:string,endDate:string,startTime:string,endTime:string,wert:int|null,colorClass:string,description:string,location:string,unpublished:bool,shiftId?:int}>
  */
 function calendarLoadEventsForUser($userId, $fromDate, $toDate) {
     $userId = (int)$userId;
@@ -127,17 +139,16 @@ function calendarLoadEventsForUser($userId, $fromDate, $toDate) {
 
     // Overlap: start <= to AND (end OR start) >= from
     // CAST/NULLIF avoids "Incorrect DATE value: ''" when EndDatum is empty string
+    // No sqlIsListed: overview also shows grayed (versteckt / outside audience) events.
     $sql = sprintf(
         'SELECT `t`.*, `m`.`Wert` AS `meldeWert` FROM `%sTermine` `t`
         LEFT JOIN `%sMeldungen` `m` ON `m`.`Termin` = `t`.`Index` AND `m`.`User` = %d
-        WHERE %s
-          AND `t`.`Datum` <= \'%s\'
+        WHERE `t`.`Datum` <= \'%s\'
           AND COALESCE(NULLIF(CAST(`t`.`EndDatum` AS CHAR), \'\'), `t`.`Datum`) >= \'%s\'
         ORDER BY `t`.`Datum`, `t`.`Uhrzeit`, `t`.`Name`;',
         $prefix,
         $prefix,
         $userId,
-        Termin::sqlIsListed('`t`.'),
         $toEsc,
         $fromEsc
     );
@@ -162,6 +173,7 @@ function calendarLoadEventsForUser($userId, $fromDate, $toDate) {
         $description = (string)$t->Beschreibung;
         $terminStart = trim((string)$t->Uhrzeit);
         $terminEnd = trim((string)$t->Uhrzeit2);
+        $unpublished = $t->shouldStyleAsUnpublished($userId);
 
         if((int)$t->Shifts) {
             $shiftIds = $t->getShifts();
@@ -207,6 +219,7 @@ function calendarLoadEventsForUser($userId, $fromDate, $toDate) {
                     'colorClass' => calendarColorClassForWert($wert),
                     'description' => $description,
                     'location' => $location,
+                    'unpublished' => $unpublished,
                 );
             }
             continue;
@@ -227,6 +240,7 @@ function calendarLoadEventsForUser($userId, $fromDate, $toDate) {
             'colorClass' => calendarColorClassForWert($wert),
             'description' => $description,
             'location' => $location,
+            'unpublished' => $unpublished,
         );
     }
 

--- a/libs/icalFeed.php
+++ b/libs/icalFeed.php
@@ -215,6 +215,8 @@ function icalFeedBuild(array $events, $websiteUrl = null) {
         $times = icalFeedEventTimes($ev);
         $wert = isset($ev['wert']) ? $ev['wert'] : null;
         $status = ($wert === null || $wert === '' || (int)$wert === 3) ? 'TENTATIVE' : 'CONFIRMED';
+        $unpublished = !empty($ev['unpublished']);
+        $transp = $unpublished ? 'TRANSPARENT' : 'OPAQUE';
 
         $descParts = array();
         $descParts[] = 'Rückmeldung: '.icalFeedMeldeLabel($wert);
@@ -235,6 +237,7 @@ function icalFeedBuild(array $events, $websiteUrl = null) {
             'SUMMARY:'.icalFeedEscapeText((string)$ev['name']),
             'DESCRIPTION:'.icalFeedEscapeText($description),
             'STATUS:'.$status,
+            'TRANSP:'.$transp,
             'DTSTART;TZID=Europe/Berlin:'.$times['begin'],
             'DTEND;TZID=Europe/Berlin:'.$times['end'],
         );
@@ -266,7 +269,8 @@ function icalFeedEtag($userId, array $events, $from, $to) {
     foreach($events as $ev) {
         $w = isset($ev['wert']) && $ev['wert'] !== null && $ev['wert'] !== '' ? (int)$ev['wert'] : 0;
         $sid = isset($ev['shiftId']) ? (int)$ev['shiftId'] : 0;
-        $parts[] = (int)$ev['id'].':'.$sid.':'.$w.':'.(string)$ev['date'].':'.(string)$ev['endDate'].':'.(string)$ev['startTime'].':'.(string)$ev['endTime'];
+        $unpub = !empty($ev['unpublished']) ? '1' : '0';
+        $parts[] = (int)$ev['id'].':'.$sid.':'.$w.':'.$unpub.':'.(string)$ev['date'].':'.(string)$ev['endDate'].':'.(string)$ev['startTime'].':'.(string)$ev['endTime'];
     }
     return '"'.hash('sha256', implode('|', $parts)).'"';
 }

--- a/libs/termin.php
+++ b/libs/termin.php
@@ -1003,15 +1003,16 @@ class Termin
         $asViewer = !array_key_exists('asViewer', $opts) || !empty($opts['asViewer']);
         $spec = $this->getVisibilitySpecArray();
         $isHiddenAudience = AudienceSpec::isEmpty($spec);
+        $canShowHidden = $this->userCanShowHiddenAppointments($userId);
 
         if($isHiddenAudience) {
-            return $asViewer && requirePermission('perm_showHiddenAppmnts');
+            return $asViewer && $canShowHidden;
         }
         if($userId > 0 && AudienceSpec::userMatches($userId, $spec)) {
             return true;
         }
         if($asViewer) {
-            if(requirePermission('perm_showHiddenAppmnts')) {
+            if($canShowHidden) {
                 return true;
             }
             if($userId > 0 && $this->getMeldungenByUser($userId)) {
@@ -1019,6 +1020,17 @@ class Termin
             }
         }
         return false;
+    }
+
+    /**
+     * Show-hidden right for this user (ICS has no session). Session as fallback.
+     */
+    private function userCanShowHiddenAppointments($userId) {
+        $userId = (int)$userId;
+        if($userId > 0 && Permissions::loadEffectiveByUser($userId)->getPermission('perm_showHiddenAppmnts')) {
+            return true;
+        }
+        return requirePermission('perm_showHiddenAppmnts');
     }
 
     /**

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -2931,6 +2931,10 @@ body.meld-cal-print {
   background: #fafafa;
 }
 
+.meld-cal-print-table tbody tr.meld-cal-print-unpublished {
+  opacity: 0.6;
+}
+
 .meld-cal-print-time {
   white-space: nowrap;
   font-variant-numeric: tabular-nums;

--- a/views/calendar/month.php
+++ b/views/calendar/month.php
@@ -58,6 +58,7 @@ $gridEnd = DateTimeImmutable::createFromFormat('Y-m-d', $bounds['gridEnd']);
      data-color-no="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnNo'], ENT_QUOTES, 'UTF-8'); ?>"
      data-color-maybe="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnMaybe'], ENT_QUOTES, 'UTF-8'); ?>"
      data-color-none="<?php echo htmlspecialchars($GLOBALS['optionsDB']['colorBtnEdit'], ENT_QUOTES, 'UTF-8'); ?>"
+     data-style-unpublished="<?php echo htmlspecialchars(calendarUnpublishedClass(), ENT_QUOTES, 'UTF-8'); ?>"
      data-can-create="<?php echo (isAdmin() && requirePermission('perm_editAppmnts')) ? '1' : '0'; ?>">
   <div class="meld-cal-grid" role="grid" aria-label="Monatskalender">
 <?php foreach($weekdays as $wd) { ?>
@@ -105,6 +106,7 @@ while($cursor && $gridEnd && $cursor <= $gridEnd) {
             'label' => $label,
             'color' => (string)$ev['colorClass'],
             'wert' => $ev['wert'] === null ? '' : (int)$ev['wert'],
+            'unpublished' => !empty($ev['unpublished']),
         );
     }
     foreach($shown as $ev) {
@@ -112,11 +114,13 @@ while($cursor && $gridEnd && $cursor <= $gridEnd) {
         $label = ($timeLabel !== '' ? $timeLabel.' ' : '').$ev['name'];
         $title = $ev['name'].($timeLabel !== '' ? ' ('.$timeLabel.')' : '');
         $color = htmlspecialchars($ev['colorClass'], ENT_QUOTES, 'UTF-8');
+        $unpub = !empty($ev['unpublished']) ? ' '.htmlspecialchars(calendarUnpublishedClass(), ENT_QUOTES, 'UTF-8') : '';
 ?>
         <button type="button"
-          class="meld-cal-chip <?php echo $color; ?>"
+          class="meld-cal-chip <?php echo $color.$unpub; ?>"
           data-termin-id="<?php echo (int)$ev['id']; ?>"
           data-melde-wert="<?php echo $ev['wert'] === null ? '' : (int)$ev['wert']; ?>"
+          data-unpublished="<?php echo !empty($ev['unpublished']) ? '1' : '0'; ?>"
           title="<?php echo htmlspecialchars($title, ENT_QUOTES, 'UTF-8'); ?>"
           onclick="openModal('calendarMelde', <?php echo (int)$ev['id']; ?>)">
           <?php echo htmlspecialchars($label, ENT_QUOTES, 'UTF-8'); ?>

--- a/views/calendar/print.php
+++ b/views/calendar/print.php
@@ -37,8 +37,9 @@
     $name = isset($ev['name']) ? (string)$ev['name'] : '';
     $location = isset($ev['location']) ? (string)$ev['location'] : '';
     $melde = calendarMeldeLabel(isset($ev['wert']) ? $ev['wert'] : null);
+    $unpub = !empty($ev['unpublished']) ? ' class="meld-cal-print-unpublished"' : '';
 ?>
-      <tr>
+      <tr<?php echo $unpub; ?>>
         <td><?php echo htmlspecialchars($dateLabel, ENT_QUOTES, 'UTF-8'); ?></td>
         <td class="meld-cal-print-time"><?php echo htmlspecialchars($timeLabel, ENT_QUOTES, 'UTF-8'); ?></td>
         <td><?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8'); ?></td>

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -42,7 +42,7 @@ $sections[] = array(
 <p>Auf dem Desktop steht die Navigation links (Icons mit Beschriftung). Auf Tablet und Smartphone unten; unter <b>Mehr</b> findest du weitere Einträge (u.&nbsp;a. Mein Profil), Admin und Ausloggen.</p>
 <ul class="help-list">
 <li><i class="far fa-calendar-alt"></i> <b>Termine</b> – bevorstehende Termine und schnelles Melden</li>
-<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; bei Schichten erscheinen die einzelnen Schichten mit ihren Zeiten; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details; bei vielen Einträgen am selben Tag öffnet <b>+N</b> die Tagesauswahl); Info-Button für Abo-Link, Drucken für alle kommenden Termine als Tabelle</li>
+<li><i class="fas fa-calendar"></i> <b>Kalender</b> – Monatsübersicht der für dich sichtbaren Termine (Farbe = deine Meldung; ausgegraut wie in der Übersicht, wenn du nicht zur Zielgruppe gehörst; bei Schichten erscheinen die einzelnen Schichten mit ihren Zeiten; Klick öffnet Meldeabfrage, „Weitere Optionen“ die Details; bei vielen Einträgen am selben Tag öffnet <b>+N</b> die Tagesauswahl); Info-Button für Abo-Link, Drucken für alle kommenden Termine als Tabelle</li>
 <li><i class="fas fa-envelope"></i> <b>Meine Nachrichten</b> – empfangene Mails aus der Meldeliste (Badge bei ungelesenen)</li>
 <li><i class="fas fa-users"></i> <b>Mein Register</b> – Rückmeldungen deines Registers (auf Tablet/Smartphone dauerhaft in der unteren Leiste)</li>
 '.($helpUser->hasInventories() ? '<li><i class="fas fa-shirt"></i> <b>Mein Inventar</b> – dir gehörendes oder an dich ausgeliehenes Inventar</li>' : '').'
@@ -65,7 +65,7 @@ $sections[] = array(
 <p>Unter <b>Termine</b> (Startseite) kannst du dich zu Terminen eintragen:</p>
 <ul>
 <li>Über die Suchzeile findest du Termine nach Titel, Ort, Datum oder Beschreibung (auch im Termin-Archiv).</li>
-<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster; bei Schichten die einzelnen Schichten mit ihren Zeiten. Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details. Passt nicht alles in die Zelle, öffnet <b>+N</b> eine Liste aller Einträge dieses Tages. Über dem Monat: Info öffnet das Abo-Fenster, Drucken listet alle kommenden Termine (nicht nur den aktuellen Monat).</li>
+<li>Unter <b>Kalender</b> siehst du dieselben Termine als Monatsraster (ausgegraut wie in der Übersicht, wenn du nicht zur Zielgruppe gehörst); bei Schichten die einzelnen Schichten mit ihren Zeiten. Klick öffnet zuerst die Meldeabfrage (ja / nein / vielleicht). Über <b>Weitere Optionen</b> erreichst du die Termin-Details. Passt nicht alles in die Zelle, öffnet <b>+N</b> eine Liste aller Einträge dieses Tages. Über dem Monat: Info öffnet das Abo-Fenster, Drucken listet alle kommenden Termine (nicht nur den aktuellen Monat).</li>
 </ul>
 '.$meldeButtons.'
 <p>Tippe auf den gewünschten Status. Die Farbe am Termin zeigt deinen aktuellen Stand. Eine erneute Auswahl ändert die Meldung.</p>
@@ -140,7 +140,7 @@ $sections[] = array(
 <li><b>Apple</b> (iOS): Einstellungen → Kalender → Accounts → Account hinzufügen → Andere → <b>Kalenderabonnement</b>; oder in der Kalender-App auf dem Mac: Ablage → Neues Kalenderabonnement.</li>
 <li><b>Outlook</b>: Kalender hinzufügen → Aus dem Internet / Abonnieren → HTTPS- oder webcal-Link.</li>
 </ul>
-<p>Abgesagte Termine (Nein) erscheinen nicht im Abo. Der Link ist persönlich — nicht weitergeben.</p>
+<p>Abgesagte Termine (Nein) erscheinen nicht im Abo. Ausgegraute Termine (außerhalb deiner Zielgruppe, aber für dich sichtbar) sind im Abo als frei hinterlegt. Der Link ist persönlich — nicht weitergeben.</p>
 '
 );
 


### PR DESCRIPTION
## Summary
- Kalender und persönliches ICS-Abo zeigen dieselben ausgegrauten Termine wie die Übersicht (außerhalb der Zielgruppe / versteckt, aber sichtbar).
- Absagen (Nein) bleiben im Abo draußen; ausgegraute Einträge sind im ICS als frei (`TRANSP:TRANSPARENT`) hinterlegt.
- Sichtbarkeit prüft das Recht „Versteckte Termine anzeigen“ am Feed-User, nicht nur an der Session.

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-203

## Test plan
- [ ] Termin außerhalb der eigenen Zielgruppe, aber mit bestehender Meldung: in Übersicht ausgegraut, im Kalender ebenfalls, im Abo sichtbar (nicht bei Nein)
- [ ] Versteckter Termin mit Recht „Versteckte Termine anzeigen“: Kalender ausgegraut, Abo ohne Login-Session ebenfalls
- [ ] Normal sichtbarer Termin: nicht ausgegraut, ICS `TRANSP:OPAQUE`