### PR TITLE
MELD-204: Ausleihe-Chip in der Inventarliste lesbar

### DIFF
--- a/libs/inventories.php
+++ b/libs/inventories.php
@@ -440,11 +440,17 @@ class Inventories
         }
         elseif($loanShort !== '' || $loanDate !== '' || $loanFull !== '') {
             $loanBits = array();
-            $loanName = $loanShort !== '' ? $loanShort : $loanFull;
+            $loanName = trim($loanShort !== '' ? $loanShort : $loanFull);
+            if($loanName === '') {
+                $loanName = trim($loanFull);
+            }
             if($loanName !== '') {
-                $loanBits[] = ($loanUserId > 0 && function_exists('entityOpenHtml'))
+                $chip = ($loanUserId > 0 && function_exists('entityOpenHtml'))
                     ? entityOpenHtml('user', $loanUserId, $loanName)
                     : $h($loanName);
+                if($chip !== '') {
+                    $loanBits[] = $chip;
+                }
             }
             if($loanDate !== '') {
                 $loanBits[] = $h($loanDate);

--- a/libs/user.php
+++ b/libs/user.php
@@ -211,28 +211,7 @@ class User
         return implode(', ', $parts);
     }
     public function getShort() {
-        if(strlen($this->Vorname) >=2) {
-            $end=2;
-            if(substr($this->Vorname,1,1)=="&") {
-                $end = strpos($this->Vorname, ";");
-            }
-            $short1 = substr($this->Vorname,0,$end);
-        }
-        else {
-            $short1 = $this->Vorname;
-        }
-        if(strlen($this->Nachname) >=2) {
-            $narray = explode(" ", $this->Nachname);
-            $end=2;
-            if(substr($narray[sizeof($narray)-1],1,1)=="&") {
-                $end = strpos($narray[sizeof($narray)-1], ";");
-            }
-            $short2 = substr($narray[sizeof($narray)-1],0,$end);
-        }
-        else {
-            $short2 = $this->Nachname;
-        }
-        return $short1.$short2;
+        return getShort((string)$this->Vorname, (string)$this->Nachname);
     }
     public function save() {
         if($this->activeLink == '' || $this->activeLink === null) $this->generateLink();

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -6198,7 +6198,7 @@ select.profile-control {
 }
 
 .inv-meta-item {
-  min-width: 0;
+  flex: 0 1 auto;
   word-break: break-word;
 }
 
@@ -6209,6 +6209,13 @@ select.profile-control {
   text-transform: uppercase;
   opacity: 0.65;
   margin-right: 0.25rem;
+  white-space: nowrap;
+}
+
+.inv-meta-line .mail-recipient-chip {
+  white-space: nowrap;
+  max-width: none;
+  flex-shrink: 0;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- Ausleihe-Chip (Kurzname) wird neben Kommentar nicht mehr zur leeren Pille gestaucht
- \`User::getShort()\` nutzt UTF-8-\`getShort()\`; leere Chips entfallen

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-204

## Test plan
- [ ] Inventarzeile mit Ausleihe + langem Kommentar: Chip mit Kurzname sichtbar
- [ ] Klick auf den Chip öffnet das User-Modal