### PR TITLE
MELD-213: Signatur-Popup darf das Formularlayout nicht verbiegen

### DIFF
--- a/loan-form.php
+++ b/loan-form.php
@@ -576,7 +576,7 @@ foreach($signSlots as $slot) {
         $showSent = !empty($slot['sent']);
         if($showSign || $showSend || $showSent) {
 ?>
-            <div class="loan-form-sign-open no-print">
+            <div class="loan-form-sign-actions no-print">
 <?php       if($showSign) { ?>
               <button type="button" class="loan-form-btn loan-form-btn--primary" data-loan-sign-open
                 data-loan="<?php echo (int)$ctx['loanId']; ?>"

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -3605,7 +3605,7 @@ body.loan-form-print {
   opacity: 0.88;
 }
 
-.loan-form-sign-open {
+.loan-form-sign-actions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;


### PR DESCRIPTION
## Summary
- Button-Zeile und `body` teilten sich `.loan-form-sign-open`; beim Öffnen des Popups wurde die Seite zur Flex-Row (Toolbar links, Formular rechts).
- Button-Zeile heißt jetzt `.loan-form-sign-actions`.

## Test plan
- [ ] Unterschreiben öffnen: Zurück/Speichern/Drucken bleiben oben, Formular nicht nach rechts

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-213