### PR TITLE
MELD-207: Inventar-Thumbnails vollständig einpassen

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -6124,7 +6124,9 @@ select.profile-control {
   display: block;
   width: 3.5rem;
   height: 3.5rem;
-  object-fit: cover;
+  object-fit: contain;
+  object-position: center;
+  background: rgba(0, 0, 0, 0.04);
   border-radius: 0.25rem;
   border: 1px solid rgba(0, 0, 0, 0.12);
   pointer-events: none;


### PR DESCRIPTION
## Summary
- Inventar-Thumbnails (Liste + Typ-Vorschau) nutzen `object-fit: contain` statt `cover`, damit das Motiv nicht abgeschnitten wird.
- Leichter Hintergrund für Letterboxing; zentriert.

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-207

## Test plan
- [ ] Inventarliste: Quer- und Hochformat-Fotos vollständig im Thumbnail sichtbar
- [ ] Inventar-Typen: Vorschau-Thumbnail ebenfalls vollständig
- [ ] Modal-Galerie unverändert (war schon contain)