### PR TITLE
MELD-206: Inventar-Typ-Thumbnails und Foto-Lightbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ uploads/**
 !uploads/inventory/.htaccess
 !uploads/inventory-docs/
 !uploads/inventory-docs/.htaccess
+!uploads/inventory-types/
+!uploads/inventory-types/.htaccess
 php.ini
 error-log.php
 .cursor/

--- a/config/DBconfig.json
+++ b/config/DBconfig.json
@@ -82,7 +82,8 @@
 	"Typ": {"Type": "text", "Collation": "utf8mb4_unicode_ci"},
 	"Prefix": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"},
 	"Protected": {"Type": "tinyint", "Default": 0},
-	"Sortierung": {"Type": "int", "Default": 1}
+	"Sortierung": {"Type": "int", "Default": 1},
+	"ThumbFile": {"Type": "text", "Null": "YES", "Collation": "utf8mb4_unicode_ci"}
     },
     "Log": {
 	"Index": {"Type": "int", "Extra": "AUTO_INCREMENT"},

--- a/config/schema_version_number.php
+++ b/config/schema_version_number.php
@@ -8,6 +8,7 @@
  * v37: Termine.Sammlungen (JSON int[] → archiv_Collection when Notenarchiv is attached).
  * v38: ensure Termine.Sammlungen (text JSON); drop obsolete Termine.Sammlung if present.
  * v39: InventoriesPhotos (MELD-191) and InventoriesDocuments (MELD-205).
+ * v40: Inventory.ThumbFile (MELD-206 type default thumbnail).
  */
-return 39;
+return 40;
 ?>

--- a/inventory-type-thumb.php
+++ b/inventory-type-thumb.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Serve inventory type default thumbnails (MELD-206).
+ * GET id — type Index
+ */
+require_once __DIR__.'/libs/sessionBootstrap.php';
+meldeConfigureSession();
+include_once 'common/include.php';
+mysqli_select_db($GLOBALS['conn'], $sql['database']) or die(mysqli_error($GLOBALS['conn']));
+requireLoggedInOrRedirect();
+
+$typeId = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$type = new Inventory();
+if($typeId > 0) {
+    $type->load_by_id($typeId);
+}
+$path = ((int)$type->Index) ? $type->thumbAbsolutePath() : null;
+if($path === null) {
+    denyAccess('Vorschau nicht gefunden.');
+}
+
+$ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+$map = array(
+    'jpg' => 'image/jpeg',
+    'jpeg' => 'image/jpeg',
+    'png' => 'image/png',
+    'gif' => 'image/gif',
+    'webp' => 'image/webp',
+);
+$mime = isset($map[$ext]) ? $map[$ext] : 'application/octet-stream';
+header('Content-Type: '.$mime);
+header('Content-Length: '.(string)filesize($path));
+header('Content-Disposition: inline; filename="'.basename($path).'"');
+header('X-Content-Type-Options: nosniff');
+readfile($path);
+exit;

--- a/inventory-types.php
+++ b/inventory-types.php
@@ -11,6 +11,25 @@ if(!requirePermission("perm_editInventories")) {
 $msg = '';
 $err = '';
 
+$applyUploadedThumb = function (Inventory $n) use (&$err) {
+    if(empty($_FILES['thumb']['tmp_name']) || !is_uploaded_file((string)$_FILES['thumb']['tmp_name'])) {
+        return;
+    }
+    if(!$n->storeThumb($_FILES['thumb'])) {
+        $err = 'Vorschau konnte nicht gespeichert werden.';
+    }
+};
+
+if(isset($_POST['deleteThumb'])) {
+    $n = new Inventory;
+    $n->load_by_id($_POST['Index']);
+    if((int)$n->Index && $n->deleteThumb()) {
+        $msg = 'Vorschau entfernt.';
+    }
+    else {
+        $err = 'Vorschau konnte nicht entfernt werden.';
+    }
+}
 if(isset($_POST['insert'])) {
     $n = new Inventory;
     $n->fill_from_array($_POST);
@@ -23,6 +42,7 @@ if(isset($_POST['insert'])) {
     }
     elseif($n->save()) {
         $msg = 'Typ angelegt.';
+        $applyUploadedThumb($n);
     }
     else {
         $err = 'Speichern fehlgeschlagen.';
@@ -32,8 +52,10 @@ if(isset($_POST['update'])) {
     $n = new Inventory;
     $n->load_by_id($_POST['Index']);
     $protected = (int)$n->Protected;
+    $thumbFile = $n->ThumbFile;
     $n->fill_from_array($_POST);
-    $n->Protected = $protected; // keep protected flag
+    $n->Protected = $protected;
+    $n->ThumbFile = $thumbFile;
     if(!$n->is_valid()) {
         $err = 'Prefix und Beschriftung sind Pflicht (Prefix nur A–Z / 0–9).';
     }
@@ -42,6 +64,7 @@ if(isset($_POST['update'])) {
     }
     elseif($n->save()) {
         $msg = 'Typ aktualisiert.';
+        $applyUploadedThumb($n);
     }
     else {
         $err = 'Aktualisieren fehlgeschlagen.';
@@ -65,11 +88,12 @@ adminListPageBegin('Inventar', 'Inventar-Typen');
 <?php if($err) { echo renderFlashHtml(array('type' => 'error', 'message' => $err)); } ?>
 
 <div class="w3-row w3-padding w3-teal type-edit-header">
+  <div class="w3-col l2 m3 s12"><b>Vorschau</b></div>
   <div class="w3-col l2 m2 s3"><b>Prefix</b></div>
-  <div class="w3-col l3 m3 s4"><b>Beschriftung</b></div>
-  <div class="w3-col l2 m2 s2"><b>Sortierung</b></div>
+  <div class="w3-col l2 m3 s4"><b>Beschriftung</b></div>
+  <div class="w3-col l1 m2 s2"><b>Sortierung</b></div>
   <div class="w3-col l2 m2 s3"><b>Status</b></div>
-  <div class="w3-col l3 m3 s12"><b>Aktionen</b></div>
+  <div class="w3-col l3 m12 s12"><b>Aktionen</b></div>
 </div>
 
 <?php
@@ -81,17 +105,27 @@ while($row = mysqli_fetch_array($dbr)) {
     $t->fill_from_array($row);
     $usage = $t->usageCount();
     $id = (int)$t->Index;
+    $thumbUrl = $t->thumbAbsolutePath() ? 'inventory-type-thumb.php?id='.$id : '';
 ?>
 <div class="w3-row w3-padding w3-border-bottom w3-border-black <?php echo $GLOBALS['optionsDB']['HoverEffect']; ?>">
-  <form method="post" class="w3-row">
+  <form method="post" enctype="multipart/form-data" class="w3-row">
     <input type="hidden" name="Index" value="<?php echo $id; ?>" />
+    <div class="w3-col l2 m3 s12 inv-type-thumb-cell">
+      <?php if($thumbUrl !== '') { ?>
+      <img class="inv-thumb" src="<?php echo htmlspecialchars($thumbUrl); ?>" alt="" width="56" height="56">
+      <?php } ?>
+      <input class="inv-type-thumb-file" type="file" name="thumb" accept="image/jpeg,image/png,image/gif,image/webp,.jpg,.jpeg,.png,.gif,.webp" aria-label="Vorschau">
+      <?php if($thumbUrl !== '') { ?>
+      <button class="w3-button w3-small w3-border" type="submit" name="deleteThumb" value="1">Entfernen</button>
+      <?php } ?>
+    </div>
     <div class="w3-col l2 m2 s3">
       <input class="w3-input <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?>" name="Prefix" value="<?php echo htmlspecialchars($t->Prefix); ?>" />
     </div>
-    <div class="w3-col l3 m3 s4">
+    <div class="w3-col l2 m3 s4">
       <input class="w3-input <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?>" name="Typ" value="<?php echo htmlspecialchars($t->Typ); ?>" />
     </div>
-    <div class="w3-col l2 m2 s2">
+    <div class="w3-col l1 m2 s2">
       <input class="w3-input <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?>" name="Sortierung" type="number" value="<?php echo (int)$t->Sortierung; ?>" />
     </div>
     <div class="w3-col l2 m2 s3 w3-small">
@@ -101,7 +135,7 @@ while($row = mysqli_fetch_array($dbr)) {
         if($usage['instruments']) echo ' · Instr: '.$usage['instruments'];
       ?>
     </div>
-    <div class="w3-col l3 m3 s12">
+    <div class="w3-col l3 m12 s12">
       <button class="w3-button w3-blue" type="submit" name="update" value="1">Speichern</button>
       <?php if($t->canDelete()) { ?>
       <button class="w3-button w3-red" type="submit" name="delete" value="1" data-confirm="Typ wirklich löschen?" data-confirm-ok="Löschen">Löschen</button>
@@ -113,12 +147,12 @@ while($row = mysqli_fetch_array($dbr)) {
 
 <div class="w3-card w3-margin w3-padding">
   <h3>Neuen Typ anlegen</h3>
-  <form method="post" class="w3-row">
-    <div class="w3-col l3 m4 s12 w3-padding">
+  <form method="post" enctype="multipart/form-data" class="w3-row">
+    <div class="w3-col l2 m4 s12 w3-padding">
       <label>Prefix</label>
       <input class="w3-input <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?>" name="Prefix" placeholder="MARSCH" required />
     </div>
-    <div class="w3-col l4 m4 s12 w3-padding">
+    <div class="w3-col l3 m4 s12 w3-padding">
       <label>Beschriftung</label>
       <input class="w3-input <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?>" name="Typ" placeholder="Marschtasche" required />
     </div>
@@ -126,7 +160,11 @@ while($row = mysqli_fetch_array($dbr)) {
       <label>Sortierung</label>
       <input class="w3-input <?php echo $GLOBALS['optionsDB']['colorInputBackground']; ?>" name="Sortierung" type="number" value="1" />
     </div>
-    <div class="w3-col l3 m2 s12 w3-padding">
+    <div class="w3-col l3 m6 s12 w3-padding">
+      <label>Vorschau</label>
+      <input class="w3-input inv-type-thumb-file" type="file" name="thumb" accept="image/jpeg,image/png,image/gif,image/webp,.jpg,.jpeg,.png,.gif,.webp" />
+    </div>
+    <div class="w3-col l2 m2 s12 w3-padding">
       <label>&nbsp;</label><br />
       <button class="w3-button w3-green" type="submit" name="insert" value="1">Anlegen</button>
     </div>

--- a/js/inventarPhotos.js
+++ b/js/inventarPhotos.js
@@ -1,8 +1,11 @@
 /**
- * MELD-191: inventory photo gallery (prev/next + AJAX upload/delete).
+ * MELD-191: inventory photo gallery (prev/next + AJAX upload/delete + lightbox).
  */
 (function(global) {
   'use strict';
+
+  var lightboxEl = null;
+  var lightboxGallery = null;
 
   function parseIds(el) {
     try {
@@ -41,6 +44,86 @@
     return isNaN(n) ? 0 : n;
   }
 
+  function lightboxSrc(gallery) {
+    var ids = parseIds(gallery);
+    var idx = currentIndex(gallery);
+    if (ids.length && ids[idx]) {
+      return 'inventory-photo.php?id=' + ids[idx];
+    }
+    var img = gallery.querySelector('.inv-photo-img');
+    return img ? (img.getAttribute('src') || '') : '';
+  }
+
+  function isLightboxOpen() {
+    return !!(lightboxEl && !lightboxEl.hasAttribute('hidden'));
+  }
+
+  function closeLightbox() {
+    if (lightboxEl) lightboxEl.setAttribute('hidden', 'hidden');
+    lightboxGallery = null;
+  }
+
+  function syncLightboxImg() {
+    if (!lightboxGallery || !lightboxEl) return;
+    var img = lightboxEl.querySelector('.inv-photo-lightbox-img');
+    var src = lightboxSrc(lightboxGallery);
+    if (img && src) img.src = src;
+  }
+
+  function stepLightbox(delta) {
+    if (!lightboxGallery) return;
+    showAt(lightboxGallery, currentIndex(lightboxGallery) + delta);
+    syncLightboxImg();
+  }
+
+  function ensureLightbox() {
+    if (lightboxEl) return lightboxEl;
+    lightboxEl = document.createElement('div');
+    lightboxEl.id = 'invPhotoLightbox';
+    lightboxEl.className = 'inv-photo-lightbox';
+    lightboxEl.setAttribute('hidden', 'hidden');
+    lightboxEl.setAttribute('role', 'dialog');
+    lightboxEl.setAttribute('aria-modal', 'true');
+    lightboxEl.setAttribute('aria-label', 'Foto');
+    lightboxEl.innerHTML =
+      '<button type="button" class="inv-photo-lightbox-close" aria-label="Schließen">&times;</button>'
+      + '<button type="button" class="inv-photo-lightbox-nav inv-photo-lightbox-nav--prev" aria-label="Vorheriges Foto">&lsaquo;</button>'
+      + '<img class="inv-photo-lightbox-img" alt="">'
+      + '<button type="button" class="inv-photo-lightbox-nav inv-photo-lightbox-nav--next" aria-label="Nächstes Foto">&rsaquo;</button>';
+    document.body.appendChild(lightboxEl);
+    lightboxEl.addEventListener('click', function(e) {
+      if (e.target === lightboxEl) closeLightbox();
+    });
+    lightboxEl.querySelector('.inv-photo-lightbox-close').addEventListener('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      closeLightbox();
+    });
+    lightboxEl.querySelector('.inv-photo-lightbox-nav--prev').addEventListener('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      stepLightbox(-1);
+    });
+    lightboxEl.querySelector('.inv-photo-lightbox-nav--next').addEventListener('click', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      stepLightbox(1);
+    });
+    return lightboxEl;
+  }
+
+  function openLightbox(gallery) {
+    var src = lightboxSrc(gallery);
+    if (!src) return;
+    lightboxGallery = gallery;
+    var box = ensureLightbox();
+    var hideNav = parseIds(gallery).length < 2;
+    box.querySelector('.inv-photo-lightbox-nav--prev').hidden = hideNav;
+    box.querySelector('.inv-photo-lightbox-nav--next').hidden = hideNav;
+    syncLightboxImg();
+    box.removeAttribute('hidden');
+  }
+
   function initGallery(root) {
     root = root || document;
     var galleries = root.querySelectorAll ? root.querySelectorAll('.inv-photo-gallery') : [];
@@ -65,9 +148,34 @@
             showAt(gallery, currentIndex(gallery) + 1);
           });
         }
+        var zoom = gallery.querySelector('.inv-photo-zoom');
+        if (zoom) {
+          zoom.addEventListener('click', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            openLightbox(gallery);
+          });
+        }
       })(galleries[i]);
     }
   }
+
+  document.addEventListener('keydown', function(e) {
+    if (!isLightboxOpen()) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      closeLightbox();
+      return;
+    }
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      stepLightbox(-1);
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      stepLightbox(1);
+    }
+  }, true);
 
   function postForm(form, done) {
     var fd = new FormData(form);
@@ -97,6 +205,7 @@
     }
     content.innerHTML = data.html;
     if (host) host.style.display = 'block';
+    closeLightbox();
     if (typeof initLoanUserChipsInModal === 'function') {
       initLoanUserChipsInModal(content);
     }
@@ -115,4 +224,5 @@
   });
 
   global.initInventarPhotosInModal = initGallery;
+  global.closeInventarPhotoLightbox = closeLightbox;
 })(window);

--- a/js/modal.js
+++ b/js/modal.js
@@ -8,6 +8,7 @@ function closeModal() {
     var host = document.getElementById('ajaxModalHost');
     if(host) host.style.display = 'none';
     if(typeof closeOrchestraSeatSheet === 'function') closeOrchestraSeatSheet();
+    if(typeof closeInventarPhotoLightbox === 'function') closeInventarPhotoLightbox();
 }
 
 function initLoanUserChipsInModal(root) {

--- a/libs/inventories.php
+++ b/libs/inventories.php
@@ -397,9 +397,9 @@ class Inventories
         $str .= '<div class="inv-id">';
         $str .= '<div class="inv-reg">'.$h($regDisplay).'</div>';
         $str .= '<div class="inv-typ">'.$h($typLabel).'</div>';
-        $thumb = InventoriesPhoto::firstForInventory((int)$this->Index);
-        if($thumb) {
-            $str .= '<img class="inv-thumb" src="'.$h(InventoriesPhoto::publicUrl((int)$thumb->Index)).'" alt="" width="56" height="56">';
+        $thumbUrl = InventoriesPhoto::listThumbUrl($this);
+        if($thumbUrl !== '') {
+            $str .= '<img class="inv-thumb" src="'.$h($thumbUrl).'" alt="" width="56" height="56">';
         }
         if($insured) {
             $str .= '<span class="mail-recipient-chip mail-recipient-chip--insured">versichert</span>';

--- a/libs/inventoriesPhoto.php
+++ b/libs/inventoriesPhoto.php
@@ -57,6 +57,17 @@ class InventoriesPhoto
         return $out;
     }
 
+    /**
+     * List thumbnail: item primary photo, else type default, else ''.
+     */
+    public static function listThumbUrl(Inventories $inv) {
+        $thumb = self::firstForInventory((int)$inv->Index);
+        if($thumb) {
+            return self::publicUrl((int)$thumb->Index);
+        }
+        return Inventory::typeThumbUrl((int)$inv->Inventory);
+    }
+
     /** @return InventoriesPhoto|null */
     public static function firstForInventory($inventoryId) {
         $list = self::listForInventory($inventoryId);
@@ -312,7 +323,15 @@ class InventoriesPhoto
         $inventoryId = (int)$inventoryId;
         $photos = self::listForInventory($inventoryId);
         $count = count($photos);
-        if(!$canEdit && $count === 0) {
+        $typeThumb = '';
+        if($count === 0) {
+            $inv = new Inventories();
+            $inv->load_by_id($inventoryId);
+            if((int)$inv->Index) {
+                $typeThumb = Inventory::typeThumbUrl((int)$inv->Inventory);
+            }
+        }
+        if(!$canEdit && $count === 0 && $typeThumb === '') {
             return '';
         }
         $h = function ($s) {
@@ -331,7 +350,9 @@ class InventoriesPhoto
             if($count > 1) {
                 $html .= '<button type="button" class="inv-photo-nav inv-photo-nav--prev" aria-label="Vorheriges Foto">&lsaquo;</button>';
             }
+            $html .= '<button type="button" class="inv-photo-zoom" aria-label="Foto vergrößern">';
             $html .= '<img class="inv-photo-img" src="'.$h(self::publicUrl($firstId)).'" alt="" data-photo-id="'.$firstId.'">';
+            $html .= '</button>';
             if($count > 1) {
                 $html .= '<button type="button" class="inv-photo-nav inv-photo-nav--next" aria-label="Nächstes Foto">&rsaquo;</button>';
             }
@@ -339,6 +360,15 @@ class InventoriesPhoto
             if($count > 1) {
                 $html .= '<p class="inv-photo-count"><span class="inv-photo-pos">1</span> / '.$count.'</p>';
             }
+            $html .= '</div>';
+        }
+        elseif($typeThumb !== '') {
+            $html .= '<div class="inv-photo-gallery inv-photo-gallery--default">';
+            $html .= '<div class="inv-photo-stage">';
+            $html .= '<button type="button" class="inv-photo-zoom" aria-label="Foto vergrößern">';
+            $html .= '<img class="inv-photo-img" src="'.$h($typeThumb).'" alt="">';
+            $html .= '</button>';
+            $html .= '</div>';
             $html .= '</div>';
         }
         if($canEdit) {
@@ -366,9 +396,6 @@ class InventoriesPhoto
                 $html .= '<button type="submit" class="w3-btn w3-border w3-mobile w3-small">Löschen</button>';
                 $html .= '</form>';
             }
-        }
-        elseif($count === 0) {
-            $html .= '<div class="profile-value">—</div>';
         }
         $html .= '</div>';
         return $html;

--- a/libs/inventory.php
+++ b/libs/inventory.php
@@ -1,7 +1,11 @@
 <?php
 class Inventory
 {
-    private $_data = array('Index' => null, 'Typ' => null, 'Prefix' => null, 'Protected' => 0, 'Sortierung' => null);
+    private $_data = array('Index' => null, 'Typ' => null, 'Prefix' => null, 'Protected' => 0, 'Sortierung' => null, 'ThumbFile' => null);
+
+    /** @var array<int,string> */
+    private static $thumbUrlCache = array();
+
     public function __get($key) {
         switch($key) {
 	    case 'Index':
@@ -9,6 +13,7 @@ class Inventory
 	    case 'Prefix':
 	    case 'Protected':
 	    case 'Sortierung':
+	    case 'ThumbFile':
             return $this->_data[$key];
         default:
             break;
@@ -27,6 +32,10 @@ class Inventory
 	    case 'Prefix':
             $this->_data[$key] = RegNumber::normalizePrefix($val);
             break;
+	    case 'ThumbFile':
+            $v = trim((string)$val);
+            $this->_data[$key] = ($v === '') ? null : $v;
+            break;
         default:
             break;
         }
@@ -39,8 +48,14 @@ class Inventory
     }
     public function fill_from_array($row) {
         foreach($row as $key => $val) {
+            if(is_int($key)) {
+                continue;
+            }
             if($key === 'Prefix') {
                 $this->Prefix = $val;
+            }
+            elseif($key === 'ThumbFile') {
+                $this->ThumbFile = $val;
             }
             else {
                 $this->_data[$key] = $val;
@@ -106,6 +121,152 @@ class Inventory
         return ($u['inventories'] === 0 && $u['instruments'] === 0);
     }
 
+    public static function thumbStorageDir($typeId) {
+        return dirname(__DIR__).'/uploads/inventory-types/'.(int)$typeId;
+    }
+
+    public static function clearThumbUrlCache($typeId = null) {
+        if($typeId === null) {
+            self::$thumbUrlCache = array();
+            return;
+        }
+        unset(self::$thumbUrlCache[(int)$typeId]);
+    }
+
+    /**
+     * Public URL for a type default thumbnail, or '' if none.
+     */
+    public static function typeThumbUrl($typeId) {
+        $typeId = (int)$typeId;
+        if($typeId < 1) {
+            return '';
+        }
+        if(array_key_exists($typeId, self::$thumbUrlCache)) {
+            return self::$thumbUrlCache[$typeId];
+        }
+        $t = new self();
+        $t->load_by_id($typeId);
+        $url = '';
+        if((int)$t->Index && $t->thumbAbsolutePath() !== null) {
+            $url = 'inventory-type-thumb.php?id='.$typeId;
+        }
+        self::$thumbUrlCache[$typeId] = $url;
+        return $url;
+    }
+
+    public function thumbAbsolutePath() {
+        $typeId = (int)$this->Index;
+        $stored = trim((string)$this->ThumbFile);
+        if($typeId < 1 || $stored === '') {
+            return null;
+        }
+        $base = realpath(self::thumbStorageDir($typeId));
+        if($base === false || !is_dir($base)) {
+            return null;
+        }
+        $name = basename(str_replace('\\', '/', $stored));
+        if($name === '' || $name === '.' || $name === '..') {
+            return null;
+        }
+        $full = realpath($base.DIRECTORY_SEPARATOR.$name);
+        if($full === false || !is_file($full)) {
+            return null;
+        }
+        if(strpos($full, $base.DIRECTORY_SEPARATOR) !== 0 && $full !== $base) {
+            return null;
+        }
+        return $full;
+    }
+
+    /**
+     * @param array $file $_FILES entry
+     * @return bool
+     */
+    public function storeThumb(array $file) {
+        if(!isset($file['error']) || (int)$file['error'] !== UPLOAD_ERR_OK) {
+            return false;
+        }
+        $tmp = isset($file['tmp_name']) ? (string)$file['tmp_name'] : '';
+        $orig = isset($file['name']) ? (string)$file['name'] : 'thumb.png';
+        return $this->storeThumbFromPath($tmp, $orig, true);
+    }
+
+    /**
+     * @return bool
+     */
+    public function storeThumbFromPath($sourcePath, $originalName, $mustBeUpload = false) {
+        if((int)$this->Index < 1) {
+            return false;
+        }
+        $sourcePath = (string)$sourcePath;
+        if($sourcePath === '' || !is_file($sourcePath)) {
+            return false;
+        }
+        if($mustBeUpload && !is_uploaded_file($sourcePath)) {
+            return false;
+        }
+        $size = filesize($sourcePath);
+        if($size === false || $size > 8e6 || $size < 1) {
+            return false;
+        }
+        $ext = InventoriesPhoto::imageExtension(array(
+            'name' => $originalName,
+            'tmp_name' => $sourcePath,
+        ));
+        if($ext === '') {
+            return false;
+        }
+        $dir = self::thumbStorageDir((int)$this->Index);
+        if(!is_dir($dir) && !@mkdir($dir, 0775, true)) {
+            return false;
+        }
+        $name = 'thumb-'.bin2hex(random_bytes(4)).'.'.$ext;
+        $target = $dir.DIRECTORY_SEPARATOR.$name;
+        $ok = $mustBeUpload ? @move_uploaded_file($sourcePath, $target) : @copy($sourcePath, $target);
+        if(!$ok) {
+            return false;
+        }
+        $old = $this->thumbAbsolutePath();
+        $this->ThumbFile = $name;
+        if(!$this->save()) {
+            @unlink($target);
+            return false;
+        }
+        if($old && is_file($old) && realpath($old) !== realpath($target)) {
+            @unlink($old);
+        }
+        self::clearThumbUrlCache((int)$this->Index);
+        return true;
+    }
+
+    public function deleteThumb() {
+        if((int)$this->Index < 1) {
+            return false;
+        }
+        $path = $this->thumbAbsolutePath();
+        $this->ThumbFile = null;
+        if(!$this->save()) {
+            return false;
+        }
+        if($path) {
+            @unlink($path);
+        }
+        $dir = self::thumbStorageDir((int)$this->Index);
+        if(is_dir($dir)) {
+            @rmdir($dir);
+        }
+        self::clearThumbUrlCache((int)$this->Index);
+        return true;
+    }
+
+    private function sqlThumbFileValue() {
+        $v = trim((string)$this->ThumbFile);
+        if($v === '') {
+            return 'NULL';
+        }
+        return '"'.mysqli_real_escape_string($GLOBALS['conn'], $v).'"';
+    }
+
     public function save() {
         if(!$this->is_valid()) return false;
         if($this->prefixInUse($this->Prefix, (int)$this->Index)) return false;
@@ -117,12 +278,13 @@ class Inventory
 
     protected function insert() {
         $sql = sprintf(
-            'INSERT INTO `%sInventory` (`Typ`, `Prefix`, `Protected`, `Sortierung`) VALUES ("%s", "%s", "%d", "%d");',
+            'INSERT INTO `%sInventory` (`Typ`, `Prefix`, `Protected`, `Sortierung`, `ThumbFile`) VALUES ("%s", "%s", "%d", "%d", %s);',
             $GLOBALS['dbprefix'],
             mysqli_real_escape_string($GLOBALS['conn'], $this->Typ),
             mysqli_real_escape_string($GLOBALS['conn'], $this->Prefix),
             (int)$this->Protected,
-            (int)$this->Sortierung ? (int)$this->Sortierung : 1
+            (int)$this->Sortierung ? (int)$this->Sortierung : 1,
+            $this->sqlThumbFileValue()
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
         sqlerror();
@@ -133,12 +295,13 @@ class Inventory
 
     protected function update() {
         $sql = sprintf(
-            'UPDATE `%sInventory` SET `Typ` = "%s", `Prefix` = "%s", `Protected` = "%d", `Sortierung` = "%d" WHERE `Index` = "%d";',
+            'UPDATE `%sInventory` SET `Typ` = "%s", `Prefix` = "%s", `Protected` = "%d", `Sortierung` = "%d", `ThumbFile` = %s WHERE `Index` = "%d";',
             $GLOBALS['dbprefix'],
             mysqli_real_escape_string($GLOBALS['conn'], $this->Typ),
             mysqli_real_escape_string($GLOBALS['conn'], $this->Prefix),
             (int)$this->Protected,
             (int)$this->Sortierung,
+            $this->sqlThumbFileValue(),
             (int)$this->Index
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
@@ -148,14 +311,24 @@ class Inventory
 
     public function delete() {
         if(!$this->canDelete()) return false;
+        $id = (int)$this->Index;
+        $path = $this->thumbAbsolutePath();
+        $dir = self::thumbStorageDir($id);
         $sql = sprintf(
             'DELETE FROM `%sInventory` WHERE `Index` = "%d" LIMIT 1;',
             $GLOBALS['dbprefix'],
-            (int)$this->Index
+            $id
         );
         $dbr = mysqli_query($GLOBALS['conn'], $sql);
         sqlerror();
         if(!$dbr) return false;
+        if($path) {
+            @unlink($path);
+        }
+        if(is_dir($dir)) {
+            @rmdir($dir);
+        }
+        self::clearThumbUrlCache($id);
         $this->_data['Index'] = null;
         return true;
     }

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -6130,6 +6130,19 @@ select.profile-control {
   pointer-events: none;
 }
 
+.inv-type-thumb-cell {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  padding-bottom: 0.35rem;
+}
+
+.inv-type-thumb-file {
+  max-width: 100%;
+  font-size: 0.8rem;
+}
+
 .inv-id .mail-recipient-chip {
   margin-top: 0.05rem;
 }
@@ -6626,6 +6639,16 @@ select.profile-control {
   object-fit: contain;
 }
 
+.inv-photo-zoom {
+  display: block;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: zoom-in;
+  max-width: 100%;
+}
+
 .inv-photo-nav {
   position: absolute;
   top: 50%;
@@ -6677,6 +6700,69 @@ select.profile-control {
   border: 1px solid rgba(0, 0, 0, 0.22);
   border-radius: 999px;
   font-size: 0.85rem;
+}
+
+/* Above .w3-modal (2000); inventory dialog stays open underneath. */
+.inv-photo-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.82);
+  box-sizing: border-box;
+  padding: 2.5rem 3.5rem;
+}
+
+.inv-photo-lightbox[hidden] {
+  display: none !important;
+}
+
+.inv-photo-lightbox-img {
+  display: block;
+  max-width: 100%;
+  max-height: 92vh;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+}
+
+.inv-photo-lightbox-close {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.5rem;
+  z-index: 1;
+  width: 2.4rem;
+  height: 2.4rem;
+  border: none;
+  background: transparent;
+  color: #fff;
+  font-size: 2rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.inv-photo-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+  width: 2.6rem;
+  height: 3rem;
+  border: none;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  font-size: 2rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.inv-photo-lightbox-nav--prev { left: 0.4rem; }
+.inv-photo-lightbox-nav--next { right: 0.4rem; }
+
+.inv-photo-lightbox-nav[hidden] {
+  display: none !important;
 }
 
 

--- a/uploads/inventory-types/.htaccess
+++ b/uploads/inventory-types/.htaccess
@@ -1,0 +1,2 @@
+# Inventory type default thumbs — serve only via inventory-type-thumb.php
+Require all denied

--- a/views/help/guide.php
+++ b/views/help/guide.php
@@ -104,7 +104,7 @@ if($helpUser->hasInventories()) {
         'title' => 'Mein Inventar',
         'body' => '
 <p>Wenn dir Inventar gehört <b>oder an dich ausgeliehen</b> ist (aktive Leihe), erscheint <b>Mein Inventar</b> in der Navigation.</p>
-<p>Dort siehst du zuerst geliehene Stücke (Chip „geliehen“), danach eigenes Eigentum – als Liste bzw. auf dem Handy als Karten mit Nr., Typ, Hersteller und Modell. Sind Fotos hinterlegt, erscheint ein Thumbnail. Ein Tippen/Klick öffnet die Details im Modal; dort kannst du durch die Fotos blättern und unter <b>Dokumente</b> hinterlegte Dateien öffnen. Bearbeiten, Hochladen und Löschen nur mit den entsprechenden Rechten.</p>
+<p>Dort siehst du zuerst geliehene Stücke (Chip „geliehen“), danach eigenes Eigentum – als Liste bzw. auf dem Handy als Karten mit Nr., Typ, Hersteller und Modell. Sind Fotos hinterlegt, erscheint ein Thumbnail; ohne Stückfoto das Default-Bild des Inventar-Typs, falls hinterlegt. Ein Tippen/Klick öffnet die Details im Modal; dort kannst du durch die Fotos blättern, Klick aufs Bild vergrößert, und unter <b>Dokumente</b> hinterlegte Dateien öffnen. Bearbeiten, Hochladen und Löschen nur mit den entsprechenden Rechten.</p>
 '
     );
 }
@@ -227,11 +227,11 @@ $sections[] = array(
     'body' => '
 <ul class="help-list">
 '.(requirePermission('perm_showInventories') ? '
-<li><b>Inventar</b> – Vereinsbesitz (Bestände, Details und Ausleihen); die Liste lädt beim Scrollen nach, Sortier-Chips sortieren serverseitig, Suche (mehrere Wörter = UND, z. B. <code>marsch Ralf</code>) und Chip <b>Versichert</b> filtern die bereits geladenen Einträge (bei aktiver Filterung wird weiter nachgeladen); Klick auf die Zeile öffnet Details; hinterlegte Fotos erscheinen als Thumbnail, im Modal blätterbar; Eigentümer-/Ausleihe-Chips öffnen die Person; „Übersicht für Versicherung“ öffnet eine druck-/PDF-fähige Tabelle (Spalten per Checkbox wählen, dann kopieren oder als PDF speichern)</li>
+<li><b>Inventar</b> – Vereinsbesitz (Bestände, Details und Ausleihen); die Liste lädt beim Scrollen nach, Sortier-Chips sortieren serverseitig, Suche (mehrere Wörter = UND, z. B. <code>marsch Ralf</code>) und Chip <b>Versichert</b> filtern die bereits geladenen Einträge (bei aktiver Filterung wird weiter nachgeladen); Klick auf die Zeile öffnet Details; hinterlegte Fotos erscheinen als Thumbnail, sonst das Default-Bild des Typs; im Modal blätterbar, Klick vergrößert; Eigentümer-/Ausleihe-Chips öffnen die Person; „Übersicht für Versicherung“ öffnet eine druck-/PDF-fähige Tabelle (Spalten per Checkbox wählen, dann kopieren oder als PDF speichern)</li>
 ' : '').'
 '.(requirePermission('perm_editInventories') ? '
 <li><b>Inventar anlegen</b> – neue Stücke über die eigene Seite (Plus in der Inventarliste oder Admin → Inventar anlegen)</li>
-<li><b>Inventar-Typen</b> – Prefix bestimmt den Nummernkreis (z.&nbsp;B. <code>MARSCH-001</code>, <code>INSTR-42</code>); die Beschriftung erscheint in Listen und Formularen</li>
+<li><b>Inventar-Typen</b> – Prefix bestimmt den Nummernkreis (z.&nbsp;B. <code>MARSCH-001</code>, <code>INSTR-42</code>); die Beschriftung erscheint in Listen und Formularen; optionale <b>Vorschau</b> (JPEG/PNG/GIF/WebP) gilt als Default-Thumbnail, solange das Stück kein eigenes Foto hat</li>
 <li>Bearbeiten, Löschen und Ausleihen nur mit Schreibrechten; im Inventar-Modal Fotos hinzufügen oder löschen, <b>Vorschau</b> setzt das angezeigte Foto als Listen-Thumbnail; unter <b>Dokumente</b> Dateien (PDF oder Bild) mit Notiz ablegen, im neuen Tab öffnen oder löschen; unter <b>Leihen</b> Person per Chip-Suche wählen und <b>Leihvertrag</b> (übrige Angaben optional bzw. im Formular) — der Vertrag öffnet sich; offene Leihen mit Datum und <b>Rückgabe</b> beenden (öffnet das Rückgabeprotokoll); beendete Leihen sind zugeklappt; Scans einzeln löschen oder den ganzen Leiheintrag entfernen</li>
 <li><b>Leihvertrag / Rückgabe</b> – aus der Leihhistorie druckbare Formulare (alle Inventartypen); Leihbeginn, Leihende, Kaution und Leihgebühr im Formular änderbar und speicherbar; Kaution und Leihgebühr im Druck nur wenn &gt; 0 €; Entleiher immer so bezeichnet; Adresse und zusätzliche Vereinbarungen/Bemerkungen optional und jederzeit änderbar (bei angeschlossener Mitgliederverwaltung wird die MIT-Anschrift vorausgefüllt, sofern noch leer); Rückgabe-Checkliste online abhakbar und speicherbar; nach Unterschrift Scan (PDF, JPEG oder PNG) ablegen, im neuen Tab öffnen oder löschen und neu hochladen. Bei Vereinsmitgliedern endet die Leihe mit dem Austritt, sonst neuer Vertrag als Nicht-Mitglied</li>
 ' : '').'


### PR DESCRIPTION
## Summary
- Optionale **Default-Vorschau** pro Inventar-Typ (Admin → Inventar-Typen)
- Liste und Modal zeigen das Typ-Bild, solange das Stück kein eigenes Foto hat
- Klick aufs Bild im Modal öffnet die **Vollbildansicht** (Esc/Pfeile/×)
- Schema v40: `Inventory.ThumbFile`

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-206

## Test plan
- [ ] Typ ohne Vorschau, Stück ohne Foto → kein Thumbnail
- [ ] Typ-Vorschau setzen → Liste und Modal zeigen das Typ-Bild
- [ ] Stückfoto hochladen → Typ-Bild weicht, Stückfoto gilt
- [ ] Klick aufs Bild vergrößert; Blättern, Esc, Schließen
- [ ] Schema-Repair auf v40