### PR TITLE
MELD-208: Inventar-Dokument-Log mit Namen statt Fragezeichen

### DIFF
--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -1089,6 +1089,15 @@ function logMessageLinkEntities($html) {
         function ($m) use ($chip, $plainLabel) {
             $extra = isset($m[3]) ? $plainLabel($m[3]) : '';
             $label = $plainLabel($m[2]);
+            if($label === '' || $label === '?') {
+                if(class_exists('User') && method_exists('User', 'inventoryChipLabel')) {
+                    $label = $plainLabel(User::inventoryChipLabel((int)$m[1]));
+                }
+                if($label === '' || $label === '?') {
+                    $label = '#'.$m[1];
+                }
+                $extra = '';
+            }
             if($extra !== '') {
                 $label = trim($label.' '.$extra);
             }

--- a/libs/inventoriesDocument.php
+++ b/libs/inventoriesDocument.php
@@ -306,24 +306,27 @@ class InventoriesDocument
 
     private function logHeader() {
         $invId = (int)$this->Inventory;
-        $label = '?';
         $inv = new Inventories();
-        if($inv->load_by_id($invId) && (int)$inv->Index) {
-            $family = $inv->getInstrumentName();
+        $inv->load_by_id($invId);
+        $typeName = '';
+        $reg = '';
+        if((int)$inv->Index) {
+            $typeName = (string)$inv->getInventoryType();
+            $family = trim((string)$inv->getInstrumentName());
             if($family !== '') {
-                $label = $family;
+                $typeName = $family;
             }
-            else {
-                $t = RegNumber::loadType($inv->Inventory);
-                if($t && !empty($t->Typ)) {
-                    $label = $t->Typ;
-                }
-            }
+            $reg = RegNumber::displayInventory($inv->Inventory, $inv->RegNumber);
         }
+        if($typeName === '') {
+            $typeName = '#'.$invId;
+        }
+        $extra = $reg !== '' ? ' '.$reg : '';
         return sprintf(
-            'Inventory: (%d) <b>%s</b>, Document-ID: %d',
+            'Inventory: (%d) <b>%s</b>%s, Document-ID: %d',
             $invId,
-            $label,
+            $typeName,
+            $extra,
             (int)$this->Index
         );
     }


### PR DESCRIPTION
## Summary
- Dokument-Insert-Log schreibt Typ/Inventarnummer statt \`?\`.
- Alte Logzeilen \`Inventory: (id) <b>?</b>\` werden beim Anzeigen zum Chip aufgelöst.

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-208

## Test plan
- [ ] Neues Inventar-Dokument: Log zeigt Inventar-Chip mit Namen, nicht \`?\`
- [ ] Alte \`?\`-Zeile nach Reload ebenfalls als Name-Chip