### PR TITLE
MELD-210: CLI-Restore nicht an sqlerror-Doppeldefinition scheitern

### DIFF
--- a/libs/helpers.php
+++ b/libs/helpers.php
@@ -2072,6 +2072,7 @@ function sql2timeRaw($time) {
     return substr((string)$time, 0, 5);
 }
 
+if(!function_exists('sqlerror')) {
 function sqlerror() {
     if(!isset($GLOBALS['conn']) || !mysqli_errno($GLOBALS['conn'])) {
         return;
@@ -2083,6 +2084,7 @@ function sqlerror() {
         $logentry = new Log;
         $logentry->error($msg);
     }
+}
 }
 
 function string2gDate($string) {


### PR DESCRIPTION
## Summary
- \`helpers.php\` deklariert \`sqlerror()\` nur, wenn sie noch fehlt — CLI-Restore kann die STDERR-Variante setzen.

Jira: https://musikverein-bonn-duisdorf.atlassian.net/browse/MELD-210

## Test plan
- [ ] \`php scripts/restoreBackup.php DATEI.zip --yes\` startet ohne Fatal error