### PR TITLE
MELD-212: VERSION-Sync nach Release ohne zweites PHPUnit

### DIFF
--- a/scripts/git-flow.sh
+++ b/scripts/git-flow.sh
@@ -105,11 +105,11 @@ cmd_release_master() {
   git merge "${REMOTE}/${BRANCH_DEV}" -m "merge ${BRANCH_DEV} into ${BRANCH_MASTER}"
   ./makeVersion.sh
   git push "$REMOTE" "$BRANCH_MASTER"
-  # Keep BRANCH_DEV release files in sync.
+  # Keep BRANCH_DEV release files in sync (VERSION/HASH only — suite already ran on master).
   git checkout "$BRANCH_DEV"
   git pull --ff-only "$REMOTE" "$BRANCH_DEV"
   git merge "$BRANCH_MASTER" -m "sync release files from ${BRANCH_MASTER}"
-  git push "$REMOTE" "$BRANCH_DEV"
+  MELDELISTE_SKIP_PREPUSH=1 git push "$REMOTE" "$BRANCH_DEV"
   git checkout "$cur"
   echo "git-flow: released ${BRANCH_MASTER}; synced ${BRANCH_DEV}"
 }


### PR DESCRIPTION
## Summary
- Zweiter Push in \`release-master\` (VERSION/HASH nach \`dev\`) überspringt PHPUnit via \`MELDELISTE_SKIP_PREPUSH\`.

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-212

## Test plan
- [ ] Feature-Push läuft weiter mit voller Suite
- [ ] \`git push origin --delete …\` ohne PHPUnit